### PR TITLE
eBay API: multi-store re-auth, category preflight, media shipping, listing management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ apify_run*.json
 apify_run*.stderr.txt
 apify_runs/
 
+# eBay listings ledger (account/inventory activity — kept locally)
+listings_log.txt
+
 # Sample / shoot images — kept on disk, not version-controlled (heavy binaries)
 *.jpg
 *.jpeg

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ never publishes on its own. Two paths:
   settle-and-verify before save, JS DOM state over lagging screenshots,
   never open the variations editor, drop inaccurate AI-suggested specifics.
 
+**Managing listings (Function 6, on request).** `lib/list_edit.py` also
+manages any offer/SKU on the account: `--offers` (query all, read-only),
+`--withdraw-offer <id>` (end a live listing, keep the offer), `--delete-offer
+<id>` and `--delete-item <sku>` (permanent removal). Mutations are dry-run
+unless `--confirm` and are user-initiated — never part of the pipeline.
+
 Python infrastructure (`config`, `ebay_client`, `apify_ebay`,
 `list_edit`, `draft_io`, `photo_prep`) lives in `lib/`.
 

--- a/RUN.md
+++ b/RUN.md
@@ -129,6 +129,22 @@ gate is what authorizes passing it. A dry run is available any time
   read-tier/sandbox limits and the debounce/trusted-input pitfalls
   documented in its prompt.
 
+**Managing live listings (Function 6, on user request).** Beyond
+publishing, `lib/list_edit.py` queries and manages any offer/SKU on the
+account. Like publish, every mutation is **dry-run unless `--confirm`** and
+runs ONLY when the user asks (never as part of the automated pipeline):
+
+| Op | Command | Effect |
+|---|---|---|
+| Query | `--offers` | list every offer (status, offerId, listingId, price, sku) — read-only |
+| Withdraw | `--withdraw-offer <id> --confirm` | end a LIVE listing; offer kept (UNPUBLISHED), re-publishable |
+| Delete offer | `--delete-offer <id> --confirm` | delete an offer (permanent; ends listing if live; SKU kept) |
+| Delete item | `--delete-item <sku> --confirm` | delete the inventory item + ALL its offers (permanent) |
+
+Withdraw/delete are destructive and **HARD-gated like publish**: confirm the
+exact target with the user (run the dry run first, show what it hits), and
+only pass `--confirm` on an explicit yes. Use `--offers` to find IDs.
+
 Cross-cutting depth rules:
 - Condition analysis in IDENTIFY and INVESTIGATE uses
   [prompts/condition-rubric.md](prompts/condition-rubric.md).

--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -250,6 +250,25 @@ categories that only allow New/Used), and (b) **flags items priced > $100**
 to add insurance at label time (only $100 is auto-included; the eBay API
 can't set insurance — see ShipCover in Seller Hub).
 
+## Managing listings (query / withdraw / delete)
+
+Account-level operations that work on ANY offer or SKU — not just items with
+a local draft. All mutations are **dry-run unless `--confirm`** (same guard
+as publish).
+
+```
+python list_edit.py --offers                            # list every offer: status, offerId, listingId, price, sku/title
+python list_edit.py --withdraw-offer <offerId> --confirm  # end a LIVE offer; offer stays (UNPUBLISHED), re-publishable
+python list_edit.py --delete-offer  <offerId> --confirm   # DELETE an offer (permanent); ends the listing if live; SKU kept
+python list_edit.py --delete-item   <sku>     --confirm   # DELETE the inventory item AND all its offers (permanent)
+```
+
+- **Withdraw vs delete:** withdraw takes a live listing down but keeps the
+  offer so you can re-publish; delete removes it for good.
+- `--delete-item` is the cleanest way to fully retire an item (removes the
+  SKU and every offer under it).
+- Use `--offers` first to find the IDs.
+
 ## Notes / limits
 
 - **Photos via EPS** use the Trading API `UploadSiteHostedPictures` (needs

--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -172,7 +172,7 @@ ebay:
 
 ```
 # 4. Pull the new account's policy IDs + inventory location
-python lib/ebay_client.py --setup-check
+python lib/list_edit.py --setup-check
 ```
 
 Paste the four account-specific values into the same env block:
@@ -186,7 +186,7 @@ Paste the four account-specific values into the same env block:
 
 ```
 # 5. Verify both the auth and the listing path see the new creds
-python lib/ebay_client.py --setup-check
+python lib/list_edit.py --setup-check
 python lib/list_edit.py  --setup-check
 ```
 

--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -269,6 +269,22 @@ python list_edit.py --delete-item   <sku>     --confirm   # DELETE the inventory
   SKU and every offer under it).
 - Use `--offers` first to find the IDs.
 
+## Listings ledger
+
+Every listing the tooling creates is appended to a plain-text ledger,
+`listings_log.txt` (repo root; override with `EBAYBIZ_LISTINGS_LOG`). One
+line per event — when an offer is first created (`--sync`/`--list`) and when
+it goes live (`--publish`/`--list --confirm`):
+
+```
+<utc> | OFFER_CREATED | offer_id=… sku=… price=$… | <title>
+<utc> | PUBLISHED | listing_id=… offer_id=… sku=… price=$… | <title> | <url>
+```
+
+It's append-only (a running record of everything listed) and gitignored
+(account/inventory activity). Re-syncing an existing item does not add a
+duplicate line — only the first creation and each publish are recorded.
+
 ## Notes / limits
 
 - **Photos via EPS** use the Trading API `UploadSiteHostedPictures` (needs

--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -117,6 +117,86 @@ draft remembers its `ebay_offer_id`).
 
 ---
 
+## Authorize / Reauthorize (connect a store, or switch to a different one)
+
+The `user_refresh_token` ties the app to **one eBay seller account**. Use
+this to grant access the first time, when the token expires (~18-month
+lifetime), or to **switch the active environment to a different store**.
+
+**What changes vs. what stays:**
+- **Stays:** the app keyset (`app_id` / `cert_id` / `dev_id` / `redirect_uri`)
+  for the active environment — you're re-authorizing the *same app*.
+- **Changes (all in the active env block, e.g. `ebay.production:`):** the
+  `user_refresh_token`, and — because they're account-specific — the
+  `merchant_location_key` and the three `*_policy_id` values. A different
+  store has different policy IDs and location; the old ones will NOT work.
+
+**⚠ The make-or-break step:** during consent you must be signed in to eBay
+as the **store you want to connect**. Log out of any other eBay account
+first, or run the browser step in an **incognito/private window** —
+otherwise you silently re-authorize whatever account is already logged in.
+
+Run from the repo root (`environment:` already points at the target env):
+
+```
+# 0. Back up the working config so you can revert
+cp config.yaml config.bak-currentstore.yaml
+
+# 1. Print the consent URL
+python lib/ebay_client.py --user-consent-url
+```
+
+```
+# 2. Open that URL in a browser SIGNED IN AS THE TARGET STORE (incognito = safest).
+#    Approve the Sell scopes. eBay redirects to your redirect_uri with ?code=...
+#    Copy the `code` value from the address bar.
+#    (Codes are single-use and expire in minutes — do step 3 promptly.
+#     If step 3 fails with invalid_grant, URL-decode the code first:
+#     %23 -> #, %5E -> ^, etc.)
+```
+
+```
+# 3. Exchange the code for the new refresh token (prints it)
+python lib/ebay_client.py --exchange-code "<code>"
+```
+
+Paste the printed `refresh_token` into `config.yaml` under the **active
+environment block** (nested — e.g. `ebay.production.user_refresh_token`,
+not a flat `ebay.user_refresh_token`):
+
+```yaml
+ebay:
+  production:
+    user_refresh_token: "v^1.1#..."
+```
+
+```
+# 4. Pull the new account's policy IDs + inventory location
+python lib/ebay_client.py --setup-check
+```
+
+Paste the four account-specific values into the same env block:
+
+```yaml
+    merchant_location_key: "<new>"
+    fulfillment_policy_id: "<new>"
+    payment_policy_id:     "<new>"
+    return_policy_id:      "<new>"
+```
+
+```
+# 5. Verify both the auth and the listing path see the new creds
+python lib/ebay_client.py --setup-check
+python lib/list_edit.py  --setup-check
+```
+
+The target store must have **Business Policies opted in** and an
+**inventory location** (see Step 3 above) — otherwise `--setup-check` lists
+no policies and `--sync` fails. To switch back later, restore
+`config.bak-currentstore.yaml`.
+
+---
+
 ## Going live (publish) — explicit and confirmation-gated
 
 API-created offers are UNPUBLISHED and do **not** appear in the Seller Hub

--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -232,6 +232,24 @@ step). That preserves the firewall's intent — no accidental or automated
 publication — while giving you a one-command way to take a reviewed offer
 live.
 
+## Shipping policies (ground default + optional Media Mail)
+
+`--sync` runs a **preflight** that picks the fulfillment policy per item:
+
+- **`fulfillment_policy_id`** — the default (ground) policy, used for most items.
+- **`fulfillment_policy_id_media`** *(optional)* — a USPS **Media Mail** policy.
+  When a draft's `primary_service` is Media Mail (DRAFT sets this for books /
+  magazines / comics / music / movies) and this policy is set, the offer uses
+  it; otherwise it falls back to the ground policy. To create one, add a
+  fulfillment policy with shipping service `USPSMedia` (free flat-rate) and
+  paste its ID here.
+
+The same preflight also (a) **auto-remaps the condition** to one the item's
+category accepts (e.g. `USED_GOOD` → `USED_EXCELLENT`/"Used" for non-media
+categories that only allow New/Used), and (b) **flags items priced > $100**
+to add insurance at label time (only $100 is auto-included; the eBay API
+can't set insurance — see ShipCover in Seller Hub).
+
 ## Notes / limits
 
 - **Photos via EPS** use the Trading API `UploadSiteHostedPictures` (needs

--- a/lib/config.example.yaml
+++ b/lib/config.example.yaml
@@ -66,7 +66,9 @@ ebay:
     redirect_uri: "SBX-RuName"
     user_refresh_token: null
     merchant_location_key: null
-    fulfillment_policy_id: null
+    fulfillment_policy_id: null          # default (ground) shipping policy
+    fulfillment_policy_id_media: null    # optional: Media Mail policy; used for
+                                         # books/magazines/comics/music/movies
     payment_policy_id: null
     return_policy_id: null
 
@@ -77,7 +79,9 @@ ebay:
     redirect_uri: "PRD-RuName"
     user_refresh_token: null
     merchant_location_key: null
-    fulfillment_policy_id: null
+    fulfillment_policy_id: null          # default (ground) shipping policy
+    fulfillment_policy_id_media: null    # optional: Media Mail policy; used for
+                                         # books/magazines/comics/music/movies
     payment_policy_id: null
     return_policy_id: null
 

--- a/lib/ebay_client.py
+++ b/lib/ebay_client.py
@@ -554,6 +554,47 @@ def get_inventory_locations(creds: Optional[EbayCredentials] = None) -> list[dic
 
 
 # ---------------------------------------------------------------------------
+# Metadata API — what a category actually accepts (conditions, etc.)
+# ---------------------------------------------------------------------------
+
+def get_item_condition_policies(category_id: str,
+                                marketplace: str = DEFAULT_MARKETPLACE,
+                                creds: Optional[EbayCredentials] = None) -> dict:
+    """Raw item-condition policy for a category (Sell Metadata API)."""
+    flt = urllib.parse.quote(f"{{{category_id}}}", safe="")  # {id} -> %7Bid%7D
+    return api_send(
+        "GET",
+        f"/sell/metadata/v1/marketplace/{marketplace}/get_item_condition_policies"
+        f"?filter=categoryIds:{flt}",
+        creds=creds, marketplace=None,
+    )
+
+
+def get_allowed_condition_ids(category_id: str,
+                              marketplace: str = DEFAULT_MARKETPLACE,
+                              creds: Optional[EbayCredentials] = None) -> tuple[set[int], bool]:
+    """Return ({allowed eBay conditionId ints}, condition_required) for a category.
+
+    Empty set means the category metadata is unavailable / unrestricted —
+    callers should treat that as "don't touch the chosen condition".
+    """
+    data = get_item_condition_policies(category_id, marketplace, creds)
+    pols = data.get("itemConditionPolicies") or []
+    if not pols:
+        return set(), False
+    cp = pols[0]
+    ids: set[int] = set()
+    for c in cp.get("itemConditions", []):
+        cid = c.get("conditionId")
+        if cid is not None:
+            try:
+                ids.add(int(cid))
+            except (ValueError, TypeError):
+                pass
+    return ids, bool(cp.get("itemConditionRequired"))
+
+
+# ---------------------------------------------------------------------------
 # eBay Picture Services (EPS) upload — Trading API UploadSiteHostedPictures
 # ---------------------------------------------------------------------------
 #

--- a/lib/ebay_client.py
+++ b/lib/ebay_client.py
@@ -525,7 +525,8 @@ def api_send(method: str, path: str, body: Optional[dict] = None,
 
 def get_fulfillment_policies(marketplace: str = DEFAULT_MARKETPLACE,
                              creds: Optional[EbayCredentials] = None) -> list[dict]:
-    data = api_send("GET", "/sell/account/v1/fulfillment_policy",
+    # Account API requires marketplace_id as a QUERY param (not just header).
+    data = api_send("GET", f"/sell/account/v1/fulfillment_policy?marketplace_id={marketplace}",
                     creds=creds, marketplace=None,
                     extra_headers={"X-EBAY-C-MARKETPLACE-ID": marketplace})
     return data.get("fulfillmentPolicies") or []
@@ -533,7 +534,7 @@ def get_fulfillment_policies(marketplace: str = DEFAULT_MARKETPLACE,
 
 def get_payment_policies(marketplace: str = DEFAULT_MARKETPLACE,
                          creds: Optional[EbayCredentials] = None) -> list[dict]:
-    data = api_send("GET", "/sell/account/v1/payment_policy",
+    data = api_send("GET", f"/sell/account/v1/payment_policy?marketplace_id={marketplace}",
                     creds=creds, marketplace=None,
                     extra_headers={"X-EBAY-C-MARKETPLACE-ID": marketplace})
     return data.get("paymentPolicies") or []
@@ -541,7 +542,7 @@ def get_payment_policies(marketplace: str = DEFAULT_MARKETPLACE,
 
 def get_return_policies(marketplace: str = DEFAULT_MARKETPLACE,
                         creds: Optional[EbayCredentials] = None) -> list[dict]:
-    data = api_send("GET", "/sell/account/v1/return_policy",
+    data = api_send("GET", f"/sell/account/v1/return_policy?marketplace_id={marketplace}",
                     creds=creds, marketplace=None,
                     extra_headers={"X-EBAY-C-MARKETPLACE-ID": marketplace})
     return data.get("returnPolicies") or []

--- a/lib/ebay_client.py
+++ b/lib/ebay_client.py
@@ -554,6 +554,67 @@ def get_inventory_locations(creds: Optional[EbayCredentials] = None) -> list[dic
 
 
 # ---------------------------------------------------------------------------
+# Listing management — query inventory/offers, withdraw, delete
+# ---------------------------------------------------------------------------
+
+def get_inventory_items(limit: int = 100, offset: int = 0,
+                        creds: Optional[EbayCredentials] = None) -> dict:
+    """One page of the account's inventory items (SKUs). Use iter_inventory_items
+    to walk all pages."""
+    return api_send("GET",
+                    f"/sell/inventory/v1/inventory_item?limit={int(limit)}&offset={int(offset)}",
+                    creds=creds, marketplace=None)
+
+
+def iter_inventory_items(creds: Optional[EbayCredentials] = None) -> list[dict]:
+    """All inventory items across pages (each has sku + product.title)."""
+    items: list[dict] = []
+    offset, limit = 0, 100
+    while True:
+        page = get_inventory_items(limit=limit, offset=offset, creds=creds)
+        batch = page.get("inventoryItems") or []
+        items.extend(batch)
+        total = page.get("total")
+        offset += limit
+        if not batch or (total is not None and offset >= total):
+            break
+    return items
+
+
+def get_offers_for_sku(sku: str, creds: Optional[EbayCredentials] = None) -> list[dict]:
+    """All offers for a SKU (each has offerId, status, listing.listingId, price)."""
+    data = api_send("GET",
+                    f"/sell/inventory/v1/offer?sku={urllib.parse.quote(str(sku), safe='')}",
+                    creds=creds, marketplace=None)
+    return data.get("offers") or []
+
+
+def get_offer(offer_id: str, creds: Optional[EbayCredentials] = None) -> dict:
+    return api_send("GET", f"/sell/inventory/v1/offer/{offer_id}", creds=creds, marketplace=None)
+
+
+def withdraw_offer(offer_id: str, creds: Optional[EbayCredentials] = None) -> dict:
+    """End (withdraw) a PUBLISHED offer — ends the live listing; the offer
+    returns to UNPUBLISHED (re-publishable). Not a delete."""
+    return api_send("POST", f"/sell/inventory/v1/offer/{offer_id}/withdraw", {},
+                    creds=creds, marketplace=None)
+
+
+def delete_offer(offer_id: str, creds: Optional[EbayCredentials] = None) -> dict:
+    """Delete an offer permanently. If it is published, this also ends the
+    live listing. The inventory item (SKU) remains."""
+    return api_send("DELETE", f"/sell/inventory/v1/offer/{offer_id}",
+                    creds=creds, marketplace=None)
+
+
+def delete_inventory_item(sku: str, creds: Optional[EbayCredentials] = None) -> dict:
+    """Delete an inventory item (SKU) and ALL of its offers permanently."""
+    return api_send("DELETE",
+                    f"/sell/inventory/v1/inventory_item/{urllib.parse.quote(str(sku), safe='')}",
+                    creds=creds, marketplace=None)
+
+
+# ---------------------------------------------------------------------------
 # Metadata API — what a category actually accepts (conditions, etc.)
 # ---------------------------------------------------------------------------
 

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -57,6 +57,10 @@ policy IDs / locations to paste in.
     python list_edit.py --setup-check                      # verify creds + policies
     python list_edit.py --sync <shoot-dir|draft.md>        # create/update eBay DRAFT (runs preflight)
     python list_edit.py --list <shoot-dir|draft.md> --confirm  # sync + publish (post review-gate)
+    python list_edit.py --offers                           # query ALL offers on the account
+    python list_edit.py --withdraw-offer <id> --confirm    # end a live offer (keeps it, UNPUBLISHED)
+    python list_edit.py --delete-offer <id> --confirm      # delete an offer (ends listing if live)
+    python list_edit.py --delete-item <sku> --confirm      # delete inventory item + ALL its offers
     python list_edit.py --check                             # legacy stub-status report
 """
 
@@ -80,15 +84,21 @@ from ebay_client import (
     EbayAuthError,
     EbayCredentials,
     api_send,
+    delete_inventory_item,
+    delete_offer,
     get_allowed_condition_ids,
     get_category_suggestions,
     get_fulfillment_policies,
     get_inventory_locations,
+    get_offer,
+    get_offers_for_sku,
     get_payment_policies,
     get_return_policies,
     get_user_access_token,
+    iter_inventory_items,
     load_credentials,
     upload_site_hosted_picture,
+    withdraw_offer,
 )
 
 
@@ -793,6 +803,105 @@ def end_listing(draft_path: Path, creds: Optional[EbayCredentials] = None,
 
 
 # ---------------------------------------------------------------------------
+# Account-level listing management — query / withdraw / delete by ID
+# (works on ANY offer/SKU on the account, not just ones with a local draft)
+# ---------------------------------------------------------------------------
+
+def list_account_offers(creds: Optional[EbayCredentials] = None) -> list[dict]:
+    """Enumerate every offer on the account (inventory items -> offers).
+
+    Returns rows: sku, title, offer_id, status, listing_id, price, marketplace.
+    """
+    creds = creds or load_credentials()
+    if not creds.has_user:
+        raise EbayAuthError("Query needs user-context OAuth. Run `python list_edit.py --setup-check`.")
+    rows: list[dict] = []
+    for it in iter_inventory_items(creds=creds):
+        sku = it.get("sku")
+        title = str((it.get("product") or {}).get("title") or "")
+        try:
+            offers = get_offers_for_sku(sku, creds=creds)
+        except EbayAPIError:
+            offers = []
+        if not offers:
+            rows.append({"sku": sku, "title": title, "offer_id": None,
+                         "status": "NO_OFFER", "listing_id": None,
+                         "price": None, "marketplace": None})
+        for off in offers:
+            rows.append({
+                "sku": sku, "title": title,
+                "offer_id": off.get("offerId"),
+                "status": off.get("status"),
+                "listing_id": (off.get("listing") or {}).get("listingId"),
+                "price": ((off.get("pricingSummary") or {}).get("price") or {}).get("value"),
+                "marketplace": off.get("marketplaceId"),
+            })
+    return rows
+
+
+@dataclass
+class OfferActionResult:
+    action: str               # "withdraw" | "delete-offer" | "delete-item"
+    dry_run: bool
+    done: bool
+    target: str               # offer_id or sku
+    status_before: Optional[str] = None
+    title: Optional[str] = None
+    listing_id: Optional[str] = None
+    detail: str = ""
+
+
+def withdraw_offer_by_id(offer_id: str, creds: Optional[EbayCredentials] = None,
+                         confirm: bool = False) -> OfferActionResult:
+    """Withdraw (end) a live offer by ID — keeps the offer (UNPUBLISHED)."""
+    creds = creds or load_credentials()
+    off = get_offer(offer_id, creds=creds)
+    status = str(off.get("status") or "UNKNOWN")
+    listing_id = str((off.get("listing") or {}).get("listingId") or "") or None
+    if status != "PUBLISHED":
+        return OfferActionResult("withdraw", not confirm, False, offer_id, status,
+                                 detail="not live (nothing to withdraw)", listing_id=listing_id)
+    if not confirm:
+        return OfferActionResult("withdraw", True, False, offer_id, status, listing_id=listing_id)
+    withdraw_offer(offer_id, creds=creds)
+    return OfferActionResult("withdraw", False, True, offer_id, status,
+                             detail="ended; offer is now UNPUBLISHED", listing_id=listing_id)
+
+
+def delete_offer_by_id(offer_id: str, creds: Optional[EbayCredentials] = None,
+                       confirm: bool = False) -> OfferActionResult:
+    """Delete an offer by ID (permanent). If live, this also ends the listing."""
+    creds = creds or load_credentials()
+    off = get_offer(offer_id, creds=creds)
+    status = str(off.get("status") or "UNKNOWN")
+    listing_id = str((off.get("listing") or {}).get("listingId") or "") or None
+    price = ((off.get("pricingSummary") or {}).get("price") or {}).get("value")
+    if not confirm:
+        return OfferActionResult("delete-offer", True, False, offer_id, status,
+                                 detail=f"sku={off.get('sku')} price={price}", listing_id=listing_id)
+    delete_offer(offer_id, creds=creds)
+    return OfferActionResult("delete-offer", False, True, offer_id, status,
+                             detail="offer deleted (inventory item/SKU kept)", listing_id=listing_id)
+
+
+def delete_item_by_sku(sku: str, creds: Optional[EbayCredentials] = None,
+                       confirm: bool = False) -> OfferActionResult:
+    """Delete an inventory item (SKU) AND all its offers (permanent)."""
+    creds = creds or load_credentials()
+    try:
+        offers = get_offers_for_sku(sku, creds=creds)
+    except EbayAPIError:
+        offers = []
+    n_live = sum(1 for o in offers if str(o.get("status")) == "PUBLISHED")
+    detail = f"{len(offers)} offer(s), {n_live} live — all will be removed"
+    if not confirm:
+        return OfferActionResult("delete-item", True, False, sku, detail=detail)
+    delete_inventory_item(sku, creds=creds)
+    return OfferActionResult("delete-item", False, True, sku,
+                             detail=f"inventory item + {len(offers)} offer(s) deleted")
+
+
+# ---------------------------------------------------------------------------
 # Status / setup-check
 # ---------------------------------------------------------------------------
 
@@ -867,8 +976,12 @@ def _cli() -> None:
     ap.add_argument("--sync", metavar="TARGET", help="Create/update the eBay DRAFT (unpublished offer) from a draft.md or shoot dir.")
     ap.add_argument("--publish", metavar="TARGET", help="Publish a synced offer to a LIVE listing. DRY RUN unless --confirm is also given.")
     ap.add_argument("--list", metavar="TARGET", dest="list_target", help="Sync THEN publish in one step (post review-gate). DRY RUN unless --confirm is also given.")
-    ap.add_argument("--end", metavar="TARGET", help="End (withdraw) a live listing. DRY RUN unless --confirm is also given.")
-    ap.add_argument("--confirm", action="store_true", help="Required with --publish/--list/--end to actually act (otherwise they are dry runs).")
+    ap.add_argument("--end", metavar="TARGET", help="End (withdraw) a live listing from a draft. DRY RUN unless --confirm is also given.")
+    ap.add_argument("--offers", action="store_true", help="Query ALL offers on the account (sku, offerId, status, listingId, price).")
+    ap.add_argument("--withdraw-offer", metavar="OFFER_ID", help="Withdraw (end) a live offer by ID — keeps the offer. DRY RUN unless --confirm.")
+    ap.add_argument("--delete-offer", metavar="OFFER_ID", help="Delete an offer by ID (permanent; ends listing if live; keeps SKU). DRY RUN unless --confirm.")
+    ap.add_argument("--delete-item", metavar="SKU", help="Delete an inventory item (SKU) AND all its offers (permanent). DRY RUN unless --confirm.")
+    ap.add_argument("--confirm", action="store_true", help="Required with --publish/--list/--end/--withdraw-offer/--delete-offer/--delete-item to actually act (otherwise dry runs).")
     ap.add_argument("--setup-check", action="store_true", help="Verify creds and list account policy IDs.")
     ap.add_argument("--check", action="store_true", help="Print module/credential status.")
     args = ap.parse_args()
@@ -953,6 +1066,46 @@ def _cli() -> None:
                 print("\n  To actually end it: re-run with --confirm")
             else:
                 print(f"[ENDED] Withdrew offer {res.offer_id} (listing {res.listing_id}) — no longer live.")
+            return
+        if args.offers:
+            rows = list_account_offers()
+            print(f"{len(rows)} offer(s) on the account:\n")
+            print(f"  {'STATUS':12} {'OFFER_ID':16} {'LISTING_ID':14} {'PRICE':>8}  SKU / TITLE")
+            for r in rows:
+                price = f"${r['price']}" if r.get("price") else "-"
+                print(f"  {str(r['status'] or '-'):12} {str(r['offer_id'] or '-'):16} "
+                      f"{str(r['listing_id'] or '-'):14} {price:>8}  {r['sku']}  |  {r['title'][:48]}")
+            return
+        if args.withdraw_offer:
+            res = withdraw_offer_by_id(args.withdraw_offer, confirm=args.confirm)
+            if not res.done and res.status_before != "PUBLISHED":
+                print(f"[i] Offer {res.target} is {res.status_before} — {res.detail}")
+            elif res.dry_run:
+                print("[DRY RUN] WOULD withdraw (end) this LIVE offer:")
+                print(f"  offer:   {res.target}\n  listing: {res.listing_id}\n  status:  {res.status_before}")
+                print("\n  To actually withdraw: re-run with --confirm")
+            else:
+                print(f"[ENDED] Withdrew offer {res.target} — {res.detail}")
+            return
+        if args.delete_offer:
+            res = delete_offer_by_id(args.delete_offer, confirm=args.confirm)
+            if res.dry_run:
+                print("[DRY RUN] WOULD DELETE this offer (permanent):")
+                print(f"  offer:   {res.target}\n  status:  {res.status_before}"
+                      + (f" (LIVE — deleting ends the listing)" if res.status_before == "PUBLISHED" else ""))
+                print(f"  {res.detail}")
+                print("\n  To actually delete: re-run with --confirm")
+            else:
+                print(f"[DELETED] Offer {res.target} — {res.detail}")
+            return
+        if args.delete_item:
+            res = delete_item_by_sku(args.delete_item, confirm=args.confirm)
+            if res.dry_run:
+                print("[DRY RUN] WOULD DELETE this inventory item AND its offers (permanent):")
+                print(f"  sku: {res.target}\n  {res.detail}")
+                print("\n  To actually delete: re-run with --confirm")
+            else:
+                print(f"[DELETED] Inventory item {res.target} — {res.detail}")
             return
         if args.check:
             s = stub_status()

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -66,6 +66,7 @@ policy IDs / locations to paste in.
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 import time
@@ -174,6 +175,43 @@ def _to_decimal_str(val: object) -> Optional[str]:
     except (InvalidOperation, ValueError):
         return None
     return f"{d:.2f}"
+
+
+def _listings_log_path() -> Path:
+    """Where the listings ledger lives: $EBAYBIZ_LISTINGS_LOG or <repo>/listings_log.txt."""
+    env = os.environ.get("EBAYBIZ_LISTINGS_LOG")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parent.parent / "listings_log.txt"
+
+
+def record_listing(event: str, *, title: str = "", sku: str = "",
+                   offer_id: str = "", listing_id: str = "",
+                   price: str = "", url: str = "") -> Optional[str]:
+    """Append one record to the listings ledger (unique IDs + title), one line
+    per created listing. Best-effort: never raises (logging must not break a
+    sync/publish). Returns the file path, or None if the write failed."""
+    try:
+        path = _listings_log_path()
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        ids = "  ".join(p for p in (
+            f"listing_id={listing_id}" if listing_id else "",
+            f"offer_id={offer_id}" if offer_id else "",
+            f"sku={sku}" if sku else "",
+            f"price=${price}" if price else "",
+        ) if p)
+        line = f"{ts} | {event} | {ids} | {title}"
+        if url:
+            line += f" | {url}"
+        fresh = not path.exists() or path.stat().st_size == 0
+        with path.open("a", encoding="utf-8") as f:
+            if fresh:
+                f.write("# eBay listings ledger — one line appended each time the "
+                        "tooling creates/publishes a listing\n")
+            f.write(line + "\n")
+        return str(path)
+    except OSError:
+        return None
 
 
 def _ebay_extra(field: str) -> Optional[str]:
@@ -664,6 +702,14 @@ def create_or_update_listing(draft_path: Path,
         "last_synced": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     })
 
+    # 5) ledger: record newly-created listings (offers) — append, not on re-sync
+    if operation == "created":
+        rec = record_listing("OFFER_CREATED", title=str(draft.get("title") or ""),
+                              sku=sku, offer_id=offer_id,
+                              price=_to_decimal_str(draft.get("price")) or "")
+        if rec:
+            print(f"  [ledger] recorded -> {rec}")
+
     hub = "https://www.ebay.com/sh/lst/drafts"
     return SyncResult(offer_id=offer_id, inventory_sku=sku, operation=operation,
                       photo_eps_urls=image_urls, category_id=category_id,
@@ -745,6 +791,9 @@ def publish_offer(draft_path: Path, creds: Optional[EbayCredentials] = None,
             "ebay_listing_id": listing_id,
             "published_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         })
+        record_listing("PUBLISHED", title=title, sku=sku, offer_id=offer_id,
+                       listing_id=listing_id, price=price,
+                       url=f"https://www.ebay.com/itm/{listing_id}")
     return PublishResult(dry_run=False, offer_id=offer_id, title=title, price=price,
                          status_before=status, listing_id=listing_id or None,
                          listing_url=(f"https://www.ebay.com/itm/{listing_id}" if listing_id else None))

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -366,8 +366,13 @@ def _resolve_policies_and_location(creds: EbayCredentials) -> tuple[dict, str]:
         "payment": _ebay_extra("payment_policy_id"),
         "return": _ebay_extra("return_policy_id"),
     }
+    # Optional: a Media Mail fulfillment policy used for media items (books,
+    # magazines, comics, music, movies). Not required — falls back to default.
+    policies["fulfillment_media"] = _ebay_extra("fulfillment_policy_id_media")
     location = _ebay_extra("merchant_location_key")
     for k, v in policies.items():
+        if k == "fulfillment_media":
+            continue  # optional
         if not v:
             missing.append(f"ebay.{k}_policy_id")
     if not location:
@@ -474,28 +479,66 @@ def _set_draft_condition(draft_path: Path, new_enum: str) -> None:
         draft_path.write_text(new_text, encoding="utf-8")
 
 
-def _check_shipping(draft: Draft, policies: dict,
-                    creds: EbayCredentials) -> list[str]:
-    """Verify the active fulfillment policy actually ships, and flag when the
-    draft's intended primary_service isn't what the policy offers."""
-    fid = str(policies.get("fulfillment") or "")
+def _is_media_service(code: str) -> bool:
+    """True if a shipping service code denotes USPS Media Mail."""
+    c = (code or "").lower()
+    return "media" in c  # USPSMedia / USPSMediaMail
+
+
+def _resolve_shipping_policy(draft: Draft, policies: dict,
+                             creds: EbayCredentials) -> tuple[str, list[str]]:
+    """Choose the fulfillment policy for THIS item and validate it.
+
+    Routing: if the draft's `primary_service` is Media Mail (DRAFT sets this
+    for books/magazines/comics/music/movies) AND a media policy is configured,
+    use it; otherwise use the default (USPS Ground) policy. Returns
+    (chosen_fulfillment_id, messages).
+    """
+    default_fid = str(policies.get("fulfillment") or "")
+    media_fid = str(policies.get("fulfillment_media") or "")
+    want = str(draft.get("shipping.primary_service") or "").strip()
+    msgs: list[str] = []
+
+    if _is_media_service(want):
+        if media_fid:
+            chosen, label = media_fid, "Media Mail (media policy)"
+        else:
+            chosen, label = default_fid, "default ground (NO media policy configured)"
+            msgs.append("shipping: item wants Media Mail but ebay.fulfillment_policy_id_media "
+                        "is unset — using default ground policy. Add a Media Mail policy to save on media.")
+    else:
+        chosen, label = default_fid, "default ground policy"
+
+    # Validate the chosen policy actually exists and ships.
     try:
         pols = get_fulfillment_policies(creds=creds)
+        pol = next((p for p in pols if str(p.get("fulfillmentPolicyId")) == chosen), None)
+        if not pol:
+            msgs.append(f"shipping: chosen fulfillment_policy_id {chosen} not found on this account")
+        else:
+            offered = [s.get("shippingServiceCode")
+                       for opt in (pol.get("shippingOptions") or [])
+                       for s in (opt.get("shippingServices") or []) if s.get("shippingServiceCode")]
+            if not offered:
+                msgs.append(f"shipping: policy '{pol.get('name')}' offers no services — publish may fail")
+            else:
+                msgs.insert(0, f"shipping: using {label} -> '{pol.get('name')}' ({', '.join(offered)})")
     except (EbayAPIError, EbayAuthError) as e:
-        return [f"shipping: could not verify fulfillment policy ({e})"]
-    pol = next((p for p in pols if str(p.get("fulfillmentPolicyId")) == fid), None)
-    if not pol:
-        return [f"shipping: fulfillment_policy_id {fid} not found on this account"]
-    offered = [s.get("shippingServiceCode")
-               for opt in (pol.get("shippingOptions") or [])
-               for s in (opt.get("shippingServices") or []) if s.get("shippingServiceCode")]
-    want = str(draft.get("shipping.primary_service") or "").strip()
-    if not offered:
-        return [f"shipping: policy '{pol.get('name')}' offers no shipping services — publish may fail"]
-    if want and want not in offered:
-        return [f"shipping: draft primary_service '{want}' is not in the active policy "
-                f"'{pol.get('name')}' (offers {offered}); eBay uses the POLICY's service. "
-                f"Switch to a matching fulfillment policy if '{want}' is required (e.g. Media Mail for books)."]
+        msgs.append(f"shipping: could not verify fulfillment policy ({e})")
+    return chosen, msgs
+
+
+def _insurance_notes(draft: Draft) -> list[str]:
+    """Remind to insure high-value items — only $100 is auto-included, and the
+    eBay API can't set insurance (it's bought at label time via ShipCover)."""
+    price = _to_decimal_str(draft.get("price"))
+    try:
+        if price and Decimal(price) > Decimal("100"):
+            return [f"insurance: price ${price} > $100 — only $100 ships included; "
+                    f"add ShipCover/added coverage when buying the label (Seller Hub -> "
+                    f"Get shipping label -> Additional liability coverage)."]
+    except InvalidOperation:
+        pass
     return []
 
 
@@ -528,9 +571,11 @@ def preflight_listing(draft_path: Path, creds: Optional[EbayCredentials] = None,
         else:
             msgs.append(f"condition: {cur} OK for category")
 
-    # Shipping vs active policy
-    ship = _check_shipping(draft, policies, creds)
-    msgs.extend(ship or ["shipping: OK (active policy offers the service)"])
+    # Shipping policy selection (media vs ground) + validation
+    _chosen, ship = _resolve_shipping_policy(draft, policies, creds)
+    msgs.extend(ship)
+    # Insurance reminder for high-value items
+    msgs.extend(_insurance_notes(draft))
     return msgs
 
 
@@ -573,7 +618,11 @@ def create_or_update_listing(draft_path: Path,
             notes = str(draft.get("meta.notes") or "")
             update_meta(draft_path, {"notes": (notes + f" | PREFLIGHT: {reason}").strip(" |")})
             print(f"  [preflight] {reason}")
-    for _m in _check_shipping(draft, policies, creds):
+    # Shipping: pick the right fulfillment policy (Media Mail for media items,
+    # else default ground) and use it for this offer.
+    chosen_fulfillment, ship_msgs = _resolve_shipping_policy(draft, policies, creds)
+    policies = {**policies, "fulfillment": chosen_fulfillment}
+    for _m in ship_msgs + _insurance_notes(draft):
         print(f"  [preflight] {_m}")
 
     # 1) photos -> EPS

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -53,8 +53,9 @@ policy IDs / locations to paste in.
 ----- CLI -----
 
     python list_edit.py --validate <shoot-dir|draft.md>   # no creds needed
+    python list_edit.py --preflight <shoot-dir|draft.md>  # check/auto-fix condition+shipping vs category
     python list_edit.py --setup-check                      # verify creds + policies
-    python list_edit.py --sync <shoot-dir|draft.md>        # create/update eBay DRAFT
+    python list_edit.py --sync <shoot-dir|draft.md>        # create/update eBay DRAFT (runs preflight)
     python list_edit.py --list <shoot-dir|draft.md> --confirm  # sync + publish (post review-gate)
     python list_edit.py --check                             # legacy stub-status report
 """
@@ -79,6 +80,7 @@ from ebay_client import (
     EbayAuthError,
     EbayCredentials,
     api_send,
+    get_allowed_condition_ids,
     get_category_suggestions,
     get_fulfillment_policies,
     get_inventory_locations,
@@ -410,6 +412,129 @@ def _resolve_category_id(draft: Draft, creds: EbayCredentials) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Pre-publish preflight — validate condition + shipping against the category
+# ---------------------------------------------------------------------------
+
+# eBay condition enum <-> numeric conditionId (the metadata API speaks ids).
+_COND_ENUM_TO_ID = {
+    "NEW": 1000, "LIKE_NEW": 2750, "NEW_OTHER": 1500, "NEW_WITH_DEFECTS": 1750,
+    "MANUFACTURER_REFURBISHED": 2000, "CERTIFIED_REFURBISHED": 2000,
+    "EXCELLENT_REFURBISHED": 2010, "VERY_GOOD_REFURBISHED": 2020,
+    "GOOD_REFURBISHED": 2030, "SELLER_REFURBISHED": 2500,
+    "USED_EXCELLENT": 3000, "USED_VERY_GOOD": 4000, "USED_GOOD": 5000,
+    "USED_ACCEPTABLE": 6000, "FOR_PARTS_OR_NOT_WORKING": 7000,
+}
+_COND_ID_TO_ENUM = {
+    1000: "NEW", 1500: "NEW_OTHER", 1750: "NEW_WITH_DEFECTS", 2750: "LIKE_NEW",
+    2000: "CERTIFIED_REFURBISHED", 2010: "EXCELLENT_REFURBISHED",
+    2020: "VERY_GOOD_REFURBISHED", 2030: "GOOD_REFURBISHED", 2500: "SELLER_REFURBISHED",
+    3000: "USED_EXCELLENT", 4000: "USED_VERY_GOOD", 5000: "USED_GOOD",
+    6000: "USED_ACCEPTABLE", 7000: "FOR_PARTS_OR_NOT_WORKING",
+}
+_COND_FAMILIES = (
+    [1000, 1500, 1750, 2750],          # new-ish
+    [2000, 2010, 2020, 2030, 2500],    # refurbished
+    [3000, 4000, 5000, 6000],          # used grades
+    [7000],                            # for parts
+)
+
+
+def _remap_condition_for_category(enum: str, allowed_ids: set[int]) -> tuple[str, Optional[str]]:
+    """Return (condition_enum, change_reason). reason is None if unchanged.
+
+    Picks the closest accepted condition in the SAME family (used->used,
+    new->new). Raises if the category accepts nothing in that family (a real
+    mismatch the user must resolve — e.g. listing a used item in a new-only
+    category).
+    """
+    cid = _COND_ENUM_TO_ID.get(enum)
+    if cid is None or not allowed_ids or cid in allowed_ids:
+        return enum, None  # unknown enum, no metadata, or already valid
+    family = next((f for f in _COND_FAMILIES if cid in f), [])
+    candidates = [i for i in family if i in allowed_ids]
+    if not candidates:
+        allowed_names = ", ".join(_COND_ID_TO_ENUM.get(i, str(i)) for i in sorted(allowed_ids))
+        raise EbayAPIError(
+            0, f"condition {enum} is invalid for this category and no same-grade "
+               f"alternative is accepted. Category accepts: {allowed_names}. "
+               f"Fix the draft's condition or category_id.", None)
+    # Prefer generic "Used" (3000) for used items; else the nearest accepted id.
+    target = 3000 if (3000 in candidates and cid in _COND_FAMILIES[2]) else \
+        min(candidates, key=lambda i: abs(i - cid))
+    new_enum = _COND_ID_TO_ENUM[target]
+    return new_enum, (f"condition {enum} not accepted by category "
+                      f"(accepts {sorted(allowed_ids)}) -> remapped to {new_enum}")
+
+
+def _set_draft_condition(draft_path: Path, new_enum: str) -> None:
+    """Rewrite the top-level `condition:` line in the draft file."""
+    text = draft_path.read_text(encoding="utf-8")
+    new_text = re.sub(r'(?m)^(condition:\s*).*$', f'condition: "{new_enum}"', text, count=1)
+    if new_text != text:
+        draft_path.write_text(new_text, encoding="utf-8")
+
+
+def _check_shipping(draft: Draft, policies: dict,
+                    creds: EbayCredentials) -> list[str]:
+    """Verify the active fulfillment policy actually ships, and flag when the
+    draft's intended primary_service isn't what the policy offers."""
+    fid = str(policies.get("fulfillment") or "")
+    try:
+        pols = get_fulfillment_policies(creds=creds)
+    except (EbayAPIError, EbayAuthError) as e:
+        return [f"shipping: could not verify fulfillment policy ({e})"]
+    pol = next((p for p in pols if str(p.get("fulfillmentPolicyId")) == fid), None)
+    if not pol:
+        return [f"shipping: fulfillment_policy_id {fid} not found on this account"]
+    offered = [s.get("shippingServiceCode")
+               for opt in (pol.get("shippingOptions") or [])
+               for s in (opt.get("shippingServices") or []) if s.get("shippingServiceCode")]
+    want = str(draft.get("shipping.primary_service") or "").strip()
+    if not offered:
+        return [f"shipping: policy '{pol.get('name')}' offers no shipping services — publish may fail"]
+    if want and want not in offered:
+        return [f"shipping: draft primary_service '{want}' is not in the active policy "
+                f"'{pol.get('name')}' (offers {offered}); eBay uses the POLICY's service. "
+                f"Switch to a matching fulfillment policy if '{want}' is required (e.g. Media Mail for books)."]
+    return []
+
+
+def preflight_listing(draft_path: Path, creds: Optional[EbayCredentials] = None,
+                      apply: bool = True) -> list[str]:
+    """Check (and, if apply=True, auto-correct) a draft against its eBay
+    category BEFORE sync/publish: condition validity + shipping. Returns a
+    list of human-readable messages. Safe to run repeatedly (idempotent)."""
+    creds = creds or load_credentials()
+    draft_path = _resolve_draft_path(draft_path)
+    draft = parse_draft(draft_path)
+    category_id = _resolve_category_id(draft, creds)
+    policies, _loc = _resolve_policies_and_location(creds)
+    msgs: list[str] = [f"category: {category_id}"]
+
+    # Condition vs category
+    allowed, required = get_allowed_condition_ids(category_id, creds=creds)
+    cur = str(draft.get("condition") or "")
+    if not allowed:
+        msgs.append(f"condition: {cur} (category condition metadata unavailable — left as-is)")
+    else:
+        new_enum, reason = _remap_condition_for_category(cur, allowed)
+        if reason:
+            msgs.append(reason)
+            if apply:
+                _set_draft_condition(draft_path, new_enum)
+                draft.frontmatter["condition"] = new_enum
+                notes = str(draft.get("meta.notes") or "")
+                update_meta(draft_path, {"notes": (notes + f" | PREFLIGHT: {reason}").strip(" |")})
+        else:
+            msgs.append(f"condition: {cur} OK for category")
+
+    # Shipping vs active policy
+    ship = _check_shipping(draft, policies, creds)
+    msgs.extend(ship or ["shipping: OK (active policy offers the service)"])
+    return msgs
+
+
+# ---------------------------------------------------------------------------
 # Main sync
 # ---------------------------------------------------------------------------
 
@@ -433,6 +558,23 @@ def create_or_update_listing(draft_path: Path,
     sku = _sku_for(draft)
     policies, location_key = _resolve_policies_and_location(creds)
     category_id = _resolve_category_id(draft, creds)
+
+    # 0.5) Preflight: make the condition valid for THIS category (auto-remap)
+    #      and sanity-check shipping. Prevents the publish-time 25021
+    #      "condition invalid for category" failure (and surfaces shipping
+    #      mismatches) before any photo upload or offer write.
+    allowed_conditions, _req = get_allowed_condition_ids(category_id, creds=creds)
+    if allowed_conditions:
+        new_enum, reason = _remap_condition_for_category(
+            str(draft.get("condition") or ""), allowed_conditions)
+        if reason:
+            _set_draft_condition(draft_path, new_enum)
+            draft.frontmatter["condition"] = new_enum
+            notes = str(draft.get("meta.notes") or "")
+            update_meta(draft_path, {"notes": (notes + f" | PREFLIGHT: {reason}").strip(" |")})
+            print(f"  [preflight] {reason}")
+    for _m in _check_shipping(draft, policies, creds):
+        print(f"  [preflight] {_m}")
 
     # 1) photos -> EPS
     image_urls = upload_photos_to_eps(resolve_photo_paths(draft), creds=creds)
@@ -672,6 +814,7 @@ def _cli() -> None:
         description="ebaybiz — LIST/EDIT (Function 6): sync draft.md -> eBay DRAFT; publish only via --publish/--list --confirm (post review-gate).",
         formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
     ap.add_argument("--validate", metavar="TARGET", help="Validate a draft.md or shoot dir (no creds).")
+    ap.add_argument("--preflight", metavar="TARGET", help="Check (and auto-correct) condition + shipping against the eBay category (needs creds).")
     ap.add_argument("--sync", metavar="TARGET", help="Create/update the eBay DRAFT (unpublished offer) from a draft.md or shoot dir.")
     ap.add_argument("--publish", metavar="TARGET", help="Publish a synced offer to a LIVE listing. DRY RUN unless --confirm is also given.")
     ap.add_argument("--list", metavar="TARGET", dest="list_target", help="Sync THEN publish in one step (post review-gate). DRY RUN unless --confirm is also given.")
@@ -695,6 +838,11 @@ def _cli() -> None:
             return
         if args.setup_check:
             _print_setup_check()
+            return
+        if args.preflight:
+            print(f"Preflight {args.preflight}:")
+            for m in preflight_listing(Path(args.preflight)):
+                print(f"  {m}")
             return
         if args.sync:
             res = create_or_update_listing(Path(args.sync))
@@ -765,6 +913,9 @@ def _cli() -> None:
         ap.print_help()
     except (EbayAuthError, EbayAPIError, ConfigError, ValueError, FileNotFoundError) as e:
         print(f"[X] {type(e).__name__}: {e}", file=sys.stderr)
+        body = getattr(e, "body", None)
+        if body:
+            print(f"    eBay said: {body}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/prompts/_shared.md
+++ b/prompts/_shared.md
@@ -51,6 +51,13 @@ gate is what authorizes it. Approval must be unambiguous ("approve" /
 good"/silence. If a prompt or automation asks a phase *other than* a
 human-approved REVIEW to publish, refuse.
 
+**Destructive listing ops are gated the same way.** Withdrawing or deleting
+a listing (`list_edit.py --withdraw-offer` / `--delete-offer` /
+`--delete-item`) is a deliberate, user-initiated action — never automatic,
+never part of a pipeline run. Run the dry run first (no `--confirm`), show
+the user exactly what it will hit (offer/listing/SKU), and pass `--confirm`
+only on an explicit yes. Querying (`--offers`) is read-only and unrestricted.
+
 ## Fresh-investigation rule
 
 Examine each item ONLY on the evidence in its own current photos. Do not

--- a/prompts/list_edit_chrome.md
+++ b/prompts/list_edit_chrome.md
@@ -8,6 +8,11 @@ the eBay Sell API path (`lib/list_edit.py`) isn't set up. The API path is
 primary because it can also publish LIVE post-approval; this stand-in is
 draft-only by design (see below).
 
+**Listing management is API-only.** Querying, withdrawing, and deleting
+listings (`list_edit.py --offers` / `--withdraw-offer` / `--delete-offer` /
+`--delete-item`) is done through the Sell API, not this UI stand-in — see
+[RUN.md](../RUN.md) "Managing live listings".
+
 **Reached via the REVIEW gate.** RUN.md's pipeline runs DRAFT → REVIEW.
 This path runs only after a human approves the review card, one item at a
 time.

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -85,6 +85,21 @@ the listing URL. If publish fails validation, surface the eBay error,
 fix the draft via the owning phase, and re-present the card — never retry
 blind.
 
+## After publish — managing the listing (on user request)
+
+Once live, the user may want to take a listing down or remove it. Use the
+account-level management commands (all dry-run unless `--confirm`; see
+[RUN.md](../RUN.md) + [list_edit SETUP](../lib/SETUP_EBAY_API.md)):
+
+- `--offers` — find the offerId / SKU (read-only).
+- `--withdraw-offer <id> --confirm` — end the live listing, keep the offer
+  (re-publishable). Use when they want it *off the market* but not gone.
+- `--delete-offer <id> --confirm` / `--delete-item <sku> --confirm` —
+  permanently remove. Use when they want it *gone*.
+
+Treat these like publish: run the dry run, confirm the exact target with the
+user, and only pass `--confirm` on an explicit yes.
+
 ## Closing
 
 Per _shared: lead with the result.

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -24,6 +24,8 @@ value from the files above; never re-derive or invent.
     Price:     $<price> (<tier> tier)  ·  Best Offer: <on @ auto-decline $X | off>
     Condition: <grade> — <one-line summary>
     Quantity:  <n> (<unit_type>)   ·   Photos: <n> (hero: <file>)
+    Shipping:  <chosen policy/service, e.g. "Media Mail (free)" or "USPS Ground (free)"; from preflight>
+    Insurance: <"$100 included" — OR, if price > $100: "⚠ add ShipCover at label time; only $100 included">
 
     Comps (supporting the price):
       • $<price> — "<title>"  ·  <A/B/C>  ·  <url>


### PR DESCRIPTION
Hardens and extends the eBay Sell API integration. Found and fixed while connecting a second production store and publishing the first live API listing.

## Multi-store / auth
- **SETUP_EBAY_API.md**: new "Authorize / Reauthorize" runbook for granting access, refreshing an expired token, or switching the active environment to a different store (incognito login gotcha, single-use codes, config backup/revert).
- **fix(ebay_client)**: Account policy GETs now send `marketplace_id` as a query param (was header-only → HTTP 400 `20401 Missing field marketplaceId`).

## Pre-publish preflight (fixes publish-time failures)
- **Condition vs category**: query `get_item_condition_policies` and auto-remap the draft's condition to one the category accepts (e.g. `USED_GOOD` → `USED_EXCELLENT`/"Used" for non-media categories that only allow New/Used). Fixes `25021` "condition id invalid for category". Errors clearly if the category accepts nothing in that family. Runs in `--sync` and standalone via `--preflight`.
- **Media-aware shipping**: pick the fulfillment policy per item — Media Mail (`fulfillment_policy_id_media`) for books/magazines/comics/music/movies, else the default ground policy. Validates the chosen policy ships.
- **Insurance reminder**: flag items priced > $100 (only $100 ships included; eBay API can't set insurance — add ShipCover at label time). Surfaced in preflight + the REVIEW card.

## Listing management (new, account-level)
`list_edit.py` now manages any offer/SKU, not just local drafts — all dry-run unless `--confirm`:
- `--offers` — query every offer (status, offerId, listingId, price, sku)
- `--withdraw-offer <id>` — end a live listing, keep the offer (re-publishable)
- `--delete-offer <id>` — delete an offer (permanent; ends listing if live)
- `--delete-item <sku>` — delete the inventory item + all its offers

## Docs / prompts
RUN.md, _shared.md, review.md, README.md, list_edit_chrome.md updated so the agent knows these ops exist and that withdraw/delete are user-initiated, dry-run-then-`--confirm` (gated like publish).

Verified end-to-end on the production store: first live API publish (sand-dollars), condition remap, media vs ground routing, and all management dry-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)