### PR TITLE
Feature/review gate publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,10 @@ venv/
 Thumbs.db
 desktop.ini
 
-# Apify raw evidence dumps (kept locally; not for repo)
+# Apify raw evidence dumps + saved run results (kept locally; not for repo)
 apify_run*.json
 apify_run*.stderr.txt
+apify_runs/
 
 # Sample / shoot images — kept on disk, not version-controlled (heavy binaries)
 *.jpg

--- a/README.md
+++ b/README.md
@@ -11,20 +11,22 @@ To run a shoot, read [`RUN.md`](RUN.md) + [`prompts/_shared.md`](prompts/_shared
 then load each phase prompt on demand. `RUN.md` is the single entry point
 — you do not pre-load all phase prompts.
 
-    plan <photos-dir>   IDENTIFY → PRICE → CURATE        (buy list)
-    list <photos-dir>   INVESTIGATE → DRAFT              (listing)
-    full <photos-dir>   all five
+    plan <photos-dir>   IDENTIFY → PRICE → CURATE                  (buy list)
+    list <photos-dir>   INVESTIGATE → DRAFT → REVIEW(gate)→publish  (listing)
+    full <photos-dir>   all in order, ending at the REVIEW gate
 
 ## What changed from v2
 
 **1 — Headless.** A single orchestrator ([`RUN.md`](RUN.md)) and an
-explicit **gate contract**: only TWO things stop a run — publishing
-(never; refused) and a paid Apify call (cost-confirmed). Every other old
-"ask the user" moment is now a SOFT gate — proceed with a documented
-default, append one line to `<shoot-dir>/NEEDS_REVIEW.md`, keep going.
-The user reviews that queue asynchronously instead of being interrupted.
-Notably: PRICE no longer waits for query approval, and the working price
-is auto-adopted (Recommended tier, provisional) so the pipeline finishes.
+explicit **gate contract**: only TWO things stop a run — the REVIEW gate
+(after DRAFT, present a decision card and publish LIVE only on explicit
+approval) and a paid Apify call (cost-confirmed). Every other old "ask the
+user" moment is now a SOFT gate — proceed with a documented default,
+append one line to `<shoot-dir>/NEEDS_REVIEW.md`, keep going. The user
+reviews that queue asynchronously instead of being interrupted. Notably:
+PRICE no longer waits for query approval, and the working price is
+auto-adopted (Recommended tier, provisional) so the pipeline finishes
+straight through to the review card.
 
 **2 — Fewer words, more confidence.** Shared rules were extracted to
 [`prompts/_shared.md`](prompts/_shared.md) (unit_type, fresh-investigation,
@@ -51,22 +53,32 @@ era-peer, and reports how hard it looked.
         _shared.md                rules every phase obeys
         condition-rubric.md       condition depth (Goal 3)
         identify.md  price.md  curate.md  investigate.md  draft.md
+        review.md                 Function 5.5 — the publish gate (decision card)
         list_edit_chrome.md       Function 6 fallback — Chrome stand-in
       templates/
         listing-v1.md             YAML frontmatter + body
       lib/                        eBay Sell API code (sync/publish/end) + SETUP_EBAY_API.md
       deprecated/                 frozen v1 prompts + v2 reference (context only)
 
-**Function 6 — LIST/EDIT.** Pushes an approved `draft.md` into an eBay
-**draft** (never publishes). Runs on explicit user request, not in the
-automated pipeline. Two paths:
+**Function 5.5 — REVIEW.** The publish gate. After DRAFT, it renders a
+succinct decision card (title, price + supporting comp links, condition,
+anything needing manual review) to chat and `review_card.md`, then STOPS.
+Only an explicit human approval at the card publishes the listing LIVE.
+This replaced the old absolute no-publish firewall: publishing is now
+*gated*, not forbidden — but never automatic, never inferred.
 
-- **Primary — eBay Sell API** (`lib/list_edit.py --sync <dir>`). Headless
-  and environment-proof: photos upload to EPS server-side, the description
-  is one HTTP field (so the Chrome missing-fields bug can't occur), and
-  re-sync is idempotent. **Verified end-to-end on sandbox** (11 photos, full
-  description, specifics, Best Offer; offer left UNPUBLISHED). One-time
-  setup: [`lib/SETUP_EBAY_API.md`](lib/SETUP_EBAY_API.md).
+**Function 6 — LIST/EDIT.** Pushes an approved `draft.md` to eBay. The
+agent reaches it only through a human-approved REVIEW card; the pipeline
+never publishes on its own. Two paths:
+
+- **Primary — eBay Sell API** (`lib/list_edit.py`). `--sync <dir>` creates
+  an UNPUBLISHED offer; `--list <dir> --confirm` syncs then publishes LIVE
+  (the post-approval command); `--publish`/`--list` without `--confirm` are
+  dry runs. Headless and environment-proof: photos upload to EPS
+  server-side, the description is one HTTP field (so the Chrome
+  missing-fields bug can't occur), and re-sync is idempotent. **Verified
+  end-to-end on sandbox** (11 photos, full description, specifics, Best
+  Offer). One-time setup: [`lib/SETUP_EBAY_API.md`](lib/SETUP_EBAY_API.md).
 - **Fallback — Chrome stand-in**
   ([`prompts/list_edit_chrome.md`](prompts/list_edit_chrome.md)). Only when
   the API isn't set up. Encodes the hard-won UI lessons: trusted-keystroke
@@ -79,6 +91,9 @@ Python infrastructure (`config`, `ebay_client`, `apify_ebay`,
 
 ## Unchanged from v2
 
-The no-publish firewall, the YAML-frontmatter listing template + its
-`_field_constraints`, the unit_type vocabulary, the Apify opt-in policy,
-and the deterministic output-file-per-phase convention all carry over.
+The no-*automatic*-publish firewall (publishing requires `--confirm` and
+is never triggered by the pipeline or `--sync`), the YAML-frontmatter
+listing template + its `_field_constraints`, the unit_type vocabulary, the
+Apify opt-in policy, and the deterministic output-file-per-phase
+convention all carry over. New in v3: the REVIEW gate turns the old
+absolute publish refusal into an approval-gated publish.

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ then load each phase prompt on demand. `RUN.md` is the single entry point
 ## What changed from v2
 
 **1 — Headless.** A single orchestrator ([`RUN.md`](RUN.md)) and an
-explicit **gate contract**: only TWO things stop a run — the REVIEW gate
+explicit **gate contract**: only ONE thing stops a run — the REVIEW gate
 (after DRAFT, present a decision card and publish LIVE only on explicit
-approval) and a paid Apify call (cost-confirmed). Every other old "ask the
-user" moment is now a SOFT gate — proceed with a documented default,
-append one line to `<shoot-dir>/NEEDS_REVIEW.md`, keep going. The user
-reviews that queue asynchronously instead of being interrupted. Notably:
-PRICE no longer waits for query approval, and the working price is
+approval). Every other old "ask the user" moment is now a SOFT gate —
+proceed with a documented default, append one line to
+`<shoot-dir>/NEEDS_REVIEW.md`, keep going. The user reviews that queue
+asynchronously instead of being interrupted. Notably: PRICE no longer
+waits for query approval and no longer gates on Apify (it runs
+automatically as Stage B of the comp hunt), and the working price is
 auto-adopted (Recommended tier, provisional) so the pipeline finishes
 straight through to the review card.
 
@@ -40,9 +41,10 @@ padding removed. Phases commit to one call instead of laddering best→worst.
 [`prompts/condition-rubric.md`](prompts/condition-rubric.md): a
 per-material defect taxonomy + eBay grade mapping with a conservative
 tie-break, used by IDENTIFY and INVESTIGATE. PRICE gained an autonomous
-**exact-match hunt** — it iterates query formulations across the free
-sources (WebSearch + Chrome→eBay) before ever falling back to an
-era-peer, and reports how hard it looked.
+**exact-match hunt** — Stage A WebSearch → Stage B Apify eBay-sold →
+optional Stage C Chrome (only when confidence is low) — iterating query
+formulations before ever falling back to an era-peer, and reporting how
+hard it looked.
 
 ## Layout
 
@@ -96,4 +98,6 @@ is never triggered by the pipeline or `--sync`), the YAML-frontmatter
 listing template + its `_field_constraints`, the unit_type vocabulary, the
 Apify opt-in policy, and the deterministic output-file-per-phase
 convention all carry over. New in v3: the REVIEW gate turns the old
-absolute publish refusal into an approval-gated publish.
+absolute publish refusal into an approval-gated publish; and Apify moved
+from a gated, opt-in fallback to the un-gated default Stage B of the comp
+hunt (Chrome demoted to an optional low-confidence cross-check).

--- a/RUN.md
+++ b/RUN.md
@@ -47,8 +47,9 @@ Reclassify every "ask the user" moment as HARD or SOFT.
 
 This is the ONLY reason a run stops. PRICE's Apify call (Stage B) used to
 be a second HARD gate; it no longer is — Apify runs automatically as part
-of the comp hunt (~$0.12/run), no cost confirmation. See PRICE for the
-Stage-A/B/C ordering and the data-quality guardrails on Apify.
+of the comp hunt (`automation-lab/ebay-sold-scraper`, ~$0.10/run), no cost
+confirmation. See PRICE for the Stage-A/B/C ordering and the currency-leak
+validator on Apify.
 
 ### SOFT gates — proceed with the default, log it
 

--- a/RUN.md
+++ b/RUN.md
@@ -35,7 +35,7 @@ shoot directory, so phases compose without re-deriving.
 
 Reclassify every "ask the user" moment as HARD or SOFT.
 
-### HARD gates — stop the run
+### HARD gate — the only thing that stops a run
 
 1. **The REVIEW gate (publish).** In `list`/`full`, after DRAFT, run
    REVIEW: present the decision card ([prompts/review.md](prompts/review.md))
@@ -44,11 +44,11 @@ Reclassify every "ask the user" moment as HARD or SOFT.
    "just list it" said before the card, no publish inferred from
    "ok"/"looks good"/silence. (This replaced the old absolute no-publish
    firewall — publishing is now gated here, not forbidden.)
-2. **Paid Apify call (PRICE Source C).** Confirm cost before each call:
-   "About to spend ~$0.12 on an Apify query for `<query>`. Approve,
-   change, or skip?" Apify is opt-in only — never run by default.
 
-These are the ONLY reasons to stop a run.
+This is the ONLY reason a run stops. PRICE's Apify call (Stage B) used to
+be a second HARD gate; it no longer is — Apify runs automatically as part
+of the comp hunt (~$0.12/run), no cost confirmation. See PRICE for the
+Stage-A/B/C ordering and the data-quality guardrails on Apify.
 
 ### SOFT gates — proceed with the default, log it
 
@@ -131,7 +131,8 @@ gate is what authorizes passing it. A dry run is available any time
 Cross-cutting depth rules:
 - Condition analysis in IDENTIFY and INVESTIGATE uses
   [prompts/condition-rubric.md](prompts/condition-rubric.md).
-- PRICE runs the autonomous exact-match hunt (free Sources A+B) before
+- PRICE runs the autonomous exact-match hunt (Stage A WebSearch → Stage B
+  Apify eBay-sold → optional Stage C Chrome when confidence is low) before
   any era-peer fallback; see its prompt.
 
 Shared rules (style, confidence, firewall, unit_type, char limits,
@@ -147,9 +148,10 @@ is unchanged and shared from `lib/` — v3 does not duplicate code.
 1. Resolve shoot dir + mode (state inferred mode in one line).
 2. IDENTIFY → write `identify.txt`. Log any grouping questions to
    NEEDS_REVIEW; do not stop.
-3. PRICE each saleable item → run the exact-match hunt on free sources;
-   adopt Recommended tier as provisional working price; write
-   `price.txt`. Stop ONLY if you reach a paid-Apify decision.
+3. PRICE each saleable item → run the exact-match hunt (Stage A WebSearch
+   → Stage B Apify eBay-sold → Stage C Chrome only if confidence is low);
+   adopt Recommended tier as provisional working price; write `price.txt`.
+   Never stops.
 4. CURATE (plan mode) → write `review.md`.
 5. INVESTIGATE (list mode), per item → commit to the confident
    assessment; log open questions; write `investigate.txt`.

--- a/RUN.md
+++ b/RUN.md
@@ -6,7 +6,10 @@ prompt on demand as you reach it. You do not need to read all phase
 prompts up front.
 
 **Goal:** carry a shoot from photos to a review-ready artifact with no
-human babysitting — stopping only at the two HARD gates below.
+human babysitting — stopping only at the HARD gates below. In `list`/`full`
+mode the run carries through to a **REVIEW gate**: it presents a decision
+card and stops for one explicit human approval, which is what publishes the
+listing LIVE.
 
 ---
 
@@ -15,9 +18,9 @@ human babysitting — stopping only at the two HARD gates below.
 The user points at a photo directory and (optionally) names a workflow
 mode. That directory is the shoot directory; all outputs land there.
 
-    plan  <photos-dir>   → IDENTIFY → PRICE → CURATE        (pre-buy: buy list)
-    list  <photos-dir>   → INVESTIGATE → DRAFT              (post-buy: listing)
-    full  <photos-dir>   → all five in order
+    plan  <photos-dir>   → IDENTIFY → PRICE → CURATE                 (pre-buy: buy list)
+    list  <photos-dir>   → INVESTIGATE → DRAFT → REVIEW(gate)→publish (post-buy: listing)
+    full  <photos-dir>   → all in order, ending at the REVIEW gate
 
 If no mode is given: a single-item or grouped shoot of items the user
 already owns → `list`; a wide field/estate scene → `plan`. State the
@@ -34,13 +37,18 @@ Reclassify every "ask the user" moment as HARD or SOFT.
 
 ### HARD gates — stop the run
 
-1. **Publish to eBay.** Never. Refuse and explain (firewall). Not even
-   if the user says to — that requires a deliberate code+prompt refactor.
+1. **The REVIEW gate (publish).** In `list`/`full`, after DRAFT, run
+   REVIEW: present the decision card ([prompts/review.md](prompts/review.md))
+   and STOP. Publishing the listing LIVE happens ONLY on the user's
+   explicit approval at this card. No automatic publish, no publish from a
+   "just list it" said before the card, no publish inferred from
+   "ok"/"looks good"/silence. (This replaced the old absolute no-publish
+   firewall — publishing is now gated here, not forbidden.)
 2. **Paid Apify call (PRICE Source C).** Confirm cost before each call:
    "About to spend ~$0.12 on an Apify query for `<query>`. Approve,
    change, or skip?" Apify is opt-in only — never run by default.
 
-These are the ONLY two reasons to stop a headless run.
+These are the ONLY reasons to stop a run.
 
 ### SOFT gates — proceed with the default, log it
 
@@ -59,8 +67,9 @@ Never block on these. Pick the documented default, append ONE line to
 
 **Working price is NOT a HARD gate.** PRICE still records "final price
 deferred to publish time", but headless flow auto-adopts the Recommended
-tier as the working price so DRAFT can complete. The final published
-price remains the user's call — nothing publishes regardless.
+tier as the working price so DRAFT can complete. The final published price
+remains the user's call — it is confirmed (or changed) at the REVIEW gate
+before anything goes live. Nothing publishes before that gate.
 
 ### NEEDS_REVIEW.md format
 
@@ -91,21 +100,24 @@ Load each prompt when you reach its phase.
 | CURATE | [prompts/curate.md](prompts/curate.md) | `identify.txt`+`price.txt`+profile | `review.md` |
 | INVESTIGATE | [prompts/investigate.md](prompts/investigate.md) | photos (+`identify.txt`) | `investigate.txt` |
 | DRAFT | [prompts/draft.md](prompts/draft.md) | `identify.txt`+`investigate.txt`+`price.txt`+template | `draft.md` |
+| REVIEW | [prompts/review.md](prompts/review.md) | `draft.md`+`price.txt`+`NEEDS_REVIEW.md` | `review_card.md` → (on approval) LIVE listing |
 
-**Post-pipeline (manual trigger only, NOT in the automated run):**
+**The publish step (reached via the REVIEW gate, on explicit approval):**
 
-| Step | How | Reads | Effect |
+| Path | How | Reads | Effect |
 |---|---|---|---|
-| LIST/EDIT (**primary**) | `python lib/list_edit.py --sync <shoot-dir>` | `draft.md` | eBay **DRAFT** via Sell API (never published) |
+| LIST/EDIT (**primary**) | `python lib/list_edit.py --list <shoot-dir> --confirm` | `draft.md` | sync + **publish LIVE** via Sell API |
+| Sync-only (no publish) | `python lib/list_edit.py --sync <shoot-dir>` | `draft.md` | eBay UNPUBLISHED offer only |
 | LIST/EDIT (fallback) | [prompts/list_edit_chrome.md](prompts/list_edit_chrome.md) | `draft.md`+`price.txt` | eBay **DRAFT** via Chrome UI |
 
-Function 6 pushes an approved `draft.md` into an eBay draft. It runs ONLY
-when the user explicitly asks ("push to eBay draft"), one item at a time —
-never as part of `full`. The firewall applies: `--sync` creates an
-UNPUBLISHED offer / the UI terminal action is "Save for later" — never
-auto-publish. Going live is a separate, deliberate command —
-`list_edit.py --publish <dir> --confirm` (dry run without `--confirm`) —
-never invoked by the pipeline or by `--sync`.
+REVIEW (Function 5.5) is the gate that authorizes Function 6. The publish
+command (`--list … --confirm`) runs ONLY after the user explicitly approves
+the review card, one item at a time (batch only on "approve all"). The
+firewall still holds against *automatic* publishing: the pipeline never
+publishes, `--sync` only ever creates an UNPUBLISHED offer, and every
+publish path keeps the `--confirm` code guard — the human's approval at the
+gate is what authorizes passing it. A dry run is available any time
+(`--list`/`--publish` without `--confirm`).
 
 - **Primary — Sell API (`lib/list_edit.py`).** Headless, full-res photo
   upload (EPS), one-payload description (no missing-fields bug), idempotent
@@ -143,8 +155,9 @@ is unchanged and shared from `lib/` — v3 does not duplicate code.
    assessment; log open questions; write `investigate.txt`.
 6. DRAFT (list mode) → render template, run the pre-write validation
    pass, write `draft.md`.
-7. Closing line: outputs written + NEEDS_REVIEW count + the one headline
-   fact per artifact. Nothing is published; LIST/EDIT remains manual.
-8. (Optional, on user request) LIST/EDIT → eBay draft via
-   [prompts/list_edit_chrome.md](prompts/list_edit_chrome.md). Still a
-   draft; the user publishes manually in Seller Hub.
+7. REVIEW (list mode) → write `review_card.md`, present the decision card,
+   and STOP (HARD gate). Surface title + price + the ⚠ count.
+8. On explicit approval at the card → `python lib/list_edit.py --list
+   <shoot-dir> --confirm` (sync + publish LIVE); report the listing URL.
+   On a change request → re-run the owning phase, re-render `draft.md`,
+   re-present the card. Anything other than explicit approval = no publish.

--- a/lib/README.md
+++ b/lib/README.md
@@ -325,6 +325,33 @@ Uses only Python stdlib (`urllib.request`, `urllib.parse`, `base64`,
 
 ---
 
+## comps_csv.py — reviewable comps CSV (all PRICE stages)
+
+Stage B (Apify) saves JSON; stages A (WebSearch) and C (Chrome) are
+agent-driven, so PRICE logs their comps here. One `<shoot-dir>/comps.csv`
+with a `stage` column lets the user open a single spreadsheet and review
+every comp the hunt looked at. Stdlib only (`csv`).
+
+Columns: `captured_at, item, stage, query, price, title, sold_date,
+condition, listing_type, url, note`.
+
+```bash
+# fresh file for a run
+python comps_csv.py --shoot-dir <dir> --reset
+# append a Stage A / C comp
+python comps_csv.py --shoot-dir <dir> --item 1 --stage C --query "..." \
+  --price 99.99 --title "..." --url "https://www.ebay.com/itm/..." \
+  --sold-date 2026-05-14 --condition "Pre-Owned" --note "near-exact"
+# fold a saved Apify run JSON in as stage B rows (unified review file)
+python comps_csv.py --shoot-dir <dir> --from-apify-json apify_runs/apify_run_*.json
+```
+
+Programmatic: `from comps_csv import append_comp, from_apify_json, reset`.
+In environments without a shell, write `<dir>/comps.csv` directly using the
+header above.
+
+---
+
 ## What's not in this MVP
 
 - **PRICE calls this as Stage B** — the prompt invokes `apify_ebay.py` /

--- a/lib/README.md
+++ b/lib/README.md
@@ -93,9 +93,10 @@ definitions.
 
 ## apify_ebay.py — Apify eBay sold-listings client
 
-Production replacement for the Claude-in-Chrome path used by PRICE's
-Source B. Returns clean structured `CompRecord` objects ready for
-PRICE's classification logic.
+PRICE's **default Stage B** comp source (the un-gated direct-eBay sold
+path). The Claude-in-Chrome browse is now the optional Stage C fallback,
+used only when confidence is low or Apify is unavailable. Returns clean
+structured `CompRecord` objects ready for PRICE's classification logic.
 
 **Actor:** built against `caffein.dev/ebay-sold-listings`
 ([docs](https://apify.com/caffein.dev/ebay-sold-listings)). Pricing:
@@ -295,9 +296,9 @@ Uses only Python stdlib (`urllib.request`, `urllib.parse`, `base64`,
 
 ## What's not in this MVP
 
-- **No PRICE integration yet** — `apify_ebay.py` is the building block;
-  wiring it into PRICE's Source B path is the next step once you've
-  verified the wrapper works against your account.
+- **PRICE calls this as Stage B** — the prompt invokes `apify_ebay.py` /
+  `search_ebay_sold()` directly as the default comp source; there is no
+  separate orchestration layer (the prompt is the orchestrator).
 - **No write operations on the eBay client yet** — only schema discovery
   and Taxonomy reads. Inventory-item creation, offer creation, and
   publishing are added when DRAFT lands.

--- a/lib/README.md
+++ b/lib/README.md
@@ -98,10 +98,32 @@ path). The Claude-in-Chrome browse is now the optional Stage C fallback,
 used only when confidence is low or Apify is unavailable. Returns clean
 structured `CompRecord` objects ready for PRICE's classification logic.
 
-**Actor:** built against `caffein.dev/ebay-sold-listings`
-([docs](https://apify.com/caffein.dev/ebay-sold-listings)). Pricing:
-from $4 / 1,000 results (~$0.004 per result; ~$0.12 for a typical
-30-comp call).
+**Actor:** `automation-lab/ebay-sold-scraper`
+([store](https://apify.com/automation-lab/ebay-sold-scraper)), configurable
+via `apify.ebay_actor`. It **pins a US residential proxy**, so eBay returns
+USD natively — this is the fix for the foreign-currency leak (see below).
+Pricing: pay-per-event, ~$0.10 for a 30-listing call.
+
+**Why not `caffein.dev/ebay-sold-listings`?** It has no proxy/country
+control, so when Apify's proxy exits a non-US country eBay localizes prices
+(e.g. BRL/CZK) and the actor mislabels them `USD`, inflating values ~5×.
+Its `soldCurrency` field lies, so it can't be filtered on. We migrated to a
+US-proxy actor and added a charm-price validator (below) as a backstop.
+
+### Currency-leak validator
+
+Every run is checked by `_check_currency_leak()`, which does **not** trust
+the actor's currency label. Genuine USD eBay sold prices are overwhelmingly
+charm-priced (.99/.95/.00/.50); an FX leak multiplies all prices by one
+rate and destroys that structure. If the charm-price share collapses below
+30% (with ≥5 priced comps), the run is flagged:
+
+- `on_currency_leak="raise"` (default) → raises `CurrencyLeakError` so the
+  caller can fall back to the Chrome path instead of anchoring on bad data.
+- `"repair"` → finds the FX divisor that restores charm structure (refined
+  search over major currencies), divides all prices by it, tags
+  `sold_currency="USD (repaired from <CUR>)"`.
+- `"ignore"` → returns as-is.
 
 ### CLI usage (manual testing)
 
@@ -110,22 +132,20 @@ python apify_ebay.py "Polo Ralph Lauren On Safari catalog"
 ```
 
 Options:
-- `--count N` — max results per keyword (default: 30)
-- `--days N` — days back to search, 1–90 (default: 90)
-- `--sort ORDER` — `endedRecently` / `timeNewlyListed` /
-  `pricePlusPostageLowest` / `pricePlusPostageHighest` (default) /
-  `distanceNearest`
-- `--site SITE` — `ebay.com` (default), `ebay.co.uk`, `ebay.de`, etc.
-- `--condition C` — `any` (default), `new`, `used`
-- `--location L` — `default`, `domestic`, `worldwide`
-- `--min-price N` / `--max-price N` — price range filter
-- `--category ID` / `--subcategory ID` — eBay category filter
+- `--max N` — max results per keyword (default: 30)
+- `--pages N` — max search pages per keyword, 60/page (default: 3)
+- `--sort ORDER` — `best_match` / `newly_listed` / `price_low` /
+  `price_high` (default)
+- `--listing-type T` — `all` (default), `auction`, `buy_it_now`
+- `--condition C [C ...]` — condition filter(s), e.g. `used new`
+- `--min-price N` / `--max-price N` — USD price range filter
 - `--actor NAME` — override the Actor ID
-- `--timeout SEC` — max wait for the Apify run (default: 180)
+- `--timeout SEC` — max wait for the Apify run (default: 300)
+- `--on-leak MODE` — `raise` (default) / `repair` / `ignore`
 - `--json` — output raw JSON instead of human-readable list
 
-Multiple keywords (up to 6) can be passed as separate positional args
-— each runs as a separate search, results tagged via `keyword_tag`:
+Multiple keywords can be passed as separate positional args — each runs as
+a separate search:
 
 ```bash
 python apify_ebay.py "Polo Ralph Lauren On Safari" "Polo Ralph Lauren Fall 1981"
@@ -134,18 +154,20 @@ python apify_ebay.py "Polo Ralph Lauren On Safari" "Polo Ralph Lauren Fall 1981"
 ### Programmatic usage
 
 ```python
-from apify_ebay import search_ebay_sold
+from apify_ebay import search_ebay_sold, CurrencyLeakError
 
-comps = search_ebay_sold(
-    "Polo Ralph Lauren On Safari catalog",
-    count=30,                          # results per keyword
-    days_to_scrape=90,
-    sort_order="pricePlusPostageHighest",
-)
+try:
+    comps = search_ebay_sold(
+        "Polo Ralph Lauren On Safari catalog",
+        max_listings=30,
+        sort="price_high",
+    )
+except CurrencyLeakError:
+    comps = []  # fall back to the Chrome (Stage C) path
 
 for c in comps:
     print(f"${c.sold_price:.2f} — {c.title}")
-    print(f"  Sold: {c.sold_date}  Condition: {c.condition}")
+    print(f"  Sold: {c.sold_date}  Condition: {c.condition}  {c.listing_type}")
     print(f"  Seller: {c.seller_username} ({c.seller_feedback_pct}%)")
     print(f"  URL: {c.url}")
 ```
@@ -155,21 +177,23 @@ for c in comps:
 | Field | Type | Notes |
 |---|---|---|
 | `title` | str | Listing title (mandatory) |
-| `sold_price` | float | Parsed from `soldPrice` string (mandatory) |
+| `sold_price` | float | USD, from numeric `soldPrice` (mandatory) |
 | `url` | str | Direct link to the eBay listing (mandatory) |
-| `sold_date` | Optional[str] | ISO 8601 from `endedAt` |
+| `sold_date` | Optional[str] | ISO 8601, parsed from `soldDate` ("May 12, 2026") |
 | `condition` | Optional[str] | Localized eBay condition label |
-| `condition_id` | Optional[int] | Numeric eBay condition ID (1000 New, 3000 Used, etc.) |
-| `seller_username` | Optional[str] | From `sellerUsername` |
-| `seller_feedback_score` | Optional[int] | From `sellerFeedbackScore` |
-| `seller_feedback_pct` | Optional[float] | From `sellerPositivePercent` |
-| `shipping_cost` | Optional[float] | Parsed from `shippingPrice` string |
-| `shipping_type` | Optional[str] | `free` / `paid` / `pickup` / `unknown` |
-| `sold_currency` | Optional[str] | Currency code (USD, GBP, EUR, ...) |
-| `total_price` | Optional[float] | `soldPrice + shippingPrice` when currencies match |
+| `condition_id` | Optional[int] | Not exposed by this actor (None) |
+| `seller_username` | Optional[str] | From `sellerName` |
+| `seller_feedback_score` | Optional[int] | From `sellerFeedbackCount` ("2K" → 2000) |
+| `seller_feedback_pct` | Optional[float] | From `sellerFeedbackPercent` ("100%" → 100.0) |
+| `shipping_cost` | Optional[float] | Parsed from `shippingCost` ("+$108.12 delivery") |
+| `shipping_type` | Optional[str] | `free` when shipping is free, else None |
+| `sold_currency` | Optional[str] | `"USD"` (or `"USD (repaired from <CUR>)"` after repair) |
+| `total_price` | Optional[float] | `sold_price + shipping_cost` |
 | `item_id` | Optional[str] | eBay item ID |
-| `keyword_tag` | Optional[str] | Which input keyword this matched (multi-keyword runs) |
-| `bo_accepted` | bool | **Always False** — caffein.dev actor doesn't expose this |
+| `listing_type` | Optional[str] | `Buy It Now` / `Auction` |
+| `bids_count` | Optional[int] | Bid count (for Tier-C single-bid exclusion) |
+| `keyword_tag` | Optional[str] | Input keyword (set on single-keyword runs) |
+| `bo_accepted` | bool | **Always False** — actor doesn't expose this |
 | `raw` | dict | Original Apify item dict (debugging) |
 
 ### Known testing landmark

--- a/lib/README.md
+++ b/lib/README.md
@@ -5,8 +5,15 @@
 ### 1. Install dependencies
 
 ```bash
-pip install apify-client pyyaml
+pip install pyyaml
 ```
+
+`apify_ebay.py` needs **no third-party package** — it calls the Apify REST
+API with the Python standard library only. This is deliberate: it runs in
+sandboxed environments (e.g. a Cowork tab) where `pip install` is blocked.
+It only needs (a) Python, (b) network egress to `api.apify.com`, and (c)
+the Apify token (config file or `APIFY_API_TOKEN` env var). `pyyaml` is for
+`config.py` / the eBay Sell-API code, not for Apify.
 
 ### 2. Create the config file
 

--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -143,12 +143,14 @@ you can re-sync/re-publish it later.
 
 ## Firewall
 
-`--sync` NEVER publishes — it stops at an unpublished offer. Publishing is
-a separate, deliberate, human-run command that does nothing without
-`--confirm`, is never invoked by `--sync`, and is never automatic. That
-preserves the firewall's intent (no accidental or automated publication)
-while giving you a one-command way to take a reviewed offer live. See
-PLAN.md "No-publish firewall".
+`--sync` NEVER publishes — it stops at an unpublished offer. Publishing
+requires `--confirm`, is never invoked by `--sync`, and is never
+automatic. The agent reaches it only after a human approves the REVIEW
+card ([../prompts/review.md](../prompts/review.md)); the post-approval
+command is `list_edit.py --list <dir> --confirm` (sync + publish in one
+step). That preserves the firewall's intent — no accidental or automated
+publication — while giving you a one-command way to take a reviewed offer
+live.
 
 ## Notes / limits
 

--- a/lib/apify_ebay.py
+++ b/lib/apify_ebay.py
@@ -1,8 +1,9 @@
 """
 Apify eBay sold-listings client.
 
-Production replacement for the Claude-in-Chrome browser navigation
-path used today by PRICE's Source B (direct eBay sold-listings browse).
+PRICE's default Stage B comp source (un-gated direct eBay sold-listings).
+The Claude-in-Chrome browse path is the optional Stage C fallback, used
+only when confidence is low or this backend is unavailable.
 
 Calls the caffein.dev/ebay-sold-listings Apify Actor (or any
 schema-compatible alternative configured via apify.ebay_actor) to

--- a/lib/apify_ebay.py
+++ b/lib/apify_ebay.py
@@ -48,20 +48,25 @@ CLI usage (manual testing):
 
 from __future__ import annotations
 
+import json
 import re
+import time
+import urllib.error
 import urllib.parse
+import urllib.request
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Optional, Union
 
-try:
-    from apify_client import ApifyClient
-except ImportError as e:
-    raise ImportError(
-        "apify-client is required. Install with: pip install apify-client"
-    ) from e
+# NOTE: no third-party dependency. The Apify backend is reached over its
+# plain HTTPS REST API using only the Python standard library (urllib), so
+# this runs in minimal/sandboxed environments where `pip install` is blocked
+# (e.g. a Cowork tab whose proxy 403s PyPI). The `apify-client` package is
+# NOT required.
 
 from config import ConfigError, get_apify_actor, get_apify_token
+
+APIFY_API_BASE = "https://api.apify.com/v2"
 
 
 # ---------------------------------------------------------------------------
@@ -218,15 +223,74 @@ def build_sold_search_url(query: str, sort_highest_price: bool = True) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Apify client
+# Apify REST transport (stdlib only — no apify-client needed)
 # ---------------------------------------------------------------------------
 
-def _client() -> ApifyClient:
+def _api_request(method: str, path: str, token: str,
+                 body: Optional[dict] = None, timeout: int = 60) -> Any:
+    """One Apify REST call. Returns the decoded `data` payload (or raw JSON)."""
+    url = f"{APIFY_API_BASE}/{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            raw = r.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", "replace")[:300] if hasattr(e, "read") else ""
+        raise ApifyError(f"Apify API {method} {path} -> HTTP {e.code}: {detail}") from e
+    except urllib.error.URLError as e:
+        raise ApifyError(
+            f"Apify API unreachable ({method} {path}): {e.reason}. "
+            f"If this is a sandbox, its proxy may be blocking api.apify.com."
+        ) from e
+    if not raw:
+        return None
+    parsed = json.loads(raw)
+    return parsed.get("data", parsed) if isinstance(parsed, dict) else parsed
+
+
+def _run_actor(actor: str, run_input: dict, timeout_sec: int) -> tuple[list[dict], str]:
+    """Start an actor run over REST, poll to completion, return (items, run_id).
+
+    Pure stdlib. `actor` may be 'user/name' (converted to 'user~name' for the
+    API path). The run id is returned as verifiable proof the query executed.
+    """
     try:
         token = get_apify_token()
     except ConfigError as e:
         raise ApifyError(str(e)) from e
-    return ApifyClient(token)
+
+    actor_path = actor.replace("/", "~")
+    run = _api_request(
+        "POST", f"acts/{actor_path}/runs?timeout={int(timeout_sec)}",
+        token, body=run_input, timeout=60,
+    )
+    run_id = (run or {}).get("id")
+    if not run_id:
+        raise ApifyError("Apify run start returned no run id")
+
+    deadline = time.monotonic() + timeout_sec
+    status = (run or {}).get("status")
+    dataset_id = (run or {}).get("defaultDatasetId")
+    while status in ("READY", "RUNNING"):
+        if time.monotonic() > deadline:
+            raise ApifyError(f"Apify run {run_id} timed out after {timeout_sec}s (status={status})")
+        time.sleep(2.5)
+        run = _api_request("GET", f"actor-runs/{run_id}", token, timeout=30)
+        status = (run or {}).get("status")
+        dataset_id = (run or {}).get("defaultDatasetId") or dataset_id
+
+    if status != "SUCCEEDED":
+        raise ApifyError(f"Apify run {run_id} did not succeed (status={status})")
+    if not dataset_id:
+        raise ApifyError(f"Apify run {run_id} has no defaultDatasetId")
+
+    items = _api_request("GET", f"datasets/{dataset_id}/items?clean=true&format=json",
+                         token, timeout=60)
+    return (items or []), run_id
 
 
 # ---------------------------------------------------------------------------
@@ -476,33 +540,8 @@ def search_ebay_sold(
     if max_price is not None:
         run_input["maxPrice"] = max_price
 
-    client = _client()
-
-    try:
-        run = client.actor(actor).call(
-            run_input=run_input,
-            run_timeout=timedelta(seconds=timeout_sec),
-        )
-    except Exception as e:
-        raise ApifyError(f"Apify run failed: {e}") from e
-
-    if run is None:
-        raise ApifyError("Apify .call() returned no run object")
-
-    # Normalize the run object (Pydantic model in newer SDKs, dict in older).
-    status = getattr(run, "status", None) if not isinstance(run, dict) else run.get("status")
-    run_id = getattr(run, "id", None) if not isinstance(run, dict) else run.get("id")
-    if status != "SUCCEEDED":
-        raise ApifyError(f"Apify run did not succeed (status={status}, run id={run_id})")
-    if not run_id:
-        raise ApifyError("Apify run has no id")
-
-    # Fetch the run's default dataset directly by run id — robust across SDK
-    # versions where model_dump() drops defaultDatasetId.
-    try:
-        raw_items = list(client.run(run_id).dataset().iterate_items())
-    except Exception as e:
-        raise ApifyError(f"failed to read Apify dataset for run {run_id}: {e}") from e
+    # Execute over the Apify REST API (stdlib only — no apify-client).
+    raw_items, run_id = _run_actor(actor, run_input, timeout_sec)
 
     single_tag = keywords[0] if len(keywords) == 1 else None
     comps: list[CompRecord] = []

--- a/lib/apify_ebay.py
+++ b/lib/apify_ebay.py
@@ -5,21 +5,29 @@ PRICE's default Stage B comp source (un-gated direct eBay sold-listings).
 The Claude-in-Chrome browse path is the optional Stage C fallback, used
 only when confidence is low or this backend is unavailable.
 
-Calls the caffein.dev/ebay-sold-listings Apify Actor (or any
-schema-compatible alternative configured via apify.ebay_actor) to
-retrieve sold-listing comps. Returns clean structured CompRecord
-objects ready for PRICE's classification logic.
+Backend Actor: **automation-lab/ebay-sold-scraper** (configurable via
+`apify.ebay_actor`). Chosen because it pins a **US residential proxy**, so
+eBay returns prices in USD natively — avoiding the silent foreign-currency
+leak that actors without proxy control suffer (e.g. caffein.dev/ebay-sold-
+listings returned BRL/CZK prices mislabeled as USD, inflating values ~5x).
 
-Actor schema reference (caffein.dev/ebay-sold-listings):
-    Input: keywords[], count, daysToScrape, sortOrder, ebaySite,
-           minPrice, maxPrice, itemLocation, itemCondition,
-           categoryId, subcategoryId
-    Output: itemId, url, title, condition, conditionId, endedAt,
-            soldPrice (string), soldCurrency, shippingPrice (string),
-            shippingCurrency, shippingType, totalPrice (string),
-            sellerUsername, sellerPositivePercent, sellerFeedbackScore,
-            scrapedAt
-    Docs: https://apify.com/caffein.dev/ebay-sold-listings
+Actor schema reference (automation-lab/ebay-sold-scraper):
+    Input:  searchQueries[], maxListingsPerSearch, maxSearchPages, sort,
+            listingType, condition[], minPrice, maxPrice, maxRequestRetries
+    Output: itemId, title, soldPrice (number, USD), soldPriceString,
+            soldDate ("May 12, 2026"), condition, listingType, bidsCount,
+            shippingCost ("+$108.12 delivery"), sellerName,
+            sellerFeedbackPercent ("100%"), sellerFeedbackCount ("2K"),
+            thumbnail, url, scrapedAt
+
+Defense in depth: even with a US proxy, every run is checked by a
+provider-agnostic **currency-leak validator** (`_check_currency_leak`).
+Genuine USD eBay sold prices are overwhelmingly charm-priced
+(.99/.95/.00/.50); an FX leak multiplies every price by one rate and
+destroys that structure. If the charm-price share collapses, the run is
+flagged (and, by default, raises CurrencyLeakError so PRICE falls back to
+Stage C instead of anchoring on corrupt data). This does NOT trust the
+actor's currency label, which can lie.
 
 Configuration:
     API token + Actor selection loaded via `config.py` from
@@ -35,7 +43,7 @@ Programmatic usage:
 
 CLI usage (manual testing):
     python apify_ebay.py "vintage polo ralph lauren on safari catalog"
-    python apify_ebay.py "..." --count 50 --days 90 --json
+    python apify_ebay.py "..." --max 50 --sort price_high --json
 """
 
 from __future__ import annotations
@@ -43,7 +51,7 @@ from __future__ import annotations
 import re
 import urllib.parse
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, Optional, Union
 
 try:
@@ -57,69 +65,134 @@ from config import ConfigError, get_apify_actor, get_apify_token
 
 
 # ---------------------------------------------------------------------------
-# Defaults (matched to PRICE's usage patterns)
+# Defaults (matched to PRICE's usage patterns) — automation-lab schema
 # ---------------------------------------------------------------------------
 
-DEFAULT_COUNT = 30                 # max results per keyword
-DEFAULT_DAYS_TO_SCRAPE = 90        # PRICE's anchor window
-DEFAULT_SORT_ORDER = "pricePlusPostageHighest"  # matches our _sop=3 convention
-DEFAULT_EBAY_SITE = "ebay.com"
-DEFAULT_ITEM_CONDITION = "any"
-DEFAULT_ITEM_LOCATION = "default"
-DEFAULT_RUN_TIMEOUT_SEC = 180
+DEFAULT_MAX_LISTINGS = 30          # maxListingsPerSearch (PRICE comp-list size)
+DEFAULT_MAX_PAGES = 3              # maxSearchPages (60 listings/page)
+DEFAULT_SORT = "price_high"        # surface the ceiling first (≈ old _sop=3)
+DEFAULT_LISTING_TYPE = "all"
+DEFAULT_MAX_RETRIES = 5
+DEFAULT_RUN_TIMEOUT_SEC = 300
 
-# Allowed values per the caffein.dev Actor docs
-VALID_SORT_ORDERS = {
-    "endedRecently",
-    "timeNewlyListed",
-    "pricePlusPostageLowest",
-    "pricePlusPostageHighest",
-    "distanceNearest",
+VALID_SORTS = {"best_match", "newly_listed", "price_low", "price_high"}
+VALID_LISTING_TYPES = {"all", "auction", "buy_it_now"}
+
+# ---------------------------------------------------------------------------
+# Currency-leak validator (provider-agnostic; does NOT trust currency labels)
+# ---------------------------------------------------------------------------
+
+# Cents endings that dominate genuine USD eBay prices (charm pricing).
+_CHARM_CENTS = {0, 49, 50, 95, 98, 99}
+# Need at least this many priced comps to judge the distribution.
+_MIN_SAMPLES_FOR_LEAK_CHECK = 5
+# Below this charm share, suspect a currency leak (clean US runs are ~0.5+).
+_CHARM_LEAK_THRESHOLD = 0.30
+# Approximate USD cross-rates of currencies eBay commonly localizes into.
+# Used ONLY to diagnose/repair a detected leak (find the divisor that
+# restores charm structure). Rates need only be close; the charm check is
+# what confirms the match.
+_FX_RATES = {
+    "BRL": 5.2, "CZK": 23.0, "MXN": 17.0, "INR": 83.0, "ZAR": 18.5,
+    "EUR": 0.92, "GBP": 0.79, "CAD": 1.37, "AUD": 1.52, "JPY": 157.0,
+    "PHP": 57.0, "PLN": 4.0, "SEK": 10.5,
 }
-VALID_ITEM_CONDITIONS = {"any", "new", "used"}
-VALID_ITEM_LOCATIONS = {"default", "domestic", "worldwide"}
-VALID_EBAY_SITES = {
-    "ebay.com", "ebay.co.uk", "ebay.de", "ebay.fr",
-    "ebay.it", "ebay.es", "ebay.ca", "ebay.com.au",
-}
-
-MAX_KEYWORDS = 6  # Actor accepts up to 6 keywords per run
-
-
-# ---------------------------------------------------------------------------
-# Data types
-# ---------------------------------------------------------------------------
-
-@dataclass
-class CompRecord:
-    """One sold-listing comp record from eBay.
-
-    Field shape designed for PRICE's classifier. Fields not present in
-    the Actor output are set to None; bo_accepted is always False for
-    the caffein.dev/ebay-sold-listings Actor (it doesn't expose the
-    Best Offer Accepted flag).
-    """
-    title: str
-    sold_price: float           # USD-equivalent, parsed from soldPrice string
-    url: str                    # direct link to the eBay listing
-    sold_date: Optional[str] = None       # ISO 8601 from endedAt
-    condition: Optional[str] = None       # localized eBay condition label
-    condition_id: Optional[int] = None    # numeric eBay condition ID (1000, 3000, ...)
-    seller_username: Optional[str] = None
-    seller_feedback_score: Optional[int] = None
-    seller_feedback_pct: Optional[float] = None
-    shipping_cost: Optional[float] = None
-    shipping_type: Optional[str] = None   # free / paid / pickup / unknown
-    sold_currency: Optional[str] = None
-    total_price: Optional[float] = None
-    item_id: Optional[str] = None
-    keyword_tag: Optional[str] = None     # which input keyword this matched
-    bo_accepted: bool = False             # NOT exposed by caffein.dev actor — always False
-    raw: dict = field(default_factory=dict, repr=False)
 
 
 class ApifyError(RuntimeError):
     """Raised when the Apify run fails, times out, or returns no usable data."""
+
+
+class CurrencyLeakError(ApifyError):
+    """Raised when a run's prices look FX-converted (not genuine USD).
+
+    Carries the detected diagnosis so a caller can decide to repair or fall
+    back to another source (Stage C / Chrome).
+    """
+
+    def __init__(self, message: str, *, charm_share: float,
+                 guessed_currency: Optional[str] = None,
+                 guessed_factor: Optional[float] = None):
+        super().__init__(message)
+        self.charm_share = charm_share
+        self.guessed_currency = guessed_currency
+        self.guessed_factor = guessed_factor
+
+
+def _charm_share(prices: list[float]) -> float:
+    """Fraction of prices whose cents land on a charm-price ending."""
+    if not prices:
+        return 0.0
+    hits = 0
+    for p in prices:
+        cents = round((p - int(p)) * 100)
+        if cents in _CHARM_CENTS:
+            hits += 1
+    return hits / len(prices)
+
+
+def _guess_leak(prices: list[float]) -> tuple[Optional[str], Optional[float], float]:
+    """Find the FX divisor that best restores charm structure.
+
+    For each candidate currency we refine the divisor within a ±4% band (the
+    exact rate eBay localized at drifts from a table value, and charm
+    restoration is sensitive to that precision), and keep the global best.
+
+    Returns (currency, factor, repaired_charm_share). currency/factor are
+    None if no candidate clearly beats the leaked distribution.
+    """
+    best_cur, best_factor, best_share = None, None, _charm_share(prices)
+    for cur, rate in _FX_RATES.items():
+        steps = 81  # ±4% scanned at ~0.1% resolution
+        for i in range(steps):
+            factor = rate * (0.96 + 0.08 * i / (steps - 1))
+            share = _charm_share([round(p / factor, 2) for p in prices])
+            if share > best_share:
+                best_cur, best_factor, best_share = cur, round(factor, 4), share
+    return best_cur, best_factor, best_share
+
+
+def _check_currency_leak(comps: list["CompRecord"], on_leak: str) -> list["CompRecord"]:
+    """Validate (and optionally repair) a run against currency leaks.
+
+    on_leak: "raise" (default) -> CurrencyLeakError; "repair" -> divide by
+    the detected FX factor and tag; "ignore" -> return as-is.
+    """
+    priced = [c for c in comps if c.sold_price and c.sold_price > 0]
+    if len(priced) < _MIN_SAMPLES_FOR_LEAK_CHECK:
+        return comps  # too few to judge — don't false-positive on thin queries
+    share = _charm_share([c.sold_price for c in priced])
+    if share >= _CHARM_LEAK_THRESHOLD:
+        return comps  # looks like genuine USD
+
+    cur, factor, repaired_share = _guess_leak([c.sold_price for c in priced])
+    diag = (f"charm-price share {share:.0%} (<{_CHARM_LEAK_THRESHOLD:.0%}); "
+            f"prices look FX-converted, not USD")
+    if cur:
+        diag += f" — best fit {cur} (÷{factor}, restores charm to {repaired_share:.0%})"
+
+    if on_leak == "ignore":
+        return comps
+    if on_leak == "repair":
+        if cur and factor and repaired_share >= 0.5:
+            for c in comps:
+                if c.sold_price:
+                    c.sold_price = round(c.sold_price / factor, 2)
+                if c.shipping_cost:
+                    c.shipping_cost = round(c.shipping_cost / factor, 2)
+                if c.total_price:
+                    c.total_price = round(c.total_price / factor, 2)
+                c.sold_currency = f"USD (repaired from {cur})"
+            return comps
+        raise CurrencyLeakError(
+            f"currency leak detected and not confidently repairable: {diag}",
+            charm_share=share, guessed_currency=cur, guessed_factor=factor)
+    # default: raise
+    raise CurrencyLeakError(
+        f"currency leak detected: {diag}. Refusing to return corrupt prices "
+        f"(set on_currency_leak='repair' to auto-correct, or fall back to "
+        f"Stage C / Chrome).",
+        charm_share=share, guessed_currency=cur, guessed_factor=factor)
 
 
 # ---------------------------------------------------------------------------
@@ -129,15 +202,10 @@ class ApifyError(RuntimeError):
 def build_sold_search_url(query: str, sort_highest_price: bool = True) -> str:
     """Build the equivalent eBay sold-listings search URL for a query.
 
-    NOT passed to the Apify Actor (which builds its own search from
-    keywords + filters). Kept as a utility for "show the user what
-    eBay search this maps to" output in human-readable reports.
+    NOT passed to the Apify Actor (which builds its own search). Kept as a
+    utility for "show the user what eBay search this maps to" output.
     """
-    params = {
-        "_nkw": query,
-        "LH_Sold": "1",
-        "LH_Complete": "1",
-    }
+    params = {"_nkw": query, "LH_Sold": "1", "LH_Complete": "1"}
     if sort_highest_price:
         params["_sop"] = "3"
     return "https://www.ebay.com/sch/i.html?" + urllib.parse.urlencode(params)
@@ -156,74 +224,138 @@ def _client() -> ApifyClient:
 
 
 # ---------------------------------------------------------------------------
-# Value parsing (defensive — actor returns strings for prices)
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CompRecord:
+    """One sold-listing comp record from eBay.
+
+    Field shape designed for PRICE's classifier. Prices are USD (the backend
+    pins a US proxy; the currency-leak validator guards the assumption).
+    Fields the Actor doesn't expose are left None.
+    """
+    title: str
+    sold_price: float                     # USD, parsed from soldPrice
+    url: str                              # direct link to the eBay listing
+    sold_date: Optional[str] = None       # ISO 8601 (parsed from "May 12, 2026")
+    condition: Optional[str] = None       # localized eBay condition label
+    condition_id: Optional[int] = None    # not exposed by this Actor (None)
+    seller_username: Optional[str] = None
+    seller_feedback_score: Optional[int] = None   # parsed from "2K" / "532"
+    seller_feedback_pct: Optional[float] = None   # parsed from "100%"
+    shipping_cost: Optional[float] = None
+    shipping_type: Optional[str] = None   # "free" when shipping is free
+    sold_currency: Optional[str] = "USD"
+    total_price: Optional[float] = None   # sold_price + shipping_cost
+    item_id: Optional[str] = None
+    listing_type: Optional[str] = None    # "Buy It Now" / "Auction"
+    bids_count: Optional[int] = None      # for Tier-C single-bid exclusion
+    keyword_tag: Optional[str] = None     # which input keyword this matched
+    bo_accepted: bool = False             # not exposed by this Actor
+    raw: dict = field(default_factory=dict, repr=False)
+
+
+# ---------------------------------------------------------------------------
+# Value parsing (defensive — Actor returns mixed string/number formats)
 # ---------------------------------------------------------------------------
 
 def _parse_price(raw: Any) -> Optional[float]:
-    """Extract a float price from a string / number / dict.
-
-    The caffein.dev actor returns prices as strings ("215", "6.20")
-    or null. This helper also handles dicts and other formats for
-    portability across Actor variants.
-    """
+    """Extract a float from a number / money string ('$450.00', '+$12 ship')."""
     if raw is None or raw == "":
         return None
     if isinstance(raw, (int, float)):
         return float(raw)
     if isinstance(raw, dict):
-        for key in ("value", "amount", "soldPrice", "currentPrice", "price"):
+        for key in ("value", "amount", "soldPrice", "price"):
             if key in raw:
                 parsed = _parse_price(raw[key])
                 if parsed is not None:
                     return parsed
         return None
     if isinstance(raw, str):
-        s = raw.replace("US", "").replace("$", "").replace(",", "").strip()
-        match = re.search(r"(\d+(?:\.\d+)?)", s)
-        if match:
-            return float(match.group(1))
+        if "free" in raw.lower():
+            return 0.0
+        m = re.search(r"(\d+(?:[\d,]*\.\d+|\d*))", raw.replace(",", ""))
+        if m:
+            try:
+                return float(m.group(1))
+            except ValueError:
+                return None
     return None
 
 
 def _parse_int(raw: Any) -> Optional[int]:
     if raw is None or raw == "":
         return None
-    if isinstance(raw, int):
-        return raw
-    if isinstance(raw, float):
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
         return int(raw)
     if isinstance(raw, str):
-        try:
-            return int(raw)
-        except ValueError:
-            return None
+        m = re.search(r"\d+", raw)
+        return int(m.group(0)) if m else None
     return None
 
 
-def _parse_float(raw: Any) -> Optional[float]:
+def _parse_feedback_count(raw: Any) -> Optional[int]:
+    """eBay feedback counts: '2K' -> 2000, '17.8K' -> 17800, '532' -> 532."""
+    if raw is None or raw == "":
+        return None
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    s = str(raw).strip().replace(",", "")
+    m = re.match(r"([\d.]+)\s*([KkMm]?)", s)
+    if not m:
+        return None
+    try:
+        val = float(m.group(1))
+    except ValueError:
+        return None
+    suffix = m.group(2).upper()
+    if suffix == "K":
+        val *= 1_000
+    elif suffix == "M":
+        val *= 1_000_000
+    return int(round(val))
+
+
+def _parse_pct(raw: Any) -> Optional[float]:
     if raw is None or raw == "":
         return None
     if isinstance(raw, (int, float)):
         return float(raw)
-    if isinstance(raw, str):
+    m = re.search(r"([\d.]+)", str(raw))
+    return float(m.group(1)) if m else None
+
+
+def _parse_sold_date(raw: Any) -> Optional[str]:
+    """'May 12, 2026' / 'Sold May 12, 2026' -> '2026-05-12' (ISO date)."""
+    if not raw:
+        return None
+    s = str(raw).strip()
+    s = re.sub(r"^Sold\s+", "", s, flags=re.IGNORECASE)
+    for fmt in ("%b %d, %Y", "%B %d, %Y"):
         try:
-            return float(raw)
+            return datetime.strptime(s, fmt).strftime("%Y-%m-%d")
         except ValueError:
-            return None
-    return None
+            continue
+    return s  # leave as-is if an unexpected format slips through
 
 
 # ---------------------------------------------------------------------------
-# Output mapping (caffein.dev/ebay-sold-listings schema)
+# Output mapping (automation-lab/ebay-sold-scraper schema)
 # ---------------------------------------------------------------------------
 
-def _map_to_comp_record(item: dict) -> Optional[CompRecord]:
-    """Convert a raw Apify item dict to a CompRecord, or None if unusable."""
+def _map_to_comp_record(item: dict, keyword_tag: Optional[str]) -> Optional[CompRecord]:
+    """Convert a raw Actor item dict to a CompRecord, or None if unusable."""
     title = item.get("title")
     if not title:
         return None
 
     sold_price = _parse_price(item.get("soldPrice"))
+    if sold_price is None:
+        sold_price = _parse_price(item.get("soldPriceString"))
     if sold_price is None:
         return None
 
@@ -231,23 +363,30 @@ def _map_to_comp_record(item: dict) -> Optional[CompRecord]:
     if not url:
         return None
 
+    ship_raw = item.get("shippingCost")
+    shipping_cost = _parse_price(ship_raw)
+    shipping_type = "free" if (isinstance(ship_raw, str) and "free" in ship_raw.lower()) else None
+    total_price = sold_price + (shipping_cost or 0.0)
+
     return CompRecord(
         title=str(title),
         sold_price=sold_price,
         url=str(url),
-        sold_date=item.get("endedAt"),
+        sold_date=_parse_sold_date(item.get("soldDate")),
         condition=item.get("condition"),
-        condition_id=_parse_int(item.get("conditionId")),
-        seller_username=item.get("sellerUsername"),
-        seller_feedback_score=_parse_int(item.get("sellerFeedbackScore")),
-        seller_feedback_pct=_parse_float(item.get("sellerPositivePercent")),
-        shipping_cost=_parse_price(item.get("shippingPrice")),
-        shipping_type=item.get("shippingType"),
-        sold_currency=item.get("soldCurrency"),
-        total_price=_parse_price(item.get("totalPrice")),
-        item_id=item.get("itemId"),
-        keyword_tag=item.get("keyword"),  # may be set by the actor to tag multi-keyword runs
-        bo_accepted=False,                # not exposed by this Actor
+        condition_id=None,
+        seller_username=item.get("sellerName"),
+        seller_feedback_score=_parse_feedback_count(item.get("sellerFeedbackCount")),
+        seller_feedback_pct=_parse_pct(item.get("sellerFeedbackPercent")),
+        shipping_cost=shipping_cost,
+        shipping_type=shipping_type,
+        sold_currency="USD",
+        total_price=round(total_price, 2),
+        item_id=str(item.get("itemId")) if item.get("itemId") is not None else None,
+        listing_type=item.get("listingType"),
+        bids_count=_parse_int(item.get("bidsCount")),
+        keyword_tag=keyword_tag,
+        bo_accepted=False,
         raw=item,
     )
 
@@ -259,102 +398,77 @@ def _map_to_comp_record(item: dict) -> Optional[CompRecord]:
 def search_ebay_sold(
     query: Union[str, list[str]],
     *,
-    count: int = DEFAULT_COUNT,
-    days_to_scrape: int = DEFAULT_DAYS_TO_SCRAPE,
-    sort_order: str = DEFAULT_SORT_ORDER,
-    ebay_site: str = DEFAULT_EBAY_SITE,
-    item_condition: str = DEFAULT_ITEM_CONDITION,
-    item_location: str = DEFAULT_ITEM_LOCATION,
+    max_listings: int = DEFAULT_MAX_LISTINGS,
+    max_pages: int = DEFAULT_MAX_PAGES,
+    sort: str = DEFAULT_SORT,
+    listing_type: str = DEFAULT_LISTING_TYPE,
+    condition: Optional[list[str]] = None,
     min_price: Optional[float] = None,
     max_price: Optional[float] = None,
-    category_id: Optional[str] = None,
-    subcategory_id: Optional[str] = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
     actor_id: Optional[str] = None,
     timeout_sec: int = DEFAULT_RUN_TIMEOUT_SEC,
+    on_currency_leak: str = "raise",
 ) -> list[CompRecord]:
-    """Run the caffein.dev/ebay-sold-listings Apify Actor and return comps.
+    """Run the eBay sold-listings Actor and return USD comps.
 
     Args:
-        query: a single search keyword string OR a list of up to 6
-               keywords (each runs as a separate search; results are
-               tagged with the keyword that matched them via the
-               `keyword_tag` field on the returned CompRecord).
-        count: max results PER KEYWORD (Actor default is 100; we
-               default to 30 to match PRICE's typical comp-list size).
-        days_to_scrape: how many days back to search (1–90).
-        sort_order: one of `endedRecently`, `timeNewlyListed`,
-                    `pricePlusPostageLowest`, `pricePlusPostageHighest`,
-                    `distanceNearest`. Default `pricePlusPostageHighest`
-                    matches PRICE's _sop=3 convention.
-        ebay_site: e.g. `ebay.com`, `ebay.co.uk`, `ebay.de`, ...
-        item_condition: one of `any`, `new`, `used`.
-        item_location: one of `default`, `domestic`, `worldwide`.
-        min_price, max_price: optional price range filters.
-        category_id, subcategory_id: optional eBay category filters.
-        actor_id: override the Apify Actor ID
-                  (default: from config; built-in fallback caffein.dev/ebay-sold-listings).
+        query: one search keyword string OR a list of keywords (each runs as
+               a separate search). With a single keyword, every returned
+               comp is tagged with it via `keyword_tag`.
+        max_listings: max results per keyword (maxListingsPerSearch).
+        max_pages: max search pages per keyword (60 listings/page).
+        sort: one of best_match / newly_listed / price_low / price_high.
+        listing_type: all / auction / buy_it_now.
+        condition: optional list of eBay condition filters (e.g. ["used"]).
+        min_price, max_price: optional USD price-range filters.
+        max_retries: per-request retries before skipping (anti-bot).
+        actor_id: override the Apify Actor ID (default: from config).
         timeout_sec: max time to wait for the Apify run.
+        on_currency_leak: "raise" (default) | "repair" | "ignore" — how to
+            handle a run whose prices fail the charm-price USD check.
 
     Returns:
-        List of CompRecord objects, ordered as Apify returns them.
+        List of CompRecord objects (USD), ordered as the Actor returns them.
 
     Raises:
-        ApifyError: on auth failure, run failure, timeout, or invalid
-                    config. ValueError on invalid argument values.
+        CurrencyLeakError: prices look FX-converted (and on_currency_leak
+            is not "repair"/"ignore").
+        ApifyError: auth failure, run failure, timeout, or invalid config.
+        ValueError: on invalid argument values.
     """
-    # Normalize and validate keywords
     keywords = [query] if isinstance(query, str) else list(query)
     if not keywords or not all(isinstance(k, str) and k.strip() for k in keywords):
         raise ValueError("query must be a non-empty string or list of non-empty strings")
-    if len(keywords) > MAX_KEYWORDS:
-        raise ValueError(
-            f"caffein.dev/ebay-sold-listings accepts up to {MAX_KEYWORDS} keywords; "
-            f"got {len(keywords)}"
-        )
 
-    # Validate enums
-    if sort_order not in VALID_SORT_ORDERS:
+    if sort not in VALID_SORTS:
+        raise ValueError(f"sort must be one of {sorted(VALID_SORTS)}; got {sort!r}")
+    if listing_type not in VALID_LISTING_TYPES:
         raise ValueError(
-            f"sort_order must be one of {sorted(VALID_SORT_ORDERS)}; got {sort_order!r}"
-        )
-    if item_condition not in VALID_ITEM_CONDITIONS:
-        raise ValueError(
-            f"item_condition must be one of {sorted(VALID_ITEM_CONDITIONS)}; "
-            f"got {item_condition!r}"
-        )
-    if item_location not in VALID_ITEM_LOCATIONS:
-        raise ValueError(
-            f"item_location must be one of {sorted(VALID_ITEM_LOCATIONS)}; "
-            f"got {item_location!r}"
-        )
-    if ebay_site not in VALID_EBAY_SITES:
-        raise ValueError(
-            f"ebay_site must be one of {sorted(VALID_EBAY_SITES)}; got {ebay_site!r}"
-        )
-    if not (1 <= days_to_scrape <= 90):
-        raise ValueError(f"days_to_scrape must be 1–90; got {days_to_scrape}")
-    if count < 1:
-        raise ValueError(f"count must be >= 1; got {count}")
+            f"listing_type must be one of {sorted(VALID_LISTING_TYPES)}; got {listing_type!r}")
+    if max_listings < 1:
+        raise ValueError(f"max_listings must be >= 1; got {max_listings}")
+    if max_pages < 1:
+        raise ValueError(f"max_pages must be >= 1; got {max_pages}")
+    if on_currency_leak not in ("raise", "repair", "ignore"):
+        raise ValueError("on_currency_leak must be 'raise', 'repair', or 'ignore'")
 
     actor = actor_id or get_apify_actor()
 
     run_input: dict[str, Any] = {
-        "keywords": keywords,
-        "count": count,
-        "daysToScrape": days_to_scrape,
-        "sortOrder": sort_order,
-        "ebaySite": ebay_site,
-        "itemCondition": item_condition,
-        "itemLocation": item_location,
+        "searchQueries": keywords,
+        "maxListingsPerSearch": max_listings,
+        "maxSearchPages": max_pages,
+        "sort": sort,
+        "listingType": listing_type,
+        "maxRequestRetries": max_retries,
     }
+    if condition:
+        run_input["condition"] = condition
     if min_price is not None:
         run_input["minPrice"] = min_price
     if max_price is not None:
         run_input["maxPrice"] = max_price
-    if category_id is not None:
-        run_input["categoryId"] = category_id
-    if subcategory_id is not None:
-        run_input["subcategoryId"] = subcategory_id
 
     client = _client()
 
@@ -369,48 +483,29 @@ def search_ebay_sold(
     if run is None:
         raise ApifyError("Apify .call() returned no run object")
 
-    # The SDK can return either a Pydantic Run model (newer versions) or
-    # a plain dict (older versions). Normalize to a dict.
-    if hasattr(run, "model_dump"):
-        run_dict: dict = run.model_dump()
-    elif isinstance(run, dict):
-        run_dict = run
-    else:
-        # Fallback: try attribute access on a duck-typed object
-        run_dict = {
-            "status": getattr(run, "status", None),
-            "id": getattr(run, "id", None),
-            "defaultDatasetId": (
-                getattr(run, "default_dataset_id", None)
-                or getattr(run, "defaultDatasetId", None)
-            ),
-        }
-
-    status = run_dict.get("status")
+    # Normalize the run object (Pydantic model in newer SDKs, dict in older).
+    status = getattr(run, "status", None) if not isinstance(run, dict) else run.get("status")
+    run_id = getattr(run, "id", None) if not isinstance(run, dict) else run.get("id")
     if status != "SUCCEEDED":
-        raise ApifyError(
-            f"Apify run did not succeed (status={status}, run id={run_dict.get('id')})"
-        )
+        raise ApifyError(f"Apify run did not succeed (status={status}, run id={run_id})")
+    if not run_id:
+        raise ApifyError("Apify run has no id")
 
-    # Pydantic models from apify-client use snake_case attribute names but
-    # the JSON-compatible model_dump() preserves the original casing... or
-    # not, depending on SDK version. Try both.
-    dataset_id = (
-        run_dict.get("defaultDatasetId")
-        or run_dict.get("default_dataset_id")
-    )
-    if not dataset_id:
-        raise ApifyError("Apify run has no defaultDatasetId")
+    # Fetch the run's default dataset directly by run id — robust across SDK
+    # versions where model_dump() drops defaultDatasetId.
+    try:
+        raw_items = list(client.run(run_id).dataset().iterate_items())
+    except Exception as e:
+        raise ApifyError(f"failed to read Apify dataset for run {run_id}: {e}") from e
 
-    raw_items = list(client.dataset(dataset_id).iterate_items())
-
+    single_tag = keywords[0] if len(keywords) == 1 else None
     comps: list[CompRecord] = []
     for item in raw_items:
-        comp = _map_to_comp_record(item)
+        comp = _map_to_comp_record(item, single_tag)
         if comp is not None:
             comps.append(comp)
 
-    return comps
+    return _check_currency_leak(comps, on_currency_leak)
 
 
 # ---------------------------------------------------------------------------
@@ -423,36 +518,27 @@ def _cli() -> None:
     import sys
 
     parser = argparse.ArgumentParser(
-        description="Apify eBay sold-listings search (caffein.dev/ebay-sold-listings)"
+        description="Apify eBay sold-listings search (automation-lab/ebay-sold-scraper)"
     )
-    parser.add_argument(
-        "query",
-        nargs="+",
-        help="One or more search keywords (each runs as a separate search; up to 6)",
-    )
-    parser.add_argument("--count", type=int, default=DEFAULT_COUNT,
-                        help=f"Max results per keyword (default: {DEFAULT_COUNT})")
-    parser.add_argument("--days", type=int, default=DEFAULT_DAYS_TO_SCRAPE,
-                        help=f"Days back to search 1-90 (default: {DEFAULT_DAYS_TO_SCRAPE})")
-    parser.add_argument("--sort", default=DEFAULT_SORT_ORDER,
-                        choices=sorted(VALID_SORT_ORDERS),
-                        help=f"Sort order (default: {DEFAULT_SORT_ORDER})")
-    parser.add_argument("--site", default=DEFAULT_EBAY_SITE,
-                        choices=sorted(VALID_EBAY_SITES),
-                        help=f"eBay marketplace (default: {DEFAULT_EBAY_SITE})")
-    parser.add_argument("--condition", default=DEFAULT_ITEM_CONDITION,
-                        choices=sorted(VALID_ITEM_CONDITIONS),
-                        help=f"Item condition filter (default: {DEFAULT_ITEM_CONDITION})")
-    parser.add_argument("--location", default=DEFAULT_ITEM_LOCATION,
-                        choices=sorted(VALID_ITEM_LOCATIONS),
-                        help=f"Item location filter (default: {DEFAULT_ITEM_LOCATION})")
-    parser.add_argument("--min-price", type=float, help="Minimum price filter")
-    parser.add_argument("--max-price", type=float, help="Maximum price filter")
-    parser.add_argument("--category", help="Category ID filter (default: all)")
-    parser.add_argument("--subcategory", help="Subcategory ID filter (overrides --category)")
+    parser.add_argument("query", nargs="+",
+                        help="One or more search keywords (each runs a separate search)")
+    parser.add_argument("--max", type=int, default=DEFAULT_MAX_LISTINGS, dest="max_listings",
+                        help=f"Max results per keyword (default: {DEFAULT_MAX_LISTINGS})")
+    parser.add_argument("--pages", type=int, default=DEFAULT_MAX_PAGES,
+                        help=f"Max search pages per keyword (default: {DEFAULT_MAX_PAGES})")
+    parser.add_argument("--sort", default=DEFAULT_SORT, choices=sorted(VALID_SORTS),
+                        help=f"Sort order (default: {DEFAULT_SORT})")
+    parser.add_argument("--listing-type", default=DEFAULT_LISTING_TYPE,
+                        choices=sorted(VALID_LISTING_TYPES),
+                        help=f"Listing type filter (default: {DEFAULT_LISTING_TYPE})")
+    parser.add_argument("--condition", nargs="*", help="Condition filter(s), e.g. used new")
+    parser.add_argument("--min-price", type=float, help="Minimum sold price (USD)")
+    parser.add_argument("--max-price", type=float, help="Maximum sold price (USD)")
     parser.add_argument("--actor", help="Override the Apify Actor ID")
     parser.add_argument("--timeout", type=int, default=DEFAULT_RUN_TIMEOUT_SEC,
                         help=f"Max seconds for the Apify run (default: {DEFAULT_RUN_TIMEOUT_SEC})")
+    parser.add_argument("--on-leak", default="raise", choices=["raise", "repair", "ignore"],
+                        help="How to handle a detected currency leak (default: raise)")
     parser.add_argument("--json", action="store_true",
                         help="Output raw JSON instead of human-readable list")
     args = parser.parse_args()
@@ -460,19 +546,22 @@ def _cli() -> None:
     try:
         comps = search_ebay_sold(
             args.query if len(args.query) > 1 else args.query[0],
-            count=args.count,
-            days_to_scrape=args.days,
-            sort_order=args.sort,
-            ebay_site=args.site,
-            item_condition=args.condition,
-            item_location=args.location,
+            max_listings=args.max_listings,
+            max_pages=args.pages,
+            sort=args.sort,
+            listing_type=args.listing_type,
+            condition=args.condition,
             min_price=args.min_price,
             max_price=args.max_price,
-            category_id=args.category,
-            subcategory_id=args.subcategory,
             actor_id=args.actor,
             timeout_sec=args.timeout,
+            on_currency_leak=args.on_leak,
         )
+    except CurrencyLeakError as e:
+        print(f"CURRENCY LEAK: {e}", file=sys.stderr)
+        print("  -> prices NOT returned. Re-run with --on-leak repair to auto-correct, "
+              "or use the Chrome (Stage C) path.", file=sys.stderr)
+        sys.exit(2)
     except (ApifyError, ValueError) as e:
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
@@ -486,7 +575,8 @@ def _cli() -> None:
                     "sold_currency": c.sold_currency,
                     "sold_date": c.sold_date,
                     "condition": c.condition,
-                    "condition_id": c.condition_id,
+                    "listing_type": c.listing_type,
+                    "bids_count": c.bids_count,
                     "url": c.url,
                     "item_id": c.item_id,
                     "seller_username": c.seller_username,
@@ -509,13 +599,13 @@ def _cli() -> None:
     print()
     for i, c in enumerate(comps, 1):
         tag = f" [{c.keyword_tag}]" if c.keyword_tag and len(args.query) > 1 else ""
-        currency = c.sold_currency or "USD"
-        print(f"[{i:2d}] {currency} {c.sold_price:.2f}{tag} - {c.title}")
+        print(f"[{i:2d}] {c.sold_currency} {c.sold_price:.2f}{tag} - {c.title}")
         if c.sold_date:
             print(f"     Sold: {c.sold_date}")
         if c.condition:
-            cond_id = f" ({c.condition_id})" if c.condition_id else ""
-            print(f"     Condition: {c.condition}{cond_id}")
+            lt = f", {c.listing_type}" if c.listing_type else ""
+            bids = f", {c.bids_count} bids" if c.bids_count else ""
+            print(f"     Condition: {c.condition}{lt}{bids}")
         if c.seller_username:
             fb_parts = []
             if c.seller_feedback_score is not None:
@@ -524,13 +614,8 @@ def _cli() -> None:
                 fb_parts.append(f"{c.seller_feedback_pct}% positive")
             fb = f" ({', '.join(fb_parts)})" if fb_parts else ""
             print(f"     Seller: {c.seller_username}{fb}")
-        if c.shipping_cost is not None or c.shipping_type:
-            ship_parts = []
-            if c.shipping_cost is not None:
-                ship_parts.append(f"+${c.shipping_cost:.2f}")
-            if c.shipping_type:
-                ship_parts.append(f"({c.shipping_type})")
-            print(f"     Shipping: {' '.join(ship_parts)}")
+        if c.shipping_cost is not None:
+            print(f"     Shipping: +${c.shipping_cost:.2f}" + (" (free)" if c.shipping_type == "free" else ""))
         print(f"     URL: {c.url}")
         print()
 

--- a/lib/apify_ebay.py
+++ b/lib/apify_ebay.py
@@ -44,18 +44,26 @@ Programmatic usage:
 CLI usage (manual testing):
     python apify_ebay.py "vintage polo ralph lauren on safari catalog"
     python apify_ebay.py "..." --max 50 --sort price_high --json
+    python apify_ebay.py "..." --save-dir samples/my-shoot   # save JSON beside price.txt
+
+Result persistence: every call saves its results to JSON (run metadata,
+normalized comps, raw dataset) for audit/cache. Default location is
+$APIFY_RUNS_DIR or <repo>/apify_runs/; override with --save-dir (or the
+search_ebay_sold(save_dir=...) arg), or disable with --no-save.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import re
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Optional, Union
 
 # NOTE: no third-party dependency. The Apify backend is reached over its
@@ -462,6 +470,62 @@ def _map_to_comp_record(item: dict, keyword_tag: Optional[str]) -> Optional[Comp
 
 
 # ---------------------------------------------------------------------------
+# Result persistence (every Apify call is saved as JSON — audit trail / cache)
+# ---------------------------------------------------------------------------
+
+def _comp_to_dict(c: "CompRecord") -> dict:
+    return {
+        "title": c.title, "sold_price": c.sold_price, "sold_currency": c.sold_currency,
+        "sold_date": c.sold_date, "condition": c.condition, "listing_type": c.listing_type,
+        "bids_count": c.bids_count, "shipping_cost": c.shipping_cost,
+        "total_price": c.total_price, "seller_username": c.seller_username,
+        "seller_feedback_score": c.seller_feedback_score,
+        "seller_feedback_pct": c.seller_feedback_pct,
+        "item_id": c.item_id, "keyword_tag": c.keyword_tag, "url": c.url,
+    }
+
+
+def _default_runs_dir() -> Path:
+    """Where run JSON is saved by default: $APIFY_RUNS_DIR or <repo>/apify_runs."""
+    env = os.environ.get("APIFY_RUNS_DIR")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parent.parent / "apify_runs"
+
+
+def save_run_json(run_id: str, actor: str, queries: list[str],
+                  raw_items: list[dict], comps: list["CompRecord"],
+                  save_dir: Optional[Union[str, Path]] = None) -> str:
+    """Persist one Apify call's results to a JSON file; return the path.
+
+    Stores run metadata, the normalized comps, and the raw dataset items, so
+    a run can be audited or re-read later without re-querying (and re-paying).
+    """
+    base = Path(save_dir) if save_dir else _default_runs_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = base / f"apify_run_{ts}_{run_id}.json"
+    prices = [c.sold_price for c in comps if c.sold_price]
+    charm = _charm_share(prices) if prices else None
+    payload = {
+        "run_id": run_id,
+        "actor": actor,
+        "queries": queries,
+        "saved_at_utc": ts,
+        "n_comps": len(comps),
+        "charm_price_share": round(charm, 3) if charm is not None else None,
+        "currency_leak_suspected": bool(
+            len(prices) >= _MIN_SAMPLES_FOR_LEAK_CHECK
+            and charm is not None and charm < _CHARM_LEAK_THRESHOLD
+        ),
+        "comps": [_comp_to_dict(c) for c in comps],
+        "raw_items": raw_items,
+    }
+    path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
 
@@ -479,6 +543,8 @@ def search_ebay_sold(
     actor_id: Optional[str] = None,
     timeout_sec: int = DEFAULT_RUN_TIMEOUT_SEC,
     on_currency_leak: str = "raise",
+    save: bool = True,
+    save_dir: Optional[Union[str, Path]] = None,
 ) -> list[CompRecord]:
     """Run the eBay sold-listings Actor and return USD comps.
 
@@ -555,6 +621,14 @@ def search_ebay_sold(
     LAST_RUN.clear()
     LAST_RUN.update(run_id=run_id, actor=actor, queries=keywords, n_comps=len(comps))
 
+    # Persist results to JSON BEFORE the leak check, so even a leak-flagged
+    # run leaves an auditable record (and a cache to avoid re-querying).
+    if save:
+        try:
+            LAST_RUN["saved_path"] = save_run_json(run_id, actor, keywords, raw_items, comps, save_dir)
+        except OSError as e:
+            LAST_RUN["save_error"] = str(e)
+
     return _check_currency_leak(comps, on_currency_leak)
 
 
@@ -589,6 +663,11 @@ def _cli() -> None:
                         help=f"Max seconds for the Apify run (default: {DEFAULT_RUN_TIMEOUT_SEC})")
     parser.add_argument("--on-leak", default="raise", choices=["raise", "repair", "ignore"],
                         help="How to handle a detected currency leak (default: raise)")
+    parser.add_argument("--save-dir", help="Directory to save the run JSON in "
+                        "(default: $APIFY_RUNS_DIR or <repo>/apify_runs). "
+                        "Tip: pass the shoot dir to save alongside price.txt.")
+    parser.add_argument("--no-save", action="store_true",
+                        help="Do not save the run results to JSON")
     parser.add_argument("--json", action="store_true",
                         help="Output raw JSON instead of human-readable list")
     args = parser.parse_args()
@@ -606,10 +685,14 @@ def _cli() -> None:
             actor_id=args.actor,
             timeout_sec=args.timeout,
             on_currency_leak=args.on_leak,
+            save=not args.no_save,
+            save_dir=args.save_dir,
         )
     except CurrencyLeakError as e:
         if LAST_RUN.get("run_id"):
             print(f"Apify run: {LAST_RUN['run_id']}  (actor {LAST_RUN.get('actor')})  — FLAGGED currency leak")
+        if LAST_RUN.get("saved_path"):
+            print(f"Saved results: {LAST_RUN['saved_path']}")
         print(f"CURRENCY LEAK: {e}", file=sys.stderr)
         print("  -> prices NOT returned. Re-run with --on-leak repair to auto-correct, "
               "or use the Chrome (Stage C) path.", file=sys.stderr)
@@ -650,6 +733,8 @@ def _cli() -> None:
     if LAST_RUN.get("run_id"):
         print(f"Apify run: {LAST_RUN['run_id']}  (actor {LAST_RUN.get('actor')})  "
               f"— proof this query hit the Apify backend")
+    if LAST_RUN.get("saved_path"):
+        print(f"Saved results: {LAST_RUN['saved_path']}")
     print(f"Equivalent eBay search: {build_sold_search_url(args.query[0])}")
     print()
     for i, c in enumerate(comps, 1):

--- a/lib/apify_ebay.py
+++ b/lib/apify_ebay.py
@@ -78,6 +78,12 @@ DEFAULT_RUN_TIMEOUT_SEC = 300
 VALID_SORTS = {"best_match", "newly_listed", "price_low", "price_high"}
 VALID_LISTING_TYPES = {"all", "auction", "buy_it_now"}
 
+# Records the most recent run's provenance so the CLI (and PRICE's research
+# log) can cite concrete proof a query hit the Apify backend: the run id,
+# actor, and comp count. Populated by search_ebay_sold() even when the run
+# is later flagged for a currency leak.
+LAST_RUN: dict = {}
+
 # ---------------------------------------------------------------------------
 # Currency-leak validator (provider-agnostic; does NOT trust currency labels)
 # ---------------------------------------------------------------------------
@@ -505,6 +511,11 @@ def search_ebay_sold(
         if comp is not None:
             comps.append(comp)
 
+    # Provenance for PRICE's research log (set before leak check so a flagged
+    # run still records that it reached the backend).
+    LAST_RUN.clear()
+    LAST_RUN.update(run_id=run_id, actor=actor, queries=keywords, n_comps=len(comps))
+
     return _check_currency_leak(comps, on_currency_leak)
 
 
@@ -558,6 +569,8 @@ def _cli() -> None:
             on_currency_leak=args.on_leak,
         )
     except CurrencyLeakError as e:
+        if LAST_RUN.get("run_id"):
+            print(f"Apify run: {LAST_RUN['run_id']}  (actor {LAST_RUN.get('actor')})  — FLAGGED currency leak")
         print(f"CURRENCY LEAK: {e}", file=sys.stderr)
         print("  -> prices NOT returned. Re-run with --on-leak repair to auto-correct, "
               "or use the Chrome (Stage C) path.", file=sys.stderr)
@@ -595,6 +608,9 @@ def _cli() -> None:
 
     query_display = " | ".join(args.query)
     print(f"Found {len(comps)} comp(s) for: {query_display}")
+    if LAST_RUN.get("run_id"):
+        print(f"Apify run: {LAST_RUN['run_id']}  (actor {LAST_RUN.get('actor')})  "
+              f"— proof this query hit the Apify backend")
     print(f"Equivalent eBay search: {build_sold_search_url(args.query[0])}")
     print()
     for i, c in enumerate(comps, 1):

--- a/lib/comps_csv.py
+++ b/lib/comps_csv.py
@@ -1,0 +1,166 @@
+"""
+comps_csv — append PRICE comps to a reviewable CSV (all stages).
+
+Stage B (Apify) persists raw results to JSON via apify_ebay.py. Stages A
+(WebSearch) and C (Chrome) are agent-driven and have no code path, so PRICE
+logs their comps here instead: one `<shoot-dir>/comps.csv` with a `stage`
+column, so the user can open a single spreadsheet and review every comp the
+hunt looked at — across all three sources.
+
+Standard library only (csv) — runs in minimal/sandboxed environments.
+
+Columns:
+    captured_at, item, stage, query, price, title, sold_date, condition,
+    listing_type, url, note
+
+CLI usage:
+    # append one comp (Stage A or C)
+    python comps_csv.py --shoot-dir <dir> --item 1 --stage A \
+        --query "M Civilized Man 1983" --price 99.99 \
+        --title "M 1983 Reagan/Prince Philip" \
+        --url "https://www.ebay.com/itm/267669342148" \
+        --sold-date 2026-05-14 --condition "Pre-Owned" --note "near-exact"
+
+    # start a fresh file for a new run (writes header only)
+    python comps_csv.py --shoot-dir <dir> --reset
+
+    # fold a saved Apify run JSON into the SAME csv as stage B rows
+    python comps_csv.py --shoot-dir <dir> --from-apify-json <path-to-run.json>
+
+Programmatic:
+    from comps_csv import append_comp, from_apify_json
+    append_comp("samples/my-shoot", stage="A", query="...", price=99.99,
+                title="...", url="...", item="1", note="near-exact")
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional, Union
+
+CSV_NAME = "comps.csv"
+HEADER = [
+    "captured_at", "item", "stage", "query", "price", "title",
+    "sold_date", "condition", "listing_type", "url", "note",
+]
+VALID_STAGES = {"A", "B", "C"}
+
+
+def _csv_path(shoot_dir: Union[str, Path]) -> Path:
+    return Path(shoot_dir) / CSV_NAME
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def reset(shoot_dir: Union[str, Path]) -> str:
+    """Truncate (or create) the CSV with just the header row. Returns path."""
+    path = _csv_path(shoot_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        csv.DictWriter(f, fieldnames=HEADER).writeheader()
+    return str(path)
+
+
+def append_rows(shoot_dir: Union[str, Path], rows: Iterable[dict]) -> str:
+    """Append rows (dicts keyed by HEADER fields) to the CSV; create if new."""
+    path = _csv_path(shoot_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    new_file = not path.exists() or path.stat().st_size == 0
+    with path.open("a", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=HEADER, extrasaction="ignore")
+        if new_file:
+            w.writeheader()
+        for row in rows:
+            r = {k: "" for k in HEADER}
+            r.update(row)
+            r.setdefault("captured_at", _now())
+            if not r["captured_at"]:
+                r["captured_at"] = _now()
+            w.writerow(r)
+    return str(path)
+
+
+def append_comp(shoot_dir: Union[str, Path], *, stage: str, query: str,
+                price: Union[str, float, None], title: str, url: str,
+                item: str = "", sold_date: str = "", condition: str = "",
+                listing_type: str = "", note: str = "") -> str:
+    """Append one comp row. `stage` is A / B / C."""
+    stage = str(stage).upper()
+    if stage not in VALID_STAGES:
+        raise ValueError(f"stage must be one of {sorted(VALID_STAGES)}; got {stage!r}")
+    return append_rows(shoot_dir, [{
+        "captured_at": _now(), "item": str(item), "stage": stage,
+        "query": query, "price": "" if price is None else price,
+        "title": title, "sold_date": sold_date, "condition": condition,
+        "listing_type": listing_type, "url": url, "note": note,
+    }])
+
+
+def from_apify_json(shoot_dir: Union[str, Path], json_path: Union[str, Path],
+                    item: str = "") -> str:
+    """Fold a saved Apify run JSON (apify_ebay.save_run_json) into the CSV as
+    stage B rows — so one comps.csv holds all three stages."""
+    data = json.loads(Path(json_path).read_text(encoding="utf-8"))
+    query = "; ".join(data.get("queries") or [])
+    rows = []
+    for c in data.get("comps", []):
+        rows.append({
+            "captured_at": _now(), "item": str(item), "stage": "B",
+            "query": query, "price": c.get("sold_price", ""),
+            "title": c.get("title", ""), "sold_date": c.get("sold_date", "") or "",
+            "condition": c.get("condition", "") or "",
+            "listing_type": c.get("listing_type", "") or "",
+            "url": c.get("url", ""),
+            "note": f"apify run {data.get('run_id','')}",
+        })
+    return append_rows(shoot_dir, rows)
+
+
+def _cli() -> None:
+    import argparse
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:  # pragma: no cover
+        pass
+
+    ap = argparse.ArgumentParser(description="Append PRICE comps to a reviewable comps.csv")
+    ap.add_argument("--shoot-dir", required=True, help="Shoot directory (CSV is <dir>/comps.csv)")
+    ap.add_argument("--reset", action="store_true", help="Truncate the CSV to just the header")
+    ap.add_argument("--from-apify-json", help="Fold a saved Apify run JSON in as stage B rows")
+    ap.add_argument("--item", default="", help="Item id/number (multi-item shoots)")
+    ap.add_argument("--stage", choices=sorted(VALID_STAGES), help="A / B / C")
+    ap.add_argument("--query", default="")
+    ap.add_argument("--price")
+    ap.add_argument("--title", default="")
+    ap.add_argument("--url", default="")
+    ap.add_argument("--sold-date", default="", dest="sold_date")
+    ap.add_argument("--condition", default="")
+    ap.add_argument("--listing-type", default="", dest="listing_type")
+    ap.add_argument("--note", default="")
+    args = ap.parse_args()
+
+    if args.reset:
+        print(f"[OK] reset {reset(args.shoot_dir)}")
+        return
+    if args.from_apify_json:
+        path = from_apify_json(args.shoot_dir, args.from_apify_json, item=args.item)
+        print(f"[OK] folded Apify JSON into {path}")
+        return
+    if not args.stage:
+        ap.error("provide --stage (with --price/--title/--url), or --reset, or --from-apify-json")
+    path = append_comp(
+        args.shoot_dir, stage=args.stage, query=args.query, price=args.price,
+        title=args.title, url=args.url, item=args.item, sold_date=args.sold_date,
+        condition=args.condition, listing_type=args.listing_type, note=args.note,
+    )
+    print(f"[OK] appended {args.stage} comp to {path}")
+
+
+if __name__ == "__main__":
+    _cli()

--- a/lib/config.example.yaml
+++ b/lib/config.example.yaml
@@ -24,9 +24,11 @@ apify:
   api_token: "apify_api_REPLACE_ME"
 
   # Optional. Which Apify Actor to call for eBay scraping.
-  # The default actor below is widely used; override only if you've
-  # found one that returns cleaner data or costs less per call.
-  ebay_actor: "caffein.dev/ebay-sold-listings"
+  # Default: automation-lab/ebay-sold-scraper — pins a US residential proxy
+  # so eBay returns USD natively (avoids the foreign-currency leak that
+  # actors without proxy control suffer). Override only if you've vetted a
+  # cleaner/cheaper alternative against the currency-leak validator.
+  ebay_actor: "automation-lab/ebay-sold-scraper"
 
 # ---------------------------------------------------------------------------
 # Anthropic — Claude API (for IDENTIFY / INVESTIGATE / PRICE / CURATE)

--- a/lib/config.example.yaml
+++ b/lib/config.example.yaml
@@ -18,7 +18,8 @@
 # Apify — eBay sold-listings scraping backend (Source B of PRICE)
 # ---------------------------------------------------------------------------
 apify:
-  # Required for PRICE's Source B to work.
+  # PRICE's default Stage B comp source (the un-gated direct-eBay sold path).
+  # If you leave this unset, Stage B falls back to the Chrome browse path.
   # Get a token at: https://console.apify.com/account/integrations
   api_token: "apify_api_REPLACE_ME"
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -58,7 +58,7 @@ class ConfigError(RuntimeError):
 # Built-in defaults (last-resort fallbacks)
 # ---------------------------------------------------------------------------
 
-DEFAULT_APIFY_ACTOR = "epctex/ebay-scraper"
+DEFAULT_APIFY_ACTOR = "automation-lab/ebay-sold-scraper"
 
 DEFAULT_PROFILE = {
     "margin_target": 0.50,

--- a/lib/ebay_client.py
+++ b/lib/ebay_client.py
@@ -468,8 +468,10 @@ def api_send(method: str, path: str, body: Optional[dict] = None,
     Returns the decoded JSON body (or {} for empty 2xx like 204). Raises
     EbayAPIError on non-2xx, carrying eBay's error body for diagnosis.
 
-    NOTE: There is intentionally NO helper here for the publish endpoint.
-    The no-publish firewall is enforced by absence (see list_edit.py).
+    NOTE: There is intentionally NO dedicated helper here for the publish
+    endpoint. The single publish call lives in list_edit.publish_offer()
+    (confirm-gated, reached only via the REVIEW gate) so the one place a
+    listing can go live stays auditable.
     """
     creds = creds or load_credentials()
     token = get_user_access_token(creds)

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -17,14 +17,20 @@ Publishing is a SEPARATE, deliberate command:
 
     python list_edit.py --publish <shoot-dir>            # DRY RUN (shows what would go live)
     python list_edit.py --publish <shoot-dir> --confirm  # actually publishes
+    python list_edit.py --list    <shoot-dir> --confirm  # sync THEN publish (post review-gate)
 
 Without --confirm it is a dry run. `publish_offer()` is the ONLY place
 this module calls the publishOffer endpoint, it runs only on a draft you
 already synced (has an ebay_offer_id), and it requires --confirm. It is
-never invoked by --sync and never triggered automatically. This is the
-deliberate, user-initiated publish path the original no-publish firewall
-required (see PLAN.md "No-publish firewall"): the firewall's intent —
-no ACCIDENTAL or AUTOMATIC publication — is preserved.
+never invoked by --sync and never triggered automatically.
+
+The firewall's intent — no ACCIDENTAL or AUTOMATIC publication — is
+preserved: nothing in the IDENTIFY→DRAFT pipeline publishes, and every
+publish path still requires the explicit --confirm guard. What changed
+(v3 review-gate): publishing is no longer categorically forbidden to the
+agent. After DRAFT, the REVIEW phase (prompts/review.md) presents a
+review card and STOPS; only an explicit human approval at that gate lets
+the agent run `--list <dir> --confirm` (one step: sync then publish).
 
 ----- Why the eBay Sell API (vs the Chrome stand-in) -----
 
@@ -49,6 +55,7 @@ policy IDs / locations to paste in.
     python list_edit.py --validate <shoot-dir|draft.md>   # no creds needed
     python list_edit.py --setup-check                      # verify creds + policies
     python list_edit.py --sync <shoot-dir|draft.md>        # create/update eBay DRAFT
+    python list_edit.py --list <shoot-dir|draft.md> --confirm  # sync + publish (post review-gate)
     python list_edit.py --check                             # legacy stub-status report
 """
 
@@ -83,7 +90,11 @@ from ebay_client import (
 )
 
 
-FIREWALL_NO_PUBLISH = True
+# No AUTOMATIC/ACCIDENTAL publish: --sync never publishes, the pipeline
+# never publishes, and every publish path requires the explicit --confirm
+# guard. Publishing is reachable by the agent only after a human approves
+# the REVIEW gate (prompts/review.md) — it is no longer categorically refused.
+FIREWALL_NO_AUTO_PUBLISH = True
 STUB_MESSAGE = "LIST/EDIT is stubbed — awaiting eBay developer key. See PLAN.md Function 6."
 
 CURRENCY = "USD"
@@ -603,8 +614,9 @@ def stub_status() -> dict:
     return {
         "module": "list_edit",
         "implementation_status": "implemented (needs credentials + sandbox test)",
-        "firewall_no_publish": FIREWALL_NO_PUBLISH,
-        "publish_function_exists": False,
+        "firewall_no_auto_publish": FIREWALL_NO_AUTO_PUBLISH,
+        "publish_requires_confirm": True,
+        "publish_requires_review_gate": True,
         "credentials": {
             "load_error": err,
             "app_id_set": bool(creds and creds.app_id),
@@ -657,13 +669,14 @@ def _cli() -> None:
         pass
 
     ap = argparse.ArgumentParser(
-        description="ebaybiz — LIST/EDIT (Function 6): sync draft.md -> eBay DRAFT (never publishes).",
+        description="ebaybiz — LIST/EDIT (Function 6): sync draft.md -> eBay DRAFT; publish only via --publish/--list --confirm (post review-gate).",
         formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
     ap.add_argument("--validate", metavar="TARGET", help="Validate a draft.md or shoot dir (no creds).")
     ap.add_argument("--sync", metavar="TARGET", help="Create/update the eBay DRAFT (unpublished offer) from a draft.md or shoot dir.")
     ap.add_argument("--publish", metavar="TARGET", help="Publish a synced offer to a LIVE listing. DRY RUN unless --confirm is also given.")
+    ap.add_argument("--list", metavar="TARGET", dest="list_target", help="Sync THEN publish in one step (post review-gate). DRY RUN unless --confirm is also given.")
     ap.add_argument("--end", metavar="TARGET", help="End (withdraw) a live listing. DRY RUN unless --confirm is also given.")
-    ap.add_argument("--confirm", action="store_true", help="Required with --publish/--end to actually act (otherwise they are dry runs).")
+    ap.add_argument("--confirm", action="store_true", help="Required with --publish/--list/--end to actually act (otherwise they are dry runs).")
     ap.add_argument("--setup-check", action="store_true", help="Verify creds and list account policy IDs.")
     ap.add_argument("--check", action="store_true", help="Print module/credential status.")
     args = ap.parse_args()
@@ -705,6 +718,27 @@ def _cli() -> None:
                 print(f"  price:  ${res.price}")
                 print(f"  status: {res.status_before} -> would become PUBLISHED (a real, live listing)")
                 print(f"\n  To actually publish: re-run with --confirm")
+            else:
+                print(f"[LIVE] Published offer {res.offer_id} -> listing {res.listing_id}")
+                if res.listing_url: print(f"  {res.listing_url}")
+                print("  This listing is now public and accepting buyers.")
+            return
+        if args.list_target:
+            # One-step LIST = sync (create/update the offer) then publish it.
+            # Same --confirm guard as --publish: without it, this syncs and then
+            # shows a DRY RUN of what would go live. This is the path the agent
+            # runs ONLY after a human approves the REVIEW card.
+            sres = create_or_update_listing(Path(args.list_target))
+            print(f"[OK] {sres.operation} eBay DRAFT (offer {sres.offer_id}, {len(sres.photo_eps_urls)} photos).")
+            res = publish_offer(Path(args.list_target), confirm=args.confirm)
+            if res.status_before == "PUBLISHED":
+                print(f"[i] Already LIVE. listing {res.listing_id}")
+                if res.listing_url: print(f"    {res.listing_url}")
+            elif res.dry_run:
+                print("[DRY RUN] Synced but NOT published. This WOULD go live:")
+                print(f"  title:  {res.title}")
+                print(f"  price:  ${res.price}")
+                print(f"\n  To actually publish: re-run --list with --confirm")
             else:
                 print(f"[LIVE] Published offer {res.offer_id} -> listing {res.listing_id}")
                 if res.listing_url: print(f"  {res.listing_url}")

--- a/prompts/_shared.md
+++ b/prompts/_shared.md
@@ -37,14 +37,19 @@ excluded" entries, best→worst ladders. v3 commits.
 
 ## Publish firewall (no accidental or automatic publishing)
 
-No v3 phase publishes. The pipeline (IDENTIFY→DRAFT) and `list_edit.py
---sync` only ever create an UNPUBLISHED eBay offer (a draft) — nothing in
-the pipeline, no chat instruction ("just publish it"), and no automated
-chain can make a listing go live. Publishing exists ONLY as a separate,
-deliberate, human-run command: `list_edit.py --publish <dir> --confirm`
-(a dry run without `--confirm`; never invoked by `--sync`). If a prompt or
-automation asks a phase to publish, refuse — publishing is the user's
-explicit out-of-band action, never something a phase or the pipeline does.
+No phase publishes *automatically*. The pipeline (IDENTIFY→DRAFT) and
+`list_edit.py --sync` only ever create an UNPUBLISHED eBay offer (a draft).
+Nothing in the pipeline, no automated chain, and no chat instruction that
+arrives *outside the REVIEW gate* ("just publish it") makes a listing go
+live. The single path to a live listing is the **REVIEW gate**
+([review.md](review.md)): DRAFT → REVIEW presents a decision card and
+STOPS → on the user's explicit approval, REVIEW runs
+`list_edit.py --list <dir> --confirm` (sync then publish). The code's
+`--confirm` guard stays as defense-in-depth; the human's approval at the
+gate is what authorizes it. Approval must be unambiguous ("approve" /
+"publish"), given against the card — never inferred from "ok"/"looks
+good"/silence. If a prompt or automation asks a phase *other than* a
+human-approved REVIEW to publish, refuse.
 
 ## Fresh-investigation rule
 
@@ -118,6 +123,7 @@ overwriting the prior run (latest run = current record).
 | CURATE | `<shoot-dir>/review.md` |
 | INVESTIGATE | `<shoot-dir>/investigate.txt` |
 | DRAFT | `<shoot-dir>/draft.md` |
+| REVIEW | `<shoot-dir>/review_card.md` |
 | (any deferred question) | `<shoot-dir>/NEEDS_REVIEW.md` (append, don't overwrite) |
 
 The shoot directory is the directory containing the photos (e.g. a
@@ -128,8 +134,9 @@ The shoot directory is the directory containing the photos (e.g. a
 Only TWO gates stop a run. Everything else proceeds with a logged
 default. Full contract in [RUN.md](../RUN.md); summary:
 
-- **HARD — stop and ask:** (1) any eBay publish (refuse, never ask);
-  (2) any paid Apify call (confirm cost per call).
+- **HARD — stop and ask:** (1) the REVIEW gate — after DRAFT, present the
+  review card and STOP; publish LIVE only on explicit approval
+  ([review.md](review.md)); (2) any paid Apify call (confirm cost per call).
 - **SOFT — proceed with default, log to `NEEDS_REVIEW.md`:** grouping
   questions, unit_type ambiguity, INVESTIGATE open questions, working-
   price selection, lookup-value substitutions, missing required fields.

--- a/prompts/_shared.md
+++ b/prompts/_shared.md
@@ -131,12 +131,13 @@ The shoot directory is the directory containing the photos (e.g. a
 
 ## Gate contract (what may stop a headless run)
 
-Only TWO gates stop a run. Everything else proceeds with a logged
-default. Full contract in [RUN.md](../RUN.md); summary:
+ONE gate stops a run. Everything else proceeds with a logged default.
+Full contract in [RUN.md](../RUN.md); summary:
 
-- **HARD — stop and ask:** (1) the REVIEW gate — after DRAFT, present the
+- **HARD — stop and ask:** the REVIEW gate — after DRAFT, present the
   review card and STOP; publish LIVE only on explicit approval
-  ([review.md](review.md)); (2) any paid Apify call (confirm cost per call).
+  ([review.md](review.md)). (PRICE's Apify call is no longer a gate — it
+  runs automatically as Stage B of the comp hunt.)
 - **SOFT — proceed with default, log to `NEEDS_REVIEW.md`:** grouping
   questions, unit_type ambiguity, INVESTIGATE open questions, working-
   price selection, lookup-value substitutions, missing required fields.

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -152,4 +152,6 @@ substitution. These stay local — never pushed to eBay.
 
 Per _shared: path + chosen title with `[N/80]` + working price. List
 flagged gaps / substitutions as one-line bullets. Don't restate
-frontmatter.
+frontmatter. In `list`/`full` mode, REVIEW ([review.md](review.md)) runs
+next — it turns this draft into the decision card and stops for approval
+before anything publishes.

--- a/prompts/list_edit_chrome.md
+++ b/prompts/list_edit_chrome.md
@@ -3,22 +3,26 @@
 Obeys [`_shared.md`](_shared.md). Read it first.
 
 Pushes an approved `draft.md` into an eBay **DRAFT** listing by driving the
-seller UI with the Claude-in-Chrome MCP. Interim until the eBay Sell API
-path is built (`lib/list_edit.py`). Same inputs, same firewall, same
-output as the API path will have — only the mechanism differs.
+seller UI with the Claude-in-Chrome MCP. **Fallback only** — use it when
+the eBay Sell API path (`lib/list_edit.py`) isn't set up. The API path is
+primary because it can also publish LIVE post-approval; this stand-in is
+draft-only by design (see below).
 
-**Not part of the automated run.** RUN.md's pipeline ends at DRAFT.
-Function 6 runs ONLY on explicit user instruction ("push to eBay
-draft"), one item at a time.
+**Reached via the REVIEW gate.** RUN.md's pipeline runs DRAFT → REVIEW.
+This path runs only after a human approves the review card, one item at a
+time.
 
 ================================================================
-HARD FIREWALL — NEVER PUBLISH
+THIS STAND-IN IS DRAFT-ONLY (publish via the API path)
 ================================================================
-Terminal action is **"Save for later" / "Save as draft"** — nothing
-else. Forbidden, no matter who asks: "List it", "Publish", "Sell now",
-"Submit listing", or any control that makes the listing live. If asked
-to publish, refuse. Publication is the user's manual action in Seller
-Hub. (Same firewall as `_shared.md`.)
+Terminal action here is **"Save for later" / "Save as draft"** — nothing
+else. Going LIVE is not done through this UI stand-in: the browser is
+granted read-tier OS automation and the publish controls are unreliable
+to drive safely, so live publishing is reserved for the API path
+(`list_edit.py --list <dir> --confirm`, run after the REVIEW approval).
+So even with an approved card, this path stops at a saved draft; if the
+user wants it live, hand off to the API command. The firewall against
+*automatic* publishing still holds (see `_shared.md`).
 
 ## Preconditions (STOP if unmet)
 

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -56,8 +56,10 @@ stage is autonomous — PRICE never stops to ask.
      the tool reports. MCP calls are brokered outside the code sandbox, so
      this works where direct `api.apify.com` egress is blocked.
    - **Path 2 — stdlib CLI (when you have a shell + egress to
-     api.apify.com).** Run `python lib/apify_ebay.py "<query>"` (no pip — it
-     uses only the standard library). Capture the printed `Apify run: <id>`.
+     api.apify.com).** Run `python lib/apify_ebay.py "<query>" --save-dir
+     <shoot-dir>` (no pip — standard library only). It saves the raw results
+     JSON beside `price.txt` and prints `Apify run: <id>` + `Saved results:
+     <path>`. Capture both.
    - **Map + validate (either path):** fields → comps (same shape); drop
      single-bid / >2× median outliers to Tier C. The CLI auto-runs the
      charm-price currency check; **on the MCP path you must eyeball it** —
@@ -66,9 +68,13 @@ stage is autonomous — PRICE never stops to ask.
      `currency`/`USD` label; the price pattern is what matters. (The
      US-proxy actor makes leaks unlikely — the old caffein.dev actor leaked
      BRL/CZK at ~5× mislabeled USD, which is why we switched.)
+   - **Save the results (both paths).** The CLI auto-saves the run JSON
+     (`--save-dir <shoot-dir>` to place it beside `price.txt`). On the MCP
+     path, write the returned items to `<shoot-dir>/apify_<runId>.json`
+     yourself. This is the audit trail + cache for the comps.
    - **Proof-of-run is mandatory.** Record the **Apify run id** (from the
-     MCP result or the CLI's `Apify run:` line) in the Research log — it's
-     verifiable in the Apify backend. **Never report Stage B as "ran"
+     MCP result or the CLI's `Apify run:` line) AND the saved JSON path in
+     the Research log — both are verifiable. **Never report Stage B as "ran"
      without a run id.**
    - Still drop outliers; if Stage B yields <3 usable comps or dispersion
      disagrees badly with Stage A, treat as LOW confidence → Stage C.
@@ -163,7 +169,7 @@ Don't confuse with the comp-quality "Tier A/B/C" further down.)
 
     Research log — Item <N>
       A · WebSearch : RAN — query "<q>" — <n> hits — <one-line finding>
-      B · Apify     : RAN via <MCP|CLI> — query "<q>" — run <runId> — <n> comps — USD-validated (charm <x>%)
+      B · Apify     : RAN via <MCP|CLI> — query "<q>" — run <runId> — <n> comps — USD-validated (charm <x>%) — saved <path>.json
                       [ALT] UNAVAILABLE — <no Apify MCP tool AND no shell/egress | api.apify.com egress blocked (sandbox proxy) | no token | CurrencyLeakError>
                       (run id comes from the MCP tool result or the CLI's `Apify run:` line; no `pip install` needed)
       C · Chrome    : NOT TRIGGERED — confidence OK (<n> usable comps from A+B)

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -10,9 +10,10 @@ IDENTIFY records.
 
 ## Autonomy (Goal: dig for the exact match, don't ask permission to look)
 
-The free sources run without any query-approval gate. v2 made you propose
-queries and wait — v3 does not. You construct queries, run A and B, and
-iterate them yourself. The ONLY paid/gated step is Apify (Source C).
+No step in PRICE gates or stops. v2 made you propose queries and wait,
+and Apify used to require cost approval — v3 does neither. You construct
+queries, run the stages, and iterate them yourself. PRICE runs
+end-to-end without ever stopping for the user.
 
 ## Selling-unit awareness
 
@@ -24,49 +25,78 @@ are per-listing-unit except `duplicate` (per-piece).
 
 ## The exact-match hunt (run before any era-peer fallback)
 
-For each item, hunt the exact match on the free sources, escalating only
-as each step dries up. Do NOT settle for an era-peer until the hunt is
-exhausted.
+For each item, hunt the exact match, escalating only as each stage dries
+up. Do NOT settle for an era-peer until the hunt is exhausted. Every
+stage is autonomous — PRICE never stops to ask.
 
 1. **Canonical query** — built from IDENTIFY's short Brand+Type+Era
    values (not the Distinguishing-marks prose). Bare words; drop
    punctuation and filler ("with/and/the"). 5–9 high-signal keywords —
    real seller-title density, so exact comps can exist. Include era ONLY
    if a printed date is visible in a photo.
-2. **Source A — WebSearch** (free, ~5s, broad). Tag `[A — WebSearch]`.
-3. **Source B — Chrome → eBay sold** (free, ~30–60s). SOLD URL with
-   `LH_Sold=1&LH_Complete=1&_sop=3`. Extract rows prefixed "Sold
-   <date>"; skip Sponsored/"Shop on eBay" house ads. Tag `[B — Chrome]`.
-   `get_page_text` gives titles/prices/dates but not per-item URLs; when
-   you can't capture each item's href (via `read_page`/`find`), cite the
-   SOLD-search URL as the verifiable source and say so — every comp stays
-   one click from verification.
-4. **If no exact match yet, broaden the query** and re-run A+B: drop the
+
+2. **Stage A — WebSearch** (free, ~5s, broad). Casts wide across the open
+   web + marketplaces. Tag `[A — WebSearch]`.
+
+3. **Stage B — Apify eBay sold** (the default direct-eBay comp source; no
+   gate). Run `python lib/apify_ebay.py "<query>"` (or `search_ebay_sold()`
+   programmatically) — it calls the eBay sold-listings Actor and returns
+   structured comps with per-item URLs, sold dates, condition, currency,
+   and seller stats. Headless, no browser. Tag `[B — Apify]`. Cost is
+   ~$0.12/run and runs automatically as part of the hunt.
+   - **Data-quality guardrails (Apify is trusted by default now, so check
+     it):** keep only `sold_currency == USD` rows — the Actor can silently
+     return GBP/BRL prices at face value; drop (or convert + note) any
+     non-USD comp. Drop the usual outliers (single bid, >2× median). If a
+     run returns suspiciously few rows, or dispersion that disagrees badly
+     with Stage A, treat confidence as **LOW** and trigger Stage C.
+   - **If Apify is unconfigured or the run fails** (no token / ApifyError /
+     timeout): fall through to Stage C for the same eBay-sold data. Note
+     "Apify unavailable → Chrome" in the Hunt line.
+
+4. **If no exact match yet, broaden and re-run A+B:** drop the
    least-load-bearing keyword (5→3 words), then try a synonym for Type.
-   Iterate 2–3 formulations. This is autonomous — no approval needed.
-5. **Active fallback** (only when sold returns zero direct matches): drop
-   the sold filters, capture active listings, tag `[B-active — ASKING
+   Iterate 2–3 formulations.
+
+5. **Stage C — Chrome → eBay sold (OPTIONAL — low-confidence only).** The
+   browser browse path is no longer routine. Invoke it ONLY when
+   confidence is still LOW after A+B — i.e. any of:
+   - no exact match, or fewer than ~3 usable USD sold comps;
+   - dispersion too wide to anchor a tier (roughly >2× spread among the
+     candidate anchors);
+   - Apify was unavailable/suspect and you need direct-eBay data;
+   - high-value item where a wrong anchor is costly and a ~60s second read
+     is worth it.
+
+   When triggered: SOLD URL with `LH_Sold=1&LH_Complete=1&_sop=3`. Extract
+   rows prefixed "Sold <date>"; skip Sponsored / "Shop on eBay" house ads.
+   Tag `[C — Chrome]`. `get_page_text` gives titles/prices/dates but not
+   per-item URLs; when you can't capture each href (via `read_page`/
+   `find`), cite the SOLD-search URL as the verifiable source and say so.
+   Subject to browser read-tier limits (see [list_edit_chrome.md](list_edit_chrome.md)).
+
+6. **Active fallback** (only when sold returns zero direct matches): drop
+   the sold filters, capture active listings, tag `[active — ASKING
    PRICE]`, treat as Tier C ceiling-context only.
-6. **Cross-reference** A vs B: agreement = high-confidence anchor;
-   divergence = trust B (direct eBay) over A.
 
-Only after steps 1–5 dry up do you fall back to the closest era-peer —
-and then state how hard you looked ("3 formulations, sold+active, no
-exact match"). Per _shared, an exact match found this way beats any
-era-peer; commit to it.
+7. **Cross-reference** A vs B (vs C if it ran): agreement = high-confidence
+   anchor; divergence = trust the direct-eBay sold source (B/C) over A's
+   broad web results.
 
-## Source C — Apify (paid, opt-in, HARD gate)
+Only after the hunt dries up do you fall back to the closest era-peer —
+and then state how hard you looked ("3 formulations, A+B+C, no exact
+match"). Per _shared, an exact match found this way beats any era-peer;
+commit to it.
 
-Tabled by default; known data issues (coverage variance run-to-run;
-silent GBP→USD; historical BRL inflation — see the Apify bug evidence
-under `deprecated/`). Run ONLY when the user explicitly
-asks, OR when A AND B both genuinely fail — then surface one fallback
-offer. Either way confirm cost first (HARD gate, per RUN.md):
+## Apify notes (the Stage B backend)
 
-> "About to spend ~$0.12 on an Apify query for `<query>`. Approve,
-> change, or skip?"
-
-Tag `[C — Apify]`. Never call without explicit approval.
+Apify is now the default Stage B source and runs without a gate. It has
+documented quirks — run-to-run coverage variance, silent GBP→USD,
+historical BRL inflation (raw evidence under `deprecated/`). The Stage-B
+guardrails above (USD-only filter, outlier drop, dispersion check, Chrome
+cross-check when suspect) exist specifically to catch these. To run
+without Apify entirely, leave the Apify token unset — Stage B then routes
+to Chrome (Stage C) automatically.
 
 ## URLs (mandatory)
 
@@ -121,8 +151,8 @@ The three tiers still apply, anchored on the era-peer.
     Working price (provisional): $X (Recommended tier). Final price is the
     user's call at publish time; recorded here for review.
 
-(No "awaiting approval" stop — headless adopts the provisional price and
-logs it. Apify is the only thing that ever stops PRICE.)
+(No stop. Headless adopts the provisional price and logs it; PRICE runs
+end-to-end without a gate.)
 
 ## Research notes (per item — catches what comps can't)
 

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -61,9 +61,14 @@ stage is autonomous — PRICE never stops to ask.
    - Still drop the usual outliers (single bid, >2× median). If Stage B
      returns <3 usable comps or dispersion disagrees badly with Stage A,
      treat as LOW confidence → Stage C.
+   - **Proof-of-run is mandatory.** The CLI prints `Apify run: <id>` — copy
+     that run id into the Research log (it's verifiable in the Apify backend).
+     **Never report Stage B as "ran" without a run id.** If you have no run
+     id, it did not run — say so and why.
    - **If Apify is unconfigured or the run fails** (no token / ApifyError /
-     timeout): fall through to Stage C for the same eBay-sold data. Note
-     "Apify unavailable → Chrome" in the Hunt line.
+     timeout / **no shell tool to run the CLI in this environment**): record
+     `B — UNAVAILABLE: <reason>` in the Research log and fall through to
+     Stage C for the same eBay-sold data. Do NOT silently skip B.
 
 4. **If no exact match yet, broaden and re-run A+B:** drop the
    least-load-bearing keyword (5→3 words), then try a synonym for Type.
@@ -116,9 +121,38 @@ entirely, leave the Apify token unset — Stage B then routes to Chrome
 Every comp carries a clickable source URL. A comp without a URL is not a
 comp.
 
+## Research log (MANDATORY — proof every search type actually ran)
+
+Every PRICE run, for every item, emits a Research log accounting for ALL
+THREE stages explicitly. This is non-negotiable evidence: it shows what
+research happened, not just the comps that survived. Stages A and B run on
+EVERY item; C is conditional. Each stage is `RAN` (with proof) /
+`SKIPPED` / `UNAVAILABLE` (with a reason) / `NOT TRIGGERED` (C only).
+
+(Note: "Stage A/B/C" = the search METHOD — WebSearch / Apify / Chrome.
+Don't confuse with the comp-quality "Tier A/B/C" further down.)
+
+    Research log — Item <N>
+      A · WebSearch : RAN — query "<q>" — <n> hits — <one-line finding>
+      B · Apify     : RAN — query "<q>" — run <runId> — <n> comps — USD-validated (charm <x>%)
+                      [ALT] UNAVAILABLE — <no shell tool / no token / ApifyError / CurrencyLeakError>
+      C · Chrome    : NOT TRIGGERED — confidence OK (<n> usable comps from A+B)
+                      [ALT] RAN — <low-confidence trigger> — <n> rows
+                      [ALT] UNAVAILABLE — <no browser/Chrome MCP in this environment>
+
+Hard rules for the log:
+- **A and B must show `RAN` on every item.** If either is `SKIPPED`/
+  `UNAVAILABLE`, that is a flagged problem — also append a line to
+  `NEEDS_REVIEW.md` so the user sees research was incomplete.
+- **B's `RAN` line MUST carry a run id** (proof it hit the Apify backend).
+  No run id ⇒ it did not run ⇒ write `UNAVAILABLE — <reason>`, never `RAN`.
+- **C must be accounted for** — `NOT TRIGGERED` + why, `RAN` + trigger, or
+  `UNAVAILABLE` + why. Never omit the C line.
+- The log records what you DID; the tiers below record what you CONCLUDED.
+
 ## Output
 
-Lead with the headline, then comps, then the three tiers, then research.
+Lead with the headline, then the Research log, then comps, then tiers.
 
     Max supported price: $X   [anchored on: <exact match | era-peer + gap>]
 
@@ -126,6 +160,7 @@ Per item:
 
     === PRICE — Item <N> (<short name>) ===
     Comps refreshed: YYYY-MM-DD   ·   Data quality: good / partial / thin
+    Research log:  (the A/B/C block above — REQUIRED)
     Hunt: <one line — formulations tried, sources, exact-match yes/no>
 
 For each scenario (or just "primary" when no bracket — most items):

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -39,36 +39,43 @@ stage is autonomous — PRICE never stops to ask.
    web + marketplaces. Tag `[A — WebSearch]`.
 
 3. **Stage B — Apify eBay sold** (the default direct-eBay comp source; no
-   gate). Run `python lib/apify_ebay.py "<query>"` (or `search_ebay_sold()`
-   programmatically) — it calls the `automation-lab/ebay-sold-scraper`
-   Actor, which **pins a US residential proxy** so eBay returns USD
-   natively, and returns structured comps with per-item URLs, sold dates,
-   condition, listing type / bid count, and seller stats. Headless, no
-   browser. Tag `[B — Apify]`. Cost ~$0.10/run; runs automatically.
-   - **Currency-leak safety is built into the wrapper** — every run is
-     checked with a provider-agnostic charm-price test (genuine USD eBay
-     prices cluster on .99/.95/.00/.50; an FX leak destroys that). If a run
-     fails the check the wrapper **raises `CurrencyLeakError`** rather than
-     return corrupt prices. Do NOT rely on the `sold_currency` label — it
-     can lie; the wrapper's check is what matters. (History: the old
-     caffein.dev actor leaked BRL/CZK at ~5× mislabeled USD — that's why we
-     switched and added this guard.)
-   - **On `CurrencyLeakError`** (rare with the US-proxy actor): treat
-     confidence as LOW and fall to Stage C (Chrome) for clean US-IP data.
-     Note "Apify currency-leak → Chrome" in the Hunt line. (A
-     `--on-leak repair` mode exists that FX-corrects the run, but prefer the
-     Chrome cross-check over trusting a repair.)
-   - Still drop the usual outliers (single bid, >2× median). If Stage B
-     returns <3 usable comps or dispersion disagrees badly with Stage A,
-     treat as LOW confidence → Stage C.
-   - **Proof-of-run is mandatory.** The CLI prints `Apify run: <id>` — copy
-     that run id into the Research log (it's verifiable in the Apify backend).
-     **Never report Stage B as "ran" without a run id.** If you have no run
-     id, it did not run — say so and why.
-   - **If Apify is unconfigured or the run fails** (no token / ApifyError /
-     timeout / **no shell tool to run the CLI in this environment**): record
-     `B — UNAVAILABLE: <reason>` in the Research log and fall through to
-     Stage C for the same eBay-sold data. Do NOT silently skip B.
+   gate). Backend Actor `automation-lab/ebay-sold-scraper` — it **pins a US
+   residential proxy** so eBay returns USD natively, and returns structured
+   comps with per-item URLs, sold dates, condition, listing type / bid
+   count, and seller stats. Tag `[B — Apify]`. ~$0.10/run. **Use whichever
+   execution path your environment supports — try them in this order:**
+
+   - **Path 1 — Apify MCP tool (preferred; works even with no sandbox
+     egress).** If an Apify MCP connector is available (e.g. in a Cowork
+     tab), call the actor `automation-lab/ebay-sold-scraper` through that
+     tool with input `{searchQueries:["<query>"], maxListingsPerSearch:30,
+     maxSearchPages:3, sort:"price_high", listingType:"all"}`. It returns
+     the dataset items (fields: `soldPrice`, `soldDate`, `title`, `url`,
+     `condition`, `listingType`, `bidsCount`, `sellerName`,
+     `sellerFeedbackCount`/`Percent`, `shippingCost`). Record the **run id**
+     the tool reports. MCP calls are brokered outside the code sandbox, so
+     this works where direct `api.apify.com` egress is blocked.
+   - **Path 2 — stdlib CLI (when you have a shell + egress to
+     api.apify.com).** Run `python lib/apify_ebay.py "<query>"` (no pip — it
+     uses only the standard library). Capture the printed `Apify run: <id>`.
+   - **Map + validate (either path):** fields → comps (same shape); drop
+     single-bid / >2× median outliers to Tier C. The CLI auto-runs the
+     charm-price currency check; **on the MCP path you must eyeball it** —
+     genuine USD eBay prices cluster on .99/.95/.00/.50; if they don't,
+     suspect a currency leak and prefer Stage C. Never trust a
+     `currency`/`USD` label; the price pattern is what matters. (The
+     US-proxy actor makes leaks unlikely — the old caffein.dev actor leaked
+     BRL/CZK at ~5× mislabeled USD, which is why we switched.)
+   - **Proof-of-run is mandatory.** Record the **Apify run id** (from the
+     MCP result or the CLI's `Apify run:` line) in the Research log — it's
+     verifiable in the Apify backend. **Never report Stage B as "ran"
+     without a run id.**
+   - Still drop outliers; if Stage B yields <3 usable comps or dispersion
+     disagrees badly with Stage A, treat as LOW confidence → Stage C.
+   - **If NEITHER path is available** (no Apify MCP tool AND no
+     shell/egress — e.g. a sandbox whose proxy 403s `api.apify.com`):
+     record `B — UNAVAILABLE: <reason>` in the Research log and fall through
+     to Stage C. Do NOT silently skip B.
 
 4. **If no exact match yet, broaden and re-run A+B:** drop the
    least-load-bearing keyword (5→3 words), then try a synonym for Type.
@@ -110,11 +117,22 @@ Apify is the default Stage B source and runs without a gate. The backend
 Actor is `automation-lab/ebay-sold-scraper` (configurable via
 `apify.ebay_actor`), chosen because it pins a **US residential proxy** —
 so eBay serves USD natively and the foreign-currency leak that sank the
-previous actor doesn't occur. The wrapper still validates every run with
-the charm-price currency check (defense in depth) and raises
-`CurrencyLeakError` if a run ever looks FX-converted. To run without Apify
-entirely, leave the Apify token unset — Stage B then routes to Chrome
-(Stage C) automatically.
+previous actor doesn't occur. The CLI/wrapper validates every run with the
+charm-price currency check (defense in depth) and raises `CurrencyLeakError`
+if a run ever looks FX-converted.
+
+**Two execution paths, by environment (see Stage B above):**
+- **Apify MCP connector** — preferred in restricted environments (e.g. a
+  Cowork tab) whose sandbox proxy blocks `api.apify.com`. MCP calls are
+  brokered outside the sandbox, so they reach Apify when raw HTTPS can't.
+  No pip, no wrapper file, token lives in the connector.
+- **stdlib CLI** (`python lib/apify_ebay.py`) — for shell environments with
+  egress. No third-party package (standard library only); needs Python +
+  network to `api.apify.com` + the Apify token.
+
+If neither is available (no MCP tool, no shell/egress), Stage B is
+`UNAVAILABLE` and PRICE routes to Chrome (Stage C). Same if the Apify token
+is unset.
 
 ## URLs (mandatory — the user verifies comps by clicking them)
 
@@ -145,9 +163,9 @@ Don't confuse with the comp-quality "Tier A/B/C" further down.)
 
     Research log — Item <N>
       A · WebSearch : RAN — query "<q>" — <n> hits — <one-line finding>
-      B · Apify     : RAN — query "<q>" — run <runId> — <n> comps — USD-validated (charm <x>%)
-                      [ALT] UNAVAILABLE — <no shell/code tool to run it | api.apify.com egress blocked | no token | CurrencyLeakError>
-                      (note: no `pip install` needed — the wrapper is stdlib-only)
+      B · Apify     : RAN via <MCP|CLI> — query "<q>" — run <runId> — <n> comps — USD-validated (charm <x>%)
+                      [ALT] UNAVAILABLE — <no Apify MCP tool AND no shell/egress | api.apify.com egress blocked (sandbox proxy) | no token | CurrencyLeakError>
+                      (run id comes from the MCP tool result or the CLI's `Apify run:` line; no `pip install` needed)
       C · Chrome    : NOT TRIGGERED — confidence OK (<n> usable comps from A+B)
                       [ALT] RAN — <low-confidence trigger> — <n> rows
                       [ALT] UNAVAILABLE — <no browser/Chrome MCP in this environment>

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -40,16 +40,27 @@ stage is autonomous — PRICE never stops to ask.
 
 3. **Stage B — Apify eBay sold** (the default direct-eBay comp source; no
    gate). Run `python lib/apify_ebay.py "<query>"` (or `search_ebay_sold()`
-   programmatically) — it calls the eBay sold-listings Actor and returns
-   structured comps with per-item URLs, sold dates, condition, currency,
-   and seller stats. Headless, no browser. Tag `[B — Apify]`. Cost is
-   ~$0.12/run and runs automatically as part of the hunt.
-   - **Data-quality guardrails (Apify is trusted by default now, so check
-     it):** keep only `sold_currency == USD` rows — the Actor can silently
-     return GBP/BRL prices at face value; drop (or convert + note) any
-     non-USD comp. Drop the usual outliers (single bid, >2× median). If a
-     run returns suspiciously few rows, or dispersion that disagrees badly
-     with Stage A, treat confidence as **LOW** and trigger Stage C.
+   programmatically) — it calls the `automation-lab/ebay-sold-scraper`
+   Actor, which **pins a US residential proxy** so eBay returns USD
+   natively, and returns structured comps with per-item URLs, sold dates,
+   condition, listing type / bid count, and seller stats. Headless, no
+   browser. Tag `[B — Apify]`. Cost ~$0.10/run; runs automatically.
+   - **Currency-leak safety is built into the wrapper** — every run is
+     checked with a provider-agnostic charm-price test (genuine USD eBay
+     prices cluster on .99/.95/.00/.50; an FX leak destroys that). If a run
+     fails the check the wrapper **raises `CurrencyLeakError`** rather than
+     return corrupt prices. Do NOT rely on the `sold_currency` label — it
+     can lie; the wrapper's check is what matters. (History: the old
+     caffein.dev actor leaked BRL/CZK at ~5× mislabeled USD — that's why we
+     switched and added this guard.)
+   - **On `CurrencyLeakError`** (rare with the US-proxy actor): treat
+     confidence as LOW and fall to Stage C (Chrome) for clean US-IP data.
+     Note "Apify currency-leak → Chrome" in the Hunt line. (A
+     `--on-leak repair` mode exists that FX-corrects the run, but prefer the
+     Chrome cross-check over trusting a repair.)
+   - Still drop the usual outliers (single bid, >2× median). If Stage B
+     returns <3 usable comps or dispersion disagrees badly with Stage A,
+     treat as LOW confidence → Stage C.
    - **If Apify is unconfigured or the run fails** (no token / ApifyError /
      timeout): fall through to Stage C for the same eBay-sold data. Note
      "Apify unavailable → Chrome" in the Hunt line.
@@ -90,13 +101,15 @@ commit to it.
 
 ## Apify notes (the Stage B backend)
 
-Apify is now the default Stage B source and runs without a gate. It has
-documented quirks — run-to-run coverage variance, silent GBP→USD,
-historical BRL inflation (raw evidence under `deprecated/`). The Stage-B
-guardrails above (USD-only filter, outlier drop, dispersion check, Chrome
-cross-check when suspect) exist specifically to catch these. To run
-without Apify entirely, leave the Apify token unset — Stage B then routes
-to Chrome (Stage C) automatically.
+Apify is the default Stage B source and runs without a gate. The backend
+Actor is `automation-lab/ebay-sold-scraper` (configurable via
+`apify.ebay_actor`), chosen because it pins a **US residential proxy** —
+so eBay serves USD natively and the foreign-currency leak that sank the
+previous actor doesn't occur. The wrapper still validates every run with
+the charm-price currency check (defense in depth) and raises
+`CurrencyLeakError` if a run ever looks FX-converted. To run without Apify
+entirely, leave the Apify token unset — Stage B then routes to Chrome
+(Stage C) automatically.
 
 ## URLs (mandatory)
 

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -36,7 +36,8 @@ stage is autonomous — PRICE never stops to ask.
    if a printed date is visible in a photo.
 
 2. **Stage A — WebSearch** (free, ~5s, broad). Casts wide across the open
-   web + marketplaces. Tag `[A — WebSearch]`.
+   web + marketplaces. Tag `[A — WebSearch]`. **Log each usable hit to
+   `<shoot-dir>/comps.csv` as stage A** (see "Saved comp artifacts").
 
 3. **Stage B — Apify eBay sold** (the default direct-eBay comp source; no
    gate). Backend Actor `automation-lab/ebay-sold-scraper` — it **pins a US
@@ -103,6 +104,8 @@ stage is autonomous — PRICE never stops to ask.
    per-item URLs; when you can't capture each href (via `read_page`/
    `find`), cite the SOLD-search URL as the verifiable source and say so.
    Subject to browser read-tier limits (see [list_edit_chrome.md](list_edit_chrome.md)).
+   **Log each comp to `<shoot-dir>/comps.csv` as stage C** (see "Saved comp
+   artifacts").
 
 6. **Active fallback** (only when sold returns zero direct matches): drop
    the sold filters, capture active listings, tag `[active — ASKING
@@ -140,6 +143,32 @@ If neither is available (no MCP tool, no shell/egress), Stage B is
 `UNAVAILABLE` and PRICE routes to Chrome (Stage C). Same if the Apify token
 is unset.
 
+## Saved comp artifacts (every stage leaves a reviewable record)
+
+The user reviews the raw research, so each stage persists its comps:
+
+- **Stage B (Apify)** → JSON (auto-saved; `--save-dir <shoot-dir>` puts it
+  beside `price.txt`; MCP path: write items to `<shoot-dir>/apify_<runId>.json`).
+- **Stages A (WebSearch) and C (Chrome)** → rows in **`<shoot-dir>/comps.csv`**,
+  the single spreadsheet the user opens to review every comp across sources.
+  Append each usable comp with `lib/comps_csv.py`:
+
+      python lib/comps_csv.py --shoot-dir <dir> --item <N> --stage A \
+        --query "<q>" --price <p> --title "<t>" --url "<url>" \
+        --sold-date <YYYY-MM-DD> --condition "<c>" --note "<why>"
+
+  (stage `C` for Chrome). **No shell?** Write `<shoot-dir>/comps.csv`
+  directly with the Write tool using this exact header:
+  `captured_at,item,stage,query,price,title,sold_date,condition,listing_type,url,note`
+- **Unify (recommended):** fold Stage B into the same CSV so one file holds
+  all three —
+  `python lib/comps_csv.py --shoot-dir <dir> --from-apify-json <run.json>`.
+- **Fresh per run:** `python lib/comps_csv.py --shoot-dir <dir> --reset`
+  once at the start of pricing an item, before appending.
+
+A comp with no price (a WebSearch context hit, a dealer asking price) still
+gets a row — leave `price` blank and say why in `note`.
+
 ## URLs (mandatory — the user verifies comps by clicking them)
 
 Every comp carries a clickable source URL inline (a comp without a URL is
@@ -168,12 +197,12 @@ EVERY item; C is conditional. Each stage is `RAN` (with proof) /
 Don't confuse with the comp-quality "Tier A/B/C" further down.)
 
     Research log — Item <N>
-      A · WebSearch : RAN — query "<q>" — <n> hits — <one-line finding>
+      A · WebSearch : RAN — query "<q>" — <n> hits — <one-line finding> — logged to comps.csv
       B · Apify     : RAN via <MCP|CLI> — query "<q>" — run <runId> — <n> comps — USD-validated (charm <x>%) — saved <path>.json
                       [ALT] UNAVAILABLE — <no Apify MCP tool AND no shell/egress | api.apify.com egress blocked (sandbox proxy) | no token | CurrencyLeakError>
                       (run id comes from the MCP tool result or the CLI's `Apify run:` line; no `pip install` needed)
       C · Chrome    : NOT TRIGGERED — confidence OK (<n> usable comps from A+B)
-                      [ALT] RAN — <low-confidence trigger> — <n> rows
+                      [ALT] RAN — <low-confidence trigger> — <n> rows — logged to comps.csv
                       [ALT] UNAVAILABLE — <no browser/Chrome MCP in this environment>
 
 Hard rules for the log:

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -116,10 +116,21 @@ the charm-price currency check (defense in depth) and raises
 entirely, leave the Apify token unset — Stage B then routes to Chrome
 (Stage C) automatically.
 
-## URLs (mandatory)
+## URLs (mandatory — the user verifies comps by clicking them)
 
-Every comp carries a clickable source URL. A comp without a URL is not a
-comp.
+Every comp carries a clickable source URL inline (a comp without a URL is
+not a comp). In ADDITION, every PRICE output ends with a consolidated
+**Comp URLs** list (see Output) so the user can click straight through and
+view the comps themselves — **exact / near-exact matches first**, then
+ceiling/context comps, then the eBay sold-search URL for the whole result
+set. These live in `price.txt` (persisted), so they're saved for reference.
+
+- Use **direct per-item eBay listing URLs** (`ebay.com/itm/<id>`) for exact
+  matches whenever you have them (Stage B/Apify returns one per comp;
+  Stage A/WebSearch and direct Chrome hrefs too).
+- Only when a per-item href genuinely can't be captured (e.g. Chrome
+  `get_page_text`) may you fall back to the sold-search URL — and say so.
+- Never list a bare price without its URL in this section.
 
 ## Research log (MANDATORY — proof every search type actually ran)
 
@@ -176,6 +187,23 @@ For each scenario (or just "primary" when no bracket — most items):
 
 Mark comps >12 months old `[STALE]`. Every Tier C needs a specific
 reason.
+
+### Comp URLs — verify these yourself (MANDATORY, ends every item)
+
+A consolidated, click-through list so the user can open the comps directly.
+Exact/near-exact anchors first; include the price + a short title with each
+URL so the list is scannable on its own. Required on every item.
+
+    Comp URLs — Item <N> (open to verify):
+      Exact / near-exact match:
+        • $<price> — "<short title>" — <https://www.ebay.com/itm/...>
+        • $<price> — "<short title>" — <https://www.ebay.com/itm/...>
+      Ceiling / context:
+        • $<price> — "<short title>" — <https://www.ebay.com/itm/...>
+      All sold results (eBay search): <sold-search URL>
+
+If NO exact match exists, say so on the "Exact / near-exact" line
+("none found") and still list the closest era-peers + the sold-search URL.
 
 ### Three tiers (always)
 

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -146,7 +146,8 @@ Don't confuse with the comp-quality "Tier A/B/C" further down.)
     Research log — Item <N>
       A · WebSearch : RAN — query "<q>" — <n> hits — <one-line finding>
       B · Apify     : RAN — query "<q>" — run <runId> — <n> comps — USD-validated (charm <x>%)
-                      [ALT] UNAVAILABLE — <no shell tool / no token / ApifyError / CurrencyLeakError>
+                      [ALT] UNAVAILABLE — <no shell/code tool to run it | api.apify.com egress blocked | no token | CurrencyLeakError>
+                      (note: no `pip install` needed — the wrapper is stdlib-only)
       C · Chrome    : NOT TRIGGERED — confidence OK (<n> usable comps from A+B)
                       [ALT] RAN — <low-confidence trigger> — <n> rows
                       [ALT] UNAVAILABLE — <no browser/Chrome MCP in this environment>

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -1,0 +1,91 @@
+# REVIEW — v3, Function 5.5 (the publish gate)
+
+Obeys [`_shared.md`](_shared.md). Read it first.
+
+The single human checkpoint in `list`/`full` mode. DRAFT produces
+`draft.md`; REVIEW turns it into a succinct decision card, **stops the
+run**, and waits. On explicit human approval — and only then — it
+publishes the listing LIVE. This is the gate that replaced the old
+"never publish" firewall: publishing is no longer refused, it is
+*gated here*.
+
+**Reads:** `draft.md` (authoritative for the listing) · `price.txt`
+(comp URLs + tiers) · `NEEDS_REVIEW.md` (deferred decisions for this item).
+**Writes:** `<shoot-dir>/review_card.md` (the card, for the record) and
+the same card to chat.
+
+## The card (succinct — fits on a screen)
+
+Lead with the headline line, then the sections. No preamble. Pull every
+value from the files above; never re-derive or invent.
+
+    ━━ REVIEW: <item_id> ━━
+    Title:     "<title>"  [N/80]
+    Price:     $<price> (<tier> tier)  ·  Best Offer: <on @ auto-decline $X | off>
+    Condition: <grade> — <one-line summary>
+    Quantity:  <n> (<unit_type>)   ·   Photos: <n> (hero: <file>)
+
+    Comps (supporting the price):
+      • $<price> — "<title>"  ·  <A/B/C>  ·  <url>
+      • $<price> — "<title>"  ·  <A/B/C>  ·  <url>
+      • (list the comps price.txt cited for the chosen tier; each with its URL)
+
+    Condition detail:
+      • <every defect the draft's Condition section flagged — verbatim, no minimizing>
+
+    ⚠ Needs review / manual intervention:
+      • <each NEEDS_REVIEW.md line for this item>
+      • <each DRAFT meta.notes gap, substitution, or rephrase worth a human eye>
+      • (write "None" if genuinely clean)
+
+    → Approve publishes this LIVE on eBay at $<price>. Reply "approve" to
+      publish, or tell me what to change.
+
+### Rules for filling it
+- **Comps:** take the URLs `price.txt` listed for the working/Recommended
+  tier. A price with no supporting comp URL is itself a ⚠ line, not a
+  silent omission.
+- **Condition:** copy the draft's flagged defects exactly. The whole point
+  of the gate is that the human sees them before money is on the line —
+  never soften or drop one.
+- **Needs review:** merge `NEEDS_REVIEW.md` entries for this item with any
+  DRAFT-flagged gap/substitution/rephrase. If a *required* field is empty
+  or a price has no comp, say so plainly and recommend resolving it before
+  approval — but the human decides.
+- **One item at a time.** In a multi-item shoot, present one card, take its
+  decision, then the next. Only batch-publish if the user says "approve all".
+
+## The gate (HARD — this is where the run stops)
+
+After writing the card, STOP and wait. Do not publish on:
+- silence, "ok", "looks good", "nice", 👍, or any ambiguous nod;
+- a chat instruction to "just publish" that did not come *after* this card;
+- your own judgment that it looks fine.
+
+Publish ONLY on an explicit, unambiguous approval ("approve", "publish it",
+"yes publish") given against this card. Before running the command, restate
+in one line: *"Publishing <item_id> LIVE at $<price> now."*
+
+If the user asks for a change, treat it as feedback: the relevant prior
+phase (INVESTIGATE/DRAFT/PRICE) re-runs, DRAFT re-renders `draft.md`, and
+REVIEW presents a fresh card. Never edit `draft.md` by hand here.
+
+## On approval — publish (one step)
+
+Run, with the human approval as the authorization for `--confirm`:
+
+    python lib/list_edit.py --list <shoot-dir> --confirm
+
+`--list` syncs (creates the offer + uploads photos to EPS) then publishes
+in one call. The `--confirm` guard remains in the code as defense-in-depth;
+your approval at this gate is what authorizes passing it. On success report
+the listing URL. If publish fails validation, surface the eBay error,
+fix the draft via the owning phase, and re-present the card — never retry
+blind.
+
+## Closing
+
+Per _shared: lead with the result.
+- Awaiting decision: `review_card.md` path + the headline (title + price)
+  + the count of ⚠ lines. Then stop.
+- After publish: the live listing URL + price. Nothing further runs.


### PR DESCRIPTION
REVIEW gate (approval-gated publish replaces the no-publish firewall)
Apify cost-gate removal + A→B→C source reorder
Apify actor migration (automation-lab, US proxy) fixing the currency leak
Mandatory per-stage research log
Consolidated comp-URL list
Dependency-free stdlib Apify wrapper
MCP-aware Stage B (Cowork path)
Apify results persisted to JSON
Stage A & C comps → reviewable comps.csv