### PR TITLE
Streamline review/record: one --review command + auto-record

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ hard it looked.
       lib/                        eBay Sell API code (sync/publish/end) + SETUP_EBAY_API.md
       deprecated/                 frozen v1 prompts + v2 reference (context only)
 
-**Function 5.5 — REVIEW.** The publish gate. After DRAFT, it renders a
-succinct decision card (title, price + supporting comp links, condition,
-anything needing manual review) to chat and `review_card.md`, then STOPS.
-Only an explicit human approval at the card publishes the listing LIVE.
-This replaced the old absolute no-publish firewall: publishing is now
-*gated*, not forbidden — but never automatic, never inferred.
+**Function 5.5 — REVIEW.** The publish gate. One command —
+`python lib/list_edit.py --review <shoot-dir>` — records the item, runs
+preflight (condition/shipping/insurance), and renders a succinct decision
+card (title, price + supporting comp links, condition, anything needing
+manual review) to `review_card.md` + chat, then STOPS. Only an explicit
+human approval at the card publishes the listing LIVE. This replaced the old
+absolute no-publish firewall: publishing is now *gated*, not forbidden —
+but never automatic, never inferred.
 
 **Function 6 — LIST/EDIT.** Pushes an approved `draft.md` to eBay. The
 agent reaches it only through a human-approved REVIEW card; the pipeline

--- a/RUN.md
+++ b/RUN.md
@@ -101,7 +101,7 @@ Load each prompt when you reach its phase.
 | CURATE | [prompts/curate.md](prompts/curate.md) | `identify.txt`+`price.txt`+profile | `review.md` |
 | INVESTIGATE | [prompts/investigate.md](prompts/investigate.md) | photos (+`identify.txt`) | `investigate.txt` |
 | DRAFT | [prompts/draft.md](prompts/draft.md) | `identify.txt`+`investigate.txt`+`price.txt`+template | `draft.md` + `--record` → SKU stamped + ledger row (DRAFTED) |
-| REVIEW | [prompts/review.md](prompts/review.md) | `draft.md`+`price.txt`+`NEEDS_REVIEW.md` | `review_card.md` → (on approval) LIVE listing |
+| REVIEW | [prompts/review.md](prompts/review.md) | `draft.md`+`price.txt`+`NEEDS_REVIEW.md` | `--review` → `review_card.md` (records+preflights) → (on approval) LIVE listing |
 
 **The publish step (reached via the REVIEW gate, on explicit approval):**
 
@@ -175,10 +175,11 @@ is unchanged and shared from `lib/` — v3 does not duplicate code.
 6. DRAFT (list mode) → render template, run the pre-write validation
    pass, write `draft.md`, then `python lib/list_edit.py --record <shoot-dir>`
    to stamp the item's SKU into the draft and create its lifecycle ledger
-   record (status DRAFTED). Do this for EVERY draft.
-7. REVIEW (list mode) → write `review_card.md`, present the decision card,
-   and STOP (HARD gate). Surface title + price + the ⚠ count.
+   record (status DRAFTED). Do this for EVERY draft, and again after any edit.
+7. REVIEW (list mode) → `python lib/list_edit.py --review <shoot-dir>` — one
+   command that records (if needed) + preflights + builds `review_card.md`.
+   Present that card and STOP (HARD gate). Surface title + price + the ⚠ count.
 8. On explicit approval at the card → `python lib/list_edit.py --list
    <shoot-dir> --confirm` (sync + publish LIVE); report the listing URL.
    On a change request → re-run the owning phase, re-render `draft.md`,
-   re-present the card. Anything other than explicit approval = no publish.
+   re-run `--review`. Anything other than explicit approval = no publish.

--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -250,6 +250,12 @@ categories that only allow New/Used), and (b) **flags items priced > $100**
 to add insurance at label time (only $100 is auto-included; the eBay API
 can't set insurance — see ShipCover in Seller Hub).
 
+**One-step review prep:** `python list_edit.py --review <shoot-dir>` does the
+whole pre-publish gate in one command — records the item (SKU + DRAFTED
+ledger row), runs the preflight above, and assembles the decision card
+(`review_card.md`) from the draft + comps + ledger + preflight. It STOPS for
+approval and never publishes; on approval you run `--list … --confirm`.
+
 ## Managing listings (query / withdraw / delete)
 
 Account-level operations that work on ANY offer or SKU — not just items with

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -55,6 +55,7 @@ policy IDs / locations to paste in.
     python list_edit.py --validate <shoot-dir|draft.md>   # no creds needed
     python list_edit.py --record <shoot-dir|draft.md>     # DRAFT-time: stamp SKU + ledger record (DRAFTED), no creds
     python list_edit.py --preflight <shoot-dir|draft.md>  # check/auto-fix condition+shipping vs category
+    python list_edit.py --review <shoot-dir|draft.md>     # record + preflight + build the REVIEW card (stops; no publish)
     python list_edit.py --setup-check                      # verify creds + policies
     python list_edit.py --sync <shoot-dir|draft.md>        # create/update eBay DRAFT (runs preflight)
     python list_edit.py --list <shoot-dir|draft.md> --confirm  # sync + publish (post review-gate)
@@ -686,6 +687,97 @@ def preflight_listing(draft_path: Path, creds: Optional[EbayCredentials] = None,
 
 
 # ---------------------------------------------------------------------------
+# REVIEW — one step: record + preflight + assemble the decision card
+# ---------------------------------------------------------------------------
+
+def build_review_card(draft_path: Path,
+                      creds: Optional[EbayCredentials] = None) -> tuple[str, str]:
+    """Prepare an item for the REVIEW gate in ONE step and return
+    (card_text, card_path). Does NOT publish.
+
+    It (1) ensures the item is recorded (SKU + DRAFTED ledger row),
+    (2) runs preflight (condition remap + shipping policy + insurance flag),
+    and (3) assembles the decision card deterministically from the draft,
+    comps, ledger, and preflight — written to <shoot>/review_card.md.
+    """
+    import csv
+    creds = creds or load_credentials()
+    draft_path = _resolve_draft_path(draft_path)
+    shoot = draft_path.parent
+
+    sku, _ = record_draft(draft_path)                  # ensure SKU + DRAFTED
+    pf = preflight_listing(draft_path, creds=creds)    # remap + shipping + insurance
+    draft = parse_draft(draft_path)                    # re-read (condition may have changed)
+
+    title = str(draft.get("title") or "")
+    price = str(draft.get("price") or "")
+    cond = str(draft.get("condition") or "")
+    cond_desc = str(draft.get("condition_description") or "").strip() or "(none)"
+    qty = draft.get("quantity") or 1
+    photos = draft.frontmatter.get("photos") or []
+    hero = photos[0] if photos else "—"
+    if draft.get("best_offer.enabled"):
+        _decl = draft.get("best_offer.auto_decline_amount")
+        bo = f"on @ auto-decline ${_decl}" if _decl else "on"
+    else:
+        bo = "off"
+
+    # Comps to verify: prefer structured comps.csv, else URL lines from price.txt.
+    comps: list[str] = []
+    cpath = shoot / "comps.csv"
+    if cpath.exists():
+        for r in list(csv.DictReader(cpath.open(encoding="utf-8")))[:8]:
+            if r.get("url"):
+                comps.append(f"  • ${r.get('price','')} — {(r.get('title') or '')[:55]} — {r['url']}")
+    if not comps and (shoot / "price.txt").exists():
+        for ln in (shoot / "price.txt").read_text(encoding="utf-8").splitlines():
+            if "http" in ln:
+                comps.append("  • " + ln.strip())
+            if len(comps) >= 8:
+                break
+    if not comps:
+        comps = ["  • (no comp URLs found — see price.txt)"]
+
+    # Flags worth a human eye.
+    flags: list[str] = []
+    nr = shoot / "NEEDS_REVIEW.md"
+    if nr.exists():
+        flags = ["  • " + ln.strip() for ln in nr.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    if not flags:
+        flags = ["  • None"]
+
+    # Ledger status for this SKU.
+    status = "?"
+    lp = _ledger_path()
+    if lp.exists():
+        for r in csv.DictReader(lp.open(encoding="utf-8")):
+            if r.get("sku") == sku:
+                status = r.get("status") or "?"
+                break
+
+    card = "\n".join([
+        f"━━ REVIEW: {shoot.name}  (sku {sku} · ledger {status}) ━━",
+        f'Title:     "{title}"  [{len(title)}/80]',
+        f"Price:     ${price}  ·  Best Offer: {bo}",
+        f"Condition: {cond}",
+        f"Quantity:  {qty}   ·   Photos: {len(photos)} (hero: {hero})",
+        "Preflight (condition / shipping / insurance):",
+        *[f"  • {m}" for m in pf],
+        "Comps (open to verify):",
+        *comps,
+        "Condition detail:",
+        f"  {cond_desc}",
+        "⚠ Needs review / manual intervention:",
+        *flags,
+        "",
+        f"→ Approve publishes this LIVE at ${price}. On approval, run:",
+        f"    python lib/list_edit.py --list {shoot} --confirm",
+    ])
+    (shoot / "review_card.md").write_text(card + "\n", encoding="utf-8")
+    return card, str(shoot / "review_card.md")
+
+
+# ---------------------------------------------------------------------------
 # Main sync
 # ---------------------------------------------------------------------------
 
@@ -1084,6 +1176,7 @@ def _cli() -> None:
     ap.add_argument("--validate", metavar="TARGET", help="Validate a draft.md or shoot dir (no creds).")
     ap.add_argument("--record", metavar="TARGET", help="DRAFT-time: stamp the SKU into the draft + create its ledger record (DRAFTED). No creds.")
     ap.add_argument("--preflight", metavar="TARGET", help="Check (and auto-correct) condition + shipping against the eBay category (needs creds).")
+    ap.add_argument("--review", metavar="TARGET", help="One step: record + preflight + build the REVIEW decision card. Stops for approval; does NOT publish.")
     ap.add_argument("--sync", metavar="TARGET", help="Create/update the eBay DRAFT (unpublished offer) from a draft.md or shoot dir.")
     ap.add_argument("--publish", metavar="TARGET", help="Publish a synced offer to a LIVE listing. DRY RUN unless --confirm is also given.")
     ap.add_argument("--list", metavar="TARGET", dest="list_target", help="Sync THEN publish in one step (post review-gate). DRY RUN unless --confirm is also given.")
@@ -1122,6 +1215,11 @@ def _cli() -> None:
             print(f"Preflight {args.preflight}:")
             for m in preflight_listing(Path(args.preflight)):
                 print(f"  {m}")
+            return
+        if args.review:
+            card, path = build_review_card(Path(args.review))
+            print(card)
+            print(f"\n[review_card] {path}")
             return
         if args.sync:
             res = create_or_update_listing(Path(args.sync))

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -150,18 +150,23 @@ substitution. These stay local — never pushed to eBay.
 
 ## Register the item (SKU + ledger record)
 
-After writing `draft.md`, register the item so it has a stable identity and
-a lifecycle record from draft time onward:
+**Whenever you finish writing `draft.md` — and again after any later edit to
+it — register the item:**
 
     python lib/list_edit.py --record <shoot-dir>
 
 This computes the item's **SKU** (a deterministic 8-hex hash of title +
 folder — no eBay call, no credentials), stamps it into the draft's
-`meta.ebay_inventory_sku`, and creates the item's row in the listings
-ledger with status **DRAFTED**. The same row is later updated in place to
-SYNCED → PUBLISHED → ENDED/DELETED. (If you can't run a shell here, it's
-not fatal — `--sync` creates the record later; registering now just means
-the SKU/record exist from draft time.)
+`meta.ebay_inventory_sku`, and creates/refreshes the item's row in the
+listings ledger with status **DRAFTED**. It's idempotent — once the SKU is
+stamped it's reused, so an edit just refreshes the row's title/price and
+never duplicates it. The same row is later updated in place to
+SYNCED → PUBLISHED → ENDED/DELETED.
+
+This guarantees the record exists from draft time, **before REVIEW**.
+Belt-and-suspenders: `--review` (and `--sync`) also call `--record`
+internally, so a missed run is recovered; if you can't run a shell here, the
+record is created at the next step that can.
 
 ## Closing
 

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -9,53 +9,43 @@ publishes the listing LIVE. This is the gate that replaced the old
 "never publish" firewall: publishing is no longer refused, it is
 *gated here*.
 
-**Reads:** `draft.md` (authoritative for the listing) · `price.txt`
-(comp URLs + tiers) · `NEEDS_REVIEW.md` (deferred decisions for this item).
-**Writes:** `<shoot-dir>/review_card.md` (the card, for the record) and
-the same card to chat.
+**Produces:** `<shoot-dir>/review_card.md` + the same card to chat. Does
+NOT publish.
 
-## The card (succinct — fits on a screen)
+## One command builds the card
 
-Lead with the headline line, then the sections. No preamble. Pull every
-value from the files above; never re-derive or invent.
+REVIEW is a single step:
 
-    ━━ REVIEW: <item_id> ━━
-    Title:     "<title>"  [N/80]
-    Price:     $<price> (<tier> tier)  ·  Best Offer: <on @ auto-decline $X | off>
-    Condition: <grade> — <one-line summary>
-    Quantity:  <n> (<unit_type>)   ·   Photos: <n> (hero: <file>)
-    Shipping:  <chosen policy/service, e.g. "Media Mail (free)" or "USPS Ground (free)"; from preflight>
-    Insurance: <"$100 included" — OR, if price > $100: "⚠ add ShipCover at label time; only $100 included">
+    python lib/list_edit.py --review <shoot-dir>
 
-    Comps (supporting the price):
-      • $<price> — "<title>"  ·  <A/B/C>  ·  <url>
-      • $<price> — "<title>"  ·  <A/B/C>  ·  <url>
-      • (list the comps price.txt cited for the chosen tier; each with its URL)
+This does the whole pre-review prep in one shot:
+1. **Records** the item if not already — mints the SKU + writes/refreshes
+   the `DRAFTED` ledger row (so a finished draft is always registered before
+   review).
+2. **Preflight** — auto-remaps the condition to one the category accepts,
+   picks the shipping policy (Media Mail vs ground), and flags insurance on
+   items > $100.
+3. **Assembles the card** from the draft, comps, ledger, and preflight, and
+   writes `review_card.md`.
 
-    Condition detail:
-      • <every defect the draft's Condition section flagged — verbatim, no minimizing>
+Present that card to the user **verbatim** and STOP. It contains:
 
-    ⚠ Needs review / manual intervention:
-      • <each NEEDS_REVIEW.md line for this item>
-      • <each DRAFT meta.notes gap, substitution, or rephrase worth a human eye>
-      • (write "None" if genuinely clean)
+    ━━ REVIEW: <item> (sku … · ledger …) ━━
+    Title [N/80] · Price · Best Offer · Condition · Quantity · Photos
+    Preflight (condition · shipping · insurance)
+    Comps (open to verify) — each with a URL
+    Condition detail (every flagged defect, verbatim — never softened)
+    ⚠ Needs review / manual intervention (NEEDS_REVIEW.md lines)
+    → Approve publishes LIVE at $<price>, with the exact --list … --confirm command
 
-    → Approve publishes this LIVE on eBay at $<price>. Reply "approve" to
-      publish, or tell me what to change.
+Don't hand-edit or re-derive the card — the command is the single source, so
+cards stay consistent. **Fallback** (no shell/creds, e.g. a Cowork tab):
+run `--record` first, then assemble the same fields by hand from `draft.md`
++ `price.txt` + `NEEDS_REVIEW.md`.
 
-### Rules for filling it
-- **Comps:** take the URLs `price.txt` listed for the working/Recommended
-  tier. A price with no supporting comp URL is itself a ⚠ line, not a
-  silent omission.
-- **Condition:** copy the draft's flagged defects exactly. The whole point
-  of the gate is that the human sees them before money is on the line —
-  never soften or drop one.
-- **Needs review:** merge `NEEDS_REVIEW.md` entries for this item with any
-  DRAFT-flagged gap/substitution/rephrase. If a *required* field is empty
-  or a price has no comp, say so plainly and recommend resolving it before
-  approval — but the human decides.
-- **One item at a time.** In a multi-item shoot, present one card, take its
-  decision, then the next. Only batch-publish if the user says "approve all".
+**One item at a time.** In a multi-item shoot, run `--review` per item,
+present its card, take the decision, then the next. Only batch-publish if
+the user says "approve all".
 
 ## The gate (HARD — this is where the run stops)
 
@@ -69,8 +59,10 @@ Publish ONLY on an explicit, unambiguous approval ("approve", "publish it",
 in one line: *"Publishing <item_id> LIVE at $<price> now."*
 
 If the user asks for a change, treat it as feedback: the relevant prior
-phase (INVESTIGATE/DRAFT/PRICE) re-runs, DRAFT re-renders `draft.md`, and
-REVIEW presents a fresh card. Never edit `draft.md` by hand here.
+phase (INVESTIGATE/DRAFT/PRICE) re-runs and re-renders `draft.md`; then
+re-run `--review` to present a fresh card. (Editing `draft.md` is fine — the
+record refreshes automatically on the next `--review`/`--record`, keeping
+the same SKU.)
 
 ## On approval — publish (one step)
 


### PR DESCRIPTION
Collapses the review/record stage into a single command and makes the record happen automatically around drafting.

## New: `python lib/list_edit.py --review <shoot-dir>`
One step that does the whole pre-review prep (and **never publishes**):
1. **Records** the item — mints the SKU + writes/refreshes the `DRAFTED` ledger row.
2. **Preflight** — auto-remaps the condition to one the category accepts, picks the shipping policy (Media Mail vs ground), flags insurance on items > $100.
3. **Assembles the decision card** deterministically from the draft + comps + ledger + preflight, writes `review_card.md`, and prints it.

Replaces the old flow (manual `--record`, then the agent hand-building the card from 3 files) — fewer steps, consistent cards. `build_review_card()` is the single source.

## Auto-record wiring
- **`prompts/draft.md`**: record on draft **completion and after any edit** (idempotent — the SKU is reused once stamped, so an edit just refreshes the row; never duplicates).
- **`prompts/review.md`**: REVIEW is now "run `--review`, present the card, STOP." Dropped the hand-assembled card spec; kept the gate discipline (explicit approval, one-at-a-time), on-approval `--list --confirm`, and after-publish management.
- **`RUN.md`**: run-sequence step 6 (record every draft + on edit) and step 7 (REVIEW via `--review`); phase table updated.

Net: a finished or edited draft is always recorded before REVIEW, and REVIEW prep is a single command. Belt-and-suspenders: `--review` and `--sync` also call `--record` internally, so a missed run is recovered.

## Testing
`--review` verified end-to-end on a real item (records + remaps condition + selects shipping + flags >$100 insurance + builds the card with comp URLs). Fixed a Best-Offer display nit (`on` vs `on @ auto-decline $None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)