### PR TITLE
Custom-label SKU as a hash + per-item lifecycle ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ apify_runs/
 
 # eBay listings ledger (account/inventory activity — kept locally)
 listings_log.txt
+listings_ledger.csv
 
 # Sample / shoot images — kept on disk, not version-controlled (heavy binaries)
 *.jpg

--- a/RUN.md
+++ b/RUN.md
@@ -100,7 +100,7 @@ Load each prompt when you reach its phase.
 | PRICE | [prompts/price.md](prompts/price.md) | `identify.txt` | `price.txt` |
 | CURATE | [prompts/curate.md](prompts/curate.md) | `identify.txt`+`price.txt`+profile | `review.md` |
 | INVESTIGATE | [prompts/investigate.md](prompts/investigate.md) | photos (+`identify.txt`) | `investigate.txt` |
-| DRAFT | [prompts/draft.md](prompts/draft.md) | `identify.txt`+`investigate.txt`+`price.txt`+template | `draft.md` |
+| DRAFT | [prompts/draft.md](prompts/draft.md) | `identify.txt`+`investigate.txt`+`price.txt`+template | `draft.md` + `--record` → SKU stamped + ledger row (DRAFTED) |
 | REVIEW | [prompts/review.md](prompts/review.md) | `draft.md`+`price.txt`+`NEEDS_REVIEW.md` | `review_card.md` → (on approval) LIVE listing |
 
 **The publish step (reached via the REVIEW gate, on explicit approval):**
@@ -173,7 +173,9 @@ is unchanged and shared from `lib/` — v3 does not duplicate code.
 5. INVESTIGATE (list mode), per item → commit to the confident
    assessment; log open questions; write `investigate.txt`.
 6. DRAFT (list mode) → render template, run the pre-write validation
-   pass, write `draft.md`.
+   pass, write `draft.md`, then `python lib/list_edit.py --record <shoot-dir>`
+   to stamp the item's SKU into the draft and create its lifecycle ledger
+   record (status DRAFTED). Do this for EVERY draft.
 7. REVIEW (list mode) → write `review_card.md`, present the decision card,
    and STOP (HARD gate). Surface title + price + the ⚠ count.
 8. On explicit approval at the card → `python lib/list_edit.py --list

--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -271,19 +271,30 @@ python list_edit.py --delete-item   <sku>     --confirm   # DELETE the inventory
 
 ## Listings ledger
 
-Every listing the tooling creates is appended to a plain-text ledger,
-`listings_log.txt` (repo root; override with `EBAYBIZ_LISTINGS_LOG`). One
-line per event — when an offer is first created (`--sync`/`--list`) and when
-it goes live (`--publish`/`--list --confirm`):
+A CSV — `listings_ledger.csv` (repo root; override with
+`EBAYBIZ_LISTINGS_LEDGER`) — holds **one row per item, keyed by SKU**, that
+is created at draft time and **updated in place** through the item's
+lifecycle. Columns:
 
 ```
-<utc> | OFFER_CREATED | offer_id=… sku=… price=$… | <title>
-<utc> | PUBLISHED | listing_id=… offer_id=… sku=… price=$… | <title> | <url>
+sku, status, title, price, offer_id, listing_id, url,
+drafted_at, synced_at, published_at, ended_at, updated_at
 ```
 
-It's append-only (a running record of everything listed) and gitignored
-(account/inventory activity). Re-syncing an existing item does not add a
-duplicate line — only the first creation and each publish are recorded.
+Status flow (each step updates the same row, never duplicates it):
+
+| When | Command | status |
+|---|---|---|
+| Draft written | `--record <dir>` (no creds) | DRAFTED |
+| Offer created/updated | `--sync` / `--list` | SYNCED |
+| Goes live | `--publish` / `--list --confirm` | PUBLISHED |
+| Withdrawn | `--withdraw-offer` / `--end` | ENDED |
+| Deleted | `--delete-offer` / `--delete-item` | DELETED |
+
+Status only advances sensibly (a re-sync of a live item stays PUBLISHED;
+DRAFTED never overwrites a later state). The ledger is gitignored
+(account/inventory activity). The SKU itself is the deterministic hash from
+`_sku_for`, so the record can exist before the first eBay call.
 
 ## Notes / limits
 

--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -287,6 +287,12 @@ duplicate line — only the first creation and each publish are recorded.
 
 ## Notes / limits
 
+- **Custom label (SKU)** is an **8-hex-digit hash of the listing title +
+  shoot folder name** (e.g. `9c6e9361`). Unique per item (the folder is
+  unique even if two items share a title), deterministic per draft (same
+  draft → same SKU, so re-syncs are idempotent), ~4.3B space (negligible
+  collision risk). Once an item is synced, its SKU is stored in the draft
+  (`meta.ebay_inventory_sku`) and reused unchanged.
 - **Photos via EPS** use the Trading API `UploadSiteHostedPictures` (needs
   `dev_id`). This is why `dev_id` is required even though the rest is REST.
 - If you'd rather not use the Trading API, you can instead host the photos

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -53,6 +53,7 @@ policy IDs / locations to paste in.
 ----- CLI -----
 
     python list_edit.py --validate <shoot-dir|draft.md>   # no creds needed
+    python list_edit.py --record <shoot-dir|draft.md>     # DRAFT-time: stamp SKU + ledger record (DRAFTED), no creds
     python list_edit.py --preflight <shoot-dir|draft.md>  # check/auto-fix condition+shipping vs category
     python list_edit.py --setup-check                      # verify creds + policies
     python list_edit.py --sync <shoot-dir|draft.md>        # create/update eBay DRAFT (runs preflight)
@@ -187,41 +188,88 @@ def _to_decimal_str(val: object) -> Optional[str]:
     return f"{d:.2f}"
 
 
-def _listings_log_path() -> Path:
-    """Where the listings ledger lives: $EBAYBIZ_LISTINGS_LOG or <repo>/listings_log.txt."""
-    env = os.environ.get("EBAYBIZ_LISTINGS_LOG")
-    if env:
-        return Path(env)
-    return Path(__file__).resolve().parent.parent / "listings_log.txt"
+# --- Listings ledger: ONE row per item (keyed by SKU), updated through its
+#     lifecycle DRAFTED -> SYNCED -> PUBLISHED -> ENDED/DELETED. The SKU is a
+#     deterministic hash (see _sku_for), so the record can be created at DRAFT
+#     time and updated in place as the item is published/withdrawn/deleted.
+
+_LEDGER_FIELDS = ["sku", "status", "title", "price", "offer_id", "listing_id",
+                  "url", "drafted_at", "synced_at", "published_at", "ended_at",
+                  "updated_at"]
+_LEDGER_TS_FOR = {"DRAFTED": "drafted_at", "SYNCED": "synced_at",
+                  "PUBLISHED": "published_at", "ENDED": "ended_at"}
 
 
-def record_listing(event: str, *, title: str = "", sku: str = "",
-                   offer_id: str = "", listing_id: str = "",
-                   price: str = "", url: str = "") -> Optional[str]:
-    """Append one record to the listings ledger (unique IDs + title), one line
-    per created listing. Best-effort: never raises (logging must not break a
-    sync/publish). Returns the file path, or None if the write failed."""
-    try:
-        path = _listings_log_path()
-        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        ids = "  ".join(p for p in (
-            f"listing_id={listing_id}" if listing_id else "",
-            f"offer_id={offer_id}" if offer_id else "",
-            f"sku={sku}" if sku else "",
-            f"price=${price}" if price else "",
-        ) if p)
-        line = f"{ts} | {event} | {ids} | {title}"
-        if url:
-            line += f" | {url}"
-        fresh = not path.exists() or path.stat().st_size == 0
-        with path.open("a", encoding="utf-8") as f:
-            if fresh:
-                f.write("# eBay listings ledger — one line appended each time the "
-                        "tooling creates/publishes a listing\n")
-            f.write(line + "\n")
-        return str(path)
-    except OSError:
+def _ledger_path() -> Path:
+    """Ledger location: $EBAYBIZ_LISTINGS_LEDGER (or legacy $EBAYBIZ_LISTINGS_LOG),
+    else <repo>/listings_ledger.csv."""
+    env = os.environ.get("EBAYBIZ_LISTINGS_LEDGER") or os.environ.get("EBAYBIZ_LISTINGS_LOG")
+    return Path(env) if env else Path(__file__).resolve().parent.parent / "listings_ledger.csv"
+
+
+def upsert_listing(sku: str, status: str, *, title: str = "", price: str = "",
+                   offer_id: str = "", listing_id: str = "", url: str = "") -> Optional[str]:
+    """Create or update this item's row in the listings ledger (keyed by SKU).
+
+    Status only advances sensibly: a re-sync of an already-PUBLISHED item
+    keeps PUBLISHED; DRAFTED never overwrites a later status; ENDED/DELETED
+    are explicit and always apply. Only fields that are provided are written
+    (so a later update never blanks an earlier value). Best-effort — never
+    raises (ledger bookkeeping must not break a sync/publish)."""
+    if not sku:
         return None
+    import csv
+    try:
+        path = _ledger_path()
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        rows: list[dict] = []
+        if path.exists():
+            with path.open(newline="", encoding="utf-8") as f:
+                rows = list(csv.DictReader(f))
+        row = next((r for r in rows if r.get("sku") == sku), None)
+        if row is None:
+            row = {k: "" for k in _LEDGER_FIELDS}
+            row["sku"] = sku
+            rows.append(row)
+        for k, v in (("title", title), ("price", price), ("offer_id", offer_id),
+                     ("listing_id", listing_id), ("url", url)):
+            if v:
+                row[k] = str(v)
+        cur = row.get("status") or ""
+        if status == "DRAFTED":
+            row["status"] = cur or "DRAFTED"
+        elif status == "SYNCED":
+            row["status"] = "PUBLISHED" if cur == "PUBLISHED" else "SYNCED"
+        else:                       # PUBLISHED / ENDED / DELETED
+            row["status"] = status
+        tsfield = _LEDGER_TS_FOR.get(status)
+        if tsfield and not row.get(tsfield):
+            row[tsfield] = ts
+        row["updated_at"] = ts
+        with path.open("w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=_LEDGER_FIELDS, extrasaction="ignore")
+            w.writeheader()
+            for r in rows:
+                w.writerow({k: r.get(k, "") for k in _LEDGER_FIELDS})
+        return str(path)
+    except (OSError, csv.Error):
+        return None
+
+
+def record_draft(draft_path: Path) -> tuple[str, Optional[str]]:
+    """DRAFT-time, no credentials: compute the SKU (deterministic hash of
+    title+folder), stamp it into the draft's frontmatter, and create the
+    item's ledger record (status DRAFTED). Lets the record exist from the
+    moment a title is chosen; sync/publish later update the same row.
+    Returns (sku, ledger_path)."""
+    draft_path = _resolve_draft_path(draft_path)
+    draft = parse_draft(draft_path)
+    sku = _sku_for(draft)
+    if str(draft.get("meta.ebay_inventory_sku") or "") != sku:
+        update_meta(draft_path, {"ebay_inventory_sku": sku})
+    ledger = upsert_listing(sku, "DRAFTED", title=str(draft.get("title") or ""),
+                            price=_to_decimal_str(draft.get("price")) or "")
+    return sku, ledger
 
 
 def _ebay_extra(field: str) -> Optional[str]:
@@ -712,13 +760,11 @@ def create_or_update_listing(draft_path: Path,
         "last_synced": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     })
 
-    # 5) ledger: record newly-created listings (offers) — append, not on re-sync
-    if operation == "created":
-        rec = record_listing("OFFER_CREATED", title=str(draft.get("title") or ""),
-                              sku=sku, offer_id=offer_id,
-                              price=_to_decimal_str(draft.get("price")) or "")
-        if rec:
-            print(f"  [ledger] recorded -> {rec}")
+    # 5) ledger: upsert this item's lifecycle record (-> SYNCED; a re-sync of
+    #    an already-published item keeps PUBLISHED).
+    if upsert_listing(sku, "SYNCED", title=str(draft.get("title") or ""),
+                      offer_id=offer_id, price=_to_decimal_str(draft.get("price")) or ""):
+        print(f"  [ledger] {sku} -> SYNCED")
 
     hub = "https://www.ebay.com/sh/lst/drafts"
     return SyncResult(offer_id=offer_id, inventory_sku=sku, operation=operation,
@@ -801,7 +847,7 @@ def publish_offer(draft_path: Path, creds: Optional[EbayCredentials] = None,
             "ebay_listing_id": listing_id,
             "published_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         })
-        record_listing("PUBLISHED", title=title, sku=sku, offer_id=offer_id,
+        upsert_listing(sku, "PUBLISHED", title=title, offer_id=offer_id,
                        listing_id=listing_id, price=price,
                        url=f"https://www.ebay.com/itm/{listing_id}")
     return PublishResult(dry_run=False, offer_id=offer_id, title=title, price=price,
@@ -857,6 +903,8 @@ def end_listing(draft_path: Path, creds: Optional[EbayCredentials] = None,
         "ebay_listing_id": "",
         "ended_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     })
+    upsert_listing(str(draft.get("meta.ebay_inventory_sku") or ""), "ENDED",
+                   title=title, offer_id=offer_id)
     return EndResult(dry_run=False, offer_id=offer_id, title=title,
                      status_before=status, ended=True, listing_id=listing_id or None)
 
@@ -923,6 +971,7 @@ def withdraw_offer_by_id(offer_id: str, creds: Optional[EbayCredentials] = None,
     if not confirm:
         return OfferActionResult("withdraw", True, False, offer_id, status, listing_id=listing_id)
     withdraw_offer(offer_id, creds=creds)
+    upsert_listing(str(off.get("sku") or ""), "ENDED", offer_id=offer_id)
     return OfferActionResult("withdraw", False, True, offer_id, status,
                              detail="ended; offer is now UNPUBLISHED", listing_id=listing_id)
 
@@ -939,6 +988,7 @@ def delete_offer_by_id(offer_id: str, creds: Optional[EbayCredentials] = None,
         return OfferActionResult("delete-offer", True, False, offer_id, status,
                                  detail=f"sku={off.get('sku')} price={price}", listing_id=listing_id)
     delete_offer(offer_id, creds=creds)
+    upsert_listing(str(off.get("sku") or ""), "DELETED", offer_id=offer_id)
     return OfferActionResult("delete-offer", False, True, offer_id, status,
                              detail="offer deleted (inventory item/SKU kept)", listing_id=listing_id)
 
@@ -956,6 +1006,7 @@ def delete_item_by_sku(sku: str, creds: Optional[EbayCredentials] = None,
     if not confirm:
         return OfferActionResult("delete-item", True, False, sku, detail=detail)
     delete_inventory_item(sku, creds=creds)
+    upsert_listing(str(sku), "DELETED")
     return OfferActionResult("delete-item", False, True, sku,
                              detail=f"inventory item + {len(offers)} offer(s) deleted")
 
@@ -1031,6 +1082,7 @@ def _cli() -> None:
         description="ebaybiz — LIST/EDIT (Function 6): sync draft.md -> eBay DRAFT; publish only via --publish/--list --confirm (post review-gate).",
         formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
     ap.add_argument("--validate", metavar="TARGET", help="Validate a draft.md or shoot dir (no creds).")
+    ap.add_argument("--record", metavar="TARGET", help="DRAFT-time: stamp the SKU into the draft + create its ledger record (DRAFTED). No creds.")
     ap.add_argument("--preflight", metavar="TARGET", help="Check (and auto-correct) condition + shipping against the eBay category (needs creds).")
     ap.add_argument("--sync", metavar="TARGET", help="Create/update the eBay DRAFT (unpublished offer) from a draft.md or shoot dir.")
     ap.add_argument("--publish", metavar="TARGET", help="Publish a synced offer to a LIVE listing. DRY RUN unless --confirm is also given.")
@@ -1056,6 +1108,12 @@ def _cli() -> None:
                 for i in issues:
                     print(f"  - {i}")
                 sys.exit(1)
+            return
+        if args.record:
+            sku, ledger = record_draft(Path(args.record))
+            print(f"[OK] recorded DRAFTED — sku {sku}")
+            if ledger:
+                print(f"  ledger: {ledger}")
             return
         if args.setup_check:
             _print_setup_check()

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -66,6 +66,7 @@ policy IDs / locations to paste in.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 import sys
@@ -156,15 +157,24 @@ def _resolve_draft_path(target: str | Path) -> Path:
 
 
 def _sku_for(draft: Draft) -> str:
-    # Reuse an already-synced SKU for idempotency; otherwise derive from the
-    # shoot FOLDER name (unique per item), NOT meta.item_id — sibling drafts
-    # in a batch often share a generic item_id and would collide on one SKU.
+    """eBay custom label (SKU): an 8-hex-digit hash of the listing title +
+    shoot folder name.
+
+    - Unique per item: the folder name is unique per item, so two items that
+      happen to share a title still get different SKUs.
+    - Deterministic per draft: the same draft always hashes to the same SKU,
+      so re-syncs stay idempotent.
+    - 8 hex digits (32 bits, ~4.3B space) → negligible collision risk at the
+      volumes this business lists.
+    """
+    # Reuse an already-synced SKU so existing listings keep their label.
     existing = draft.get("meta.ebay_inventory_sku")
     if existing:
         return str(existing)
-    basis = draft.path.parent.name or str(draft.get("meta.item_id") or "item")
-    sku = re.sub(r"[^A-Za-z0-9_-]+", "-", f"ebaybiz-{basis}").strip("-")
-    return sku[:50] or "ebaybiz-item"
+    title = re.sub(r"\s+", " ", str(draft.get("title") or "")).strip().lower()
+    folder = draft.path.parent.name or str(draft.get("meta.item_id") or "item")
+    basis = f"{title}\n{folder}".encode("utf-8")
+    return hashlib.sha1(basis).hexdigest()[:8]
 
 
 def _to_decimal_str(val: object) -> Optional[str]:

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -148,6 +148,21 @@ condition grade + tie-break; weight/dims rounding; price tier + source;
 photo order; any rephrase (field, orig→final length); any lookup
 substitution. These stay local — never pushed to eBay.
 
+## Register the item (SKU + ledger record)
+
+After writing `draft.md`, register the item so it has a stable identity and
+a lifecycle record from draft time onward:
+
+    python lib/list_edit.py --record <shoot-dir>
+
+This computes the item's **SKU** (a deterministic 8-hex hash of title +
+folder — no eBay call, no credentials), stamps it into the draft's
+`meta.ebay_inventory_sku`, and creates the item's row in the listings
+ledger with status **DRAFTED**. The same row is later updated in place to
+SYNCED → PUBLISHED → ENDED/DELETED. (If you can't run a shell here, it's
+not fatal — `--sync` creates the record later; registering now just means
+the SKU/record exist from draft time.)
+
 ## Closing
 
 Per _shared: path + chosen title with `[N/80]` + working price. List


### PR DESCRIPTION
Reworks the eBay **custom label (SKU)** into a stable, unique, deterministic identifier, and uses it as the key for a **per-item lifecycle record** that's created at draft time and updated in place as the item moves through its life.

## 1. SKU = 8-hex hash of title + folder
Replaces the readable `ebaybiz-<folder>` custom label with an **8-hex-digit hash of the listing title + shoot folder name** (e.g. `2b73702c`).

- **Unique per item** — the folder is unique even if two items share a title (so identical titles don't collide).
- **Deterministic** — same draft → same SKU, so re-syncs stay idempotent; and because it's not timestamp-based it can be generated *before* any eBay call.
- **~4.3B space (32-bit)** → negligible collision risk at these volumes (~0.01% at 1,000 listings).
- **Non-disruptive** — already-synced items keep their stored `meta.ebay_inventory_sku` (the live `sand-dollars` listing is unaffected).

## 2. Listings ledger = one lifecycle record per item (keyed by SKU)
Replaces the previous append-only event log with a single **upsert-by-SKU** record in `listings_ledger.csv` (gitignored; override with `EBAYBIZ_LISTINGS_LEDGER`). One row per item, **updated in place** through its lifecycle — never duplicated.

Columns:
```
sku, status, title, price, offer_id, listing_id, url,
drafted_at, synced_at, published_at, ended_at, updated_at
```

Status flow (each step updates the same row):

| When | Command | status |
|---|---|---|
| Draft written | `--record <dir>` (no creds) | DRAFTED |
| Offer created/updated | `--sync` / `--list` | SYNCED |
| Goes live | `--publish` / `--list --confirm` | PUBLISHED |
| Withdrawn | `--withdraw-offer` / `--end` | ENDED |
| Deleted | `--delete-offer` / `--delete-item` | DELETED |

Status only advances sensibly: a re-sync of a live item stays PUBLISHED; DRAFTED never overwrites a later state; ENDED/DELETED are explicit and always apply. Updates only touch provided fields (a later event never blanks an earlier value).

## 3. DRAFT-time registration
New `python lib/list_edit.py --record <dir>` (no credentials) computes the SKU, stamps it into the draft's `meta.ebay_inventory_sku`, and writes the DRAFTED row — so the record exists the moment a title is chosen. Wired into the standard flow:
- `prompts/draft.md` runs `--record` after writing `draft.md`.
- `RUN.md` run-sequence step 6 + phase table include it ("for EVERY draft").
- Safety net: if `--record` is skipped, `--sync` upserts the same row anyway.

## Files
- `lib/list_edit.py`: `_sku_for` (hash), `upsert_listing`, `record_draft`, lifecycle hooks in sync/publish/withdraw/delete, `--record` CLI.
- `prompts/draft.md`, `RUN.md`: DRAFT-time `--record` step.
- `lib/SETUP_EBAY_API.md`: SKU + ledger docs (status table).
- `.gitignore`: `listings_ledger.csv`.

## Testing
Verified offline: deterministic/unique SKU (same title, different folder → different SKU; already-synced items reuse their label); full DRAFTED→SYNCED→PUBLISHED→ENDED stays one row with correct status/timestamps and a re-sync of a live item staying PUBLISHED. Verified live (no eBay write): `--record to-id/m-agni` stamped SKU `2b73702c` and created the DRAFTED row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)