### PR TITLE
feat: PRICE strategy v2 (distribution-based) + legacy-SKU self-heal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ listings_ledger.csv
 # Sensitive business documents + correspondence — kept locally, not tracked
 *.docx
 letters/
+
+# Entity formation docs — contain PII (legal name, home address). Local only.
+/formation/

--- a/docs/price-strategy-v2.md
+++ b/docs/price-strategy-v2.md
@@ -1,8 +1,27 @@
-# PRICE strategy v2 — distribution-based (PROPOSAL, not yet implemented)
+# PRICE strategy v2 — distribution-based (IMPLEMENTED)
 
-A proposal to re-examine PRICE now that Stage B (Apify) can cheaply return
-two complementary views of the sold market. **Nothing here is wired in yet
-— this is for review.**
+Re-examines PRICE now that Stage B (Apify) can cheaply return two
+complementary views of the sold market. **Implemented:** the deterministic
+half (filtering + statistics + tier placement) lives in
+[`lib/price_stats.py`](../lib/price_stats.py); the orchestration (dual query,
+query ladder, ceiling vetting, exact-match short-circuit, reporting) is wired
+into [`prompts/price.md`](../prompts/price.md). This document is the rationale
+and the record of the policy choices below.
+
+**Policy defaults chosen** (the "Open decisions" at the bottom — all
+configurable as constants at the top of `price_stats.py`):
+1. Conservative = 25th pct · Recommended = median · Push-high = vetted
+   `price_high` ceiling, else 90th pct.
+2. Outlier cutoff: a `price_high` survivor above **2.5× median** is surfaced
+   as a *ceiling candidate to vet* (not auto-dropped) — the prompt confirms
+   comparability, else falls back to the 90th pct.
+3. Thin-market threshold: **n < 3** like-condition comps → closest-comp
+   fallback. Broaden the query ladder while surviving comps < 3.
+4. Condition: price within the like-condition cohort; **pool Used grades
+   (with unknown) only when the strict cohort is thin**.
+5. Recommended basis: median of **comparable (same-condition)** sold.
+6. Exact-match short-circuit: **kept** — a true exact comp anchors
+   Recommended on the median of exact matches.
 
 ## Why change
 
@@ -137,10 +156,51 @@ ladder steps.
   unconfirmed. "Fewer-words" padding on niche queries is verified real.
 - Thin markets are common in this inventory — the fallback matters.
 
-## Open decisions (need your call)
-1. **Percentiles:** Conservative=25th / Recommended=median / Push-high=vetted-ceiling-or-90th — OK, or different (e.g. Recommended = 40th to lean conservative)?
-2. **Outlier cutoff:** exclude `price_high` items >2× median that aren't clearly comparable — too strict / too loose?
-3. **Thin-market threshold:** n<3 → fallback. Right number?
-4. **Condition:** price strictly within the same condition cohort, or pool Used grades together when samples are thin?
-5. **Recommended basis:** median of *comparable* (same condition) vs median of *all* sold for the query?
-6. **Keep the exact-match short-circuit** (anchor on an exact comp when one exists), or always blend with the distribution?
+## Lessons from live runs
+
+**Size (and other un-tokenizable grade axes) is not a filterable token —
+the broad median can under-price.** First live end-to-end run (2026-06-10,
+`to-id/sand-dollars`, lot of 18 ~3in white keyhole sand dollars): the engine
+cleanly filtered unit/condition and reported a used-cohort **median of $18**
+— but that pools *every* sand-dollar lot regardless of piece SIZE, and size
+is the dominant price driver here (tiny 1.5–2in lots sell $10–15; ~3in lots
+sell $24.99–30). The token filter can't separate them because eBay titles
+express size inconsistently ("2-3in", "3 inch", "2.5-3.5\"", or not at all),
+so a size term in the query/`require_tokens` is unreliable. The
+**exact-match short-circuit** is what corrected it: two genuine size+grade
+matches (13 @ 2.5-3in $24.99; 20 @ 2-3in $30) anchored Recommended at **$28**,
+well above the pooled median. (Filter note observed the same run:
+`looks_multi_item` misses a *bare leading count* — "25 White Keyhole…" reads
+as single-item — directionally harmless here but a known gap.)
+
+**How to apply now:** for any size- or grade-driven category, don't take the
+engine's broad median at face value — anchor on the size/grade sub-cohort via
+the exact-match short-circuit, and say in `price.txt` that the broad median is
+a mix artifact (as the sand-dollars run did).
+
+**↻ Revisit in the future:** the engine could make this less manual — e.g. a
+size-bucket extractor that parses inch/cm ranges from comp titles and prices
+within the item's size band (treating size like a condition cohort), and/or
+fixing `looks_multi_item` to catch a bare leading count. Worth doing once more
+live runs show how often the size-mix artifact actually bites; until then the
+short-circuit + an honest note is the documented workaround.
+
+## Open decisions — RESOLVED (defaults shipped; tune in `price_stats.py`)
+
+The proposal shipped with the defaults below. Each is a named constant at the
+top of [`lib/price_stats.py`](../lib/price_stats.py) — change it there in one
+place, no prompt edit needed. Revisit any of these if real runs argue for it.
+
+1. **Percentiles** — `CONSERVATIVE_PCT=25` / `RECOMMENDED_PCT=50` (median) /
+   Push-high = vetted ceiling, else `PUSH_HIGH_FALLBACK_PCT=90`. (Open knob
+   if Recommended should lean conservative: set `RECOMMENDED_PCT=40`.)
+2. **Outlier cutoff** — `OUTLIER_MULT=2.5`. A `price_high` survivor above
+   2.5× median is surfaced as a ceiling candidate **to vet**, not auto-
+   dropped (the module can't judge comparability; the prompt does).
+3. **Thin-market threshold** — `THIN_N=3`. Below it: closest-comp fallback;
+   broaden the query ladder while surviving comps < 3.
+4. **Condition** — like-condition cohort; pool Used grades (+ unknown) only
+   when the strict cohort is thin (`pool_used_when_thin`, on by default).
+5. **Recommended basis** — median of *comparable* (same-condition) sold.
+6. **Exact-match short-circuit** — kept; anchors Recommended on the median of
+   exact matches when the hunt finds one.

--- a/docs/price-strategy-v2.md
+++ b/docs/price-strategy-v2.md
@@ -1,0 +1,103 @@
+# PRICE strategy v2 — distribution-based (PROPOSAL, not yet implemented)
+
+A proposal to re-examine PRICE now that Stage B (Apify) can cheaply return
+two complementary views of the sold market. **Nothing here is wired in yet
+— this is for review.**
+
+## Why change
+
+Today PRICE hand-picks a few comps from a single capped Apify pull and
+reasons to three tiers. Two problems:
+
+1. The pull defaulted to `price_high`, so the comp set leaned toward the
+   ceiling (or, for niche queries, came back jumbled) — not a representative
+   sample. The Recommended/working price can skew high.
+2. "Pick the strongest comp" is subjective and cherry-picks.
+
+We verified empirically (see the Apify investigation) that:
+- **`best_match`** returns the representative body of the distribution.
+- **`price_high`** genuinely returns the price+shipping high end, *sorted
+  descending* (so the cap can't hide the expensive outliers) — modulo a
+  row-0 anomaly and "results matching fewer words" padding on niche queries.
+
+So we can now price on the **actual distribution** instead of a few comps.
+
+## The core shift
+
+From *"pick the strongest comps"* → *"characterize the sold distribution,
+then place tiers on it."*
+
+## Proposed pipeline (PRICE Stage B)
+
+1. **Dual query** per selling unit (single/pair/set/lot per `unit_type`):
+   - `best_match` — representative set (≈30 results, 2 pages).
+   - `price_high` — ceiling/outlier set (≈20 results).
+   - (Stage A WebSearch and Stage C Chrome keep their current roles: A broad
+     context; C low-confidence fallback.)
+
+2. **Normalize before any stats:**
+   - Currency validation (existing charm-price guard).
+   - **Strip noise:** drop the row-0 anomaly and "fewer-words" loose matches
+     (title missing the key query tokens).
+   - **Condition cohort:** bucket by condition; price the item against its
+     like-condition cohort (New vs Used grades).
+   - **Unit match:** compare only same `unit_type`; `duplicate` → per-piece.
+   - **Exclusions (Tier C reasons, unchanged in spirit):** single-bid
+     auctions, <50-feedback sellers, active/asking prices.
+
+3. **Distribution stats** from the cleaned representative (`best_match`) set:
+   - `n`, median, 25th/75th percentile (IQR), min/max.
+   - Dispersion = IQR/median (or max/min) → confidence + rarity signal.
+
+4. **Vet the `price_high` extremes** against the representative median:
+   - A high item that is genuinely the same item/condition → a real **ceiling
+     comp**.
+   - A high item that's a bundle/mislisting/different model (e.g. >2–3×
+     median and not comparable) → **excluded outlier** (logged, not silently
+     dropped).
+
+5. **Place the three tiers:**
+   - **Exact-match short-circuit (unchanged):** if ≥1 true exact-match comp
+     exists, anchor **Recommended** on it (median of exact matches); keep the
+     distribution for context.
+   - **Else distribution-based:**
+     - **Conservative** = ~25th percentile of like-condition sold (no-objection floor).
+     - **Recommended** (working price) = **median** of like-condition comparable sold.
+     - **Push-high** = the vetted ceiling from `price_high` (a real comparable
+       top sale); if none vets out, fall back to the representative ~90th pct.
+   - Best Offer gate unchanged: enable if list > Recommended; auto-decline = Recommended.
+
+6. **Confidence / data quality:**
+   - `good`: n ≥ ~8 like-condition comps, tight IQR.
+   - `partial`: n 3–7, or wide dispersion.
+   - `thin`: n < 3 → **fall back to today's method** (anchor on closest comp /
+     era-peer, widen the bracket, flag rarity). Don't compute percentiles off
+     2 points.
+
+7. **Report (price.txt):**
+   - Distribution line: `n=… median=$… IQR=$…–$… ceiling=$…`.
+   - Both run ids (best_match + price_high) as proof.
+   - Comp URLs: the representative anchors + the vetted ceiling comps.
+   - Three tiers, each labeled with its basis (percentile / median / vetted ceiling).
+   - Outliers excluded + reason.
+   - Confidence.
+
+## What this fixes
+- **Bias:** Recommended is the typical sold price (median), not the ceiling.
+- **Outliers:** seen and judged explicitly, not hidden by a cap or dropped by a blunt rule.
+- **Defensibility:** tiers trace to a distribution + sample size, not a vibe.
+- **Confidence/rarity:** measured (n + dispersion + best_match/price_high overlap).
+
+## Costs / caveats
+- **2 Apify calls/item (~$0.20)** instead of 1 (already accepted).
+- Must normalize condition + unit before stats, or the median lies.
+- Must strip the row-0 anomaly + "fewer-words" padding (verified real).
+- Thin markets are common in this inventory — the fallback matters.
+
+## Open decisions (need your call)
+1. **Percentiles:** Conservative=25th / Recommended=median / Push-high=vetted-ceiling-or-90th — OK, or different (e.g. Recommended = 40th to lean conservative)?
+2. **Outlier cutoff:** exclude `price_high` items >2× median that aren't clearly comparable — too strict / too loose?
+3. **Thin-market threshold:** n<3 → fallback. Right number?
+4. **Condition:** price strictly within the same condition cohort, or pool Used grades together when samples are thin?
+5. **Recommended basis:** median of *comparable* (same condition) vs median of *all* sold for the query?
+6. **Keep the exact-match short-circuit** (anchor on an exact comp when one exists), or always blend with the distribution?

--- a/docs/price-strategy-v2.md
+++ b/docs/price-strategy-v2.md
@@ -43,15 +43,27 @@ then place tiers on it."*
      order; cause unconfirmed, so KEEP it and surface a note each run for the
      human to judge. (Separately, "fewer-words" loose matches — title missing
      the key query tokens — can be down-weighted.)
+   - **Unit match (biggest lever):** when pricing a single, EXCLUDE multi-item
+     listings — title contains `lot`/`lots`/`set`/`bundle`/`complete`/
+     `collection`, multiple distinct years, or `N issues/pcs/pieces`. (Demo:
+     m-agni raw $10–$506 → after excluding lots $10–$144, IQR $27–$115 →
+     $24–$45.) `duplicate` → per-piece; when pricing a lot, keep only lots.
+   - **Same-item (core tokens):** require the brand/type tokens from IDENTIFY
+     in the comp title — drops loose keyword matches. (Demo: eagle-art's $250
+     non-needlepoint outlier removed by requiring "needlepoint".)
    - **Condition cohort:** bucket by condition; price the item against its
      like-condition cohort (New vs Used grades).
-   - **Unit match:** compare only same `unit_type`; `duplicate` → per-piece.
    - **Exclusions (Tier C reasons, unchanged in spirit):** single-bid
      auctions, <50-feedback sellers, active/asking prices.
 
 3. **Distribution stats** from the cleaned representative (`best_match`) set:
    - `n`, median, 25th/75th percentile (IQR), min/max.
+   - **Report the IQR + median as the core comp range — NOT min–max.** After
+     the unit/same-item/condition filters, the middle 50% is the robust price
+     basis; min–max is dominated by the outliers those filters target.
    - Dispersion = IQR/median (or max/min) → confidence + rarity signal.
+   - Anything outside the IQR fence is an outlier to vet — and the `price_high`
+     set is exactly where those high-side outliers live.
 
 4. **Vet the `price_high` extremes** against the representative median:
    - A high item that is genuinely the same item/condition → a real **ceiling

--- a/docs/price-strategy-v2.md
+++ b/docs/price-strategy-v2.md
@@ -17,8 +17,10 @@ reasons to three tiers. Two problems:
 We verified empirically (see the Apify investigation) that:
 - **`best_match`** returns the representative body of the distribution.
 - **`price_high`** genuinely returns the price+shipping high end, *sorted
-  descending* (so the cap can't hide the expensive outliers) — modulo a
-  row-0 anomaly and "results matching fewer words" padding on niche queries.
+  descending* (so the cap can't hide the expensive outliers). Two things to
+  watch, NOT strip: a frequently **out-of-order first row** (cause
+  unconfirmed — keep it and flag it each run for the human to judge), and
+  "results matching fewer words" padding on niche queries.
 
 So we can now price on the **actual distribution** instead of a few comps.
 
@@ -37,8 +39,10 @@ then place tiers on it."*
 
 2. **Normalize before any stats:**
    - Currency validation (existing charm-price guard).
-   - **Strip noise:** drop the row-0 anomaly and "fewer-words" loose matches
-     (title missing the key query tokens).
+   - **Flag, don't strip, the first row:** the first item is often out of
+     order; cause unconfirmed, so KEEP it and surface a note each run for the
+     human to judge. (Separately, "fewer-words" loose matches — title missing
+     the key query tokens — can be down-weighted.)
    - **Condition cohort:** bucket by condition; price the item against its
      like-condition cohort (New vs Used grades).
    - **Unit match:** compare only same `unit_type`; `duplicate` → per-piece.
@@ -82,6 +86,32 @@ then place tiers on it."*
    - Outliers excluded + reason.
    - Confidence.
 
+## Thin results → broaden the query (NOT a new draft)
+
+The comp **search query** is internal to PRICE and is **not** the listing
+**title**. Broadening a query never changes the `draft.md`, the SEO title,
+the SKU, or the ledger record. (A *new draft* — and its re-record — happens
+only if the actual listing title/identification changes, e.g. DRAFT
+re-renders after a mis-ID. That's separate and deliberate.)
+
+Build queries from IDENTIFY's structured short fields (Brand / Type / Era /
+Category) — which IDENTIFY already separates from the rich prose — as a
+specificity ladder, so we never have to "simplify the SEO title":
+
+- **L1 (specific):** Brand + Type + Era [+ one distinguishing word]
+- **L2 (broader):** Type + material; drop era + modifiers
+- **L3 (broadest):** category noun (+ material)
+
+Fallback rule: run `best_match` + `price_high` at L1. If the combined unique
+comps are below `MIN`, step down (L2, then L3) and re-run, until enough
+comps or the ladder is exhausted. Log each formulation in the Hunt line.
+Note: `price_high` often returns data when `best_match` is empty (observed:
+mask-red `best_match`=0, `price_high`=25), so an empty `best_match` doesn't
+block — broaden for representativeness, but you already have a usable set.
+
+Open decision: `MIN` comps before broadening (0 only, or < 3?) and how many
+ladder steps.
+
 ## What this fixes
 - **Bias:** Recommended is the typical sold price (median), not the ceiling.
 - **Outliers:** seen and judged explicitly, not hidden by a cap or dropped by a blunt rule.
@@ -91,7 +121,8 @@ then place tiers on it."*
 ## Costs / caveats
 - **2 Apify calls/item (~$0.20)** instead of 1 (already accepted).
 - Must normalize condition + unit before stats, or the median lies.
-- Must strip the row-0 anomaly + "fewer-words" padding (verified real).
+- Surface (don't strip) the out-of-order first row each run; cause
+  unconfirmed. "Fewer-words" padding on niche queries is verified real.
 - Thin markets are common in this inventory — the fallback matters.
 
 ## Open decisions (need your call)

--- a/lib/apify_ebay.py
+++ b/lib/apify_ebay.py
@@ -736,6 +736,13 @@ def _cli() -> None:
     import json
     import sys
 
+    # Avoid UnicodeEncodeError on Windows (cp1252) when comp titles contain
+    # non-cp1252 characters (e.g. emoji); same approach as lib/list_edit.py.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
     parser = argparse.ArgumentParser(
         description="Apify eBay sold-listings search (automation-lab/ebay-sold-scraper)"
     )
@@ -849,7 +856,11 @@ def _cli() -> None:
     print()
     for i, c in enumerate(comps, 1):
         tag = f" [{c.keyword_tag}]" if c.keyword_tag and len(args.query) > 1 else ""
-        print(f"[{i:2d}] {c.sold_currency} {c.sold_price:.2f}{tag} - {c.title}")
+        try:
+            print(f"[{i:2d}] {c.sold_currency} {c.sold_price:.2f}{tag} - {c.title}")
+        except UnicodeEncodeError:
+            safe = c.title.encode("ascii", "replace").decode("ascii")
+            print(f"[{i:2d}] {c.sold_currency} {c.sold_price:.2f}{tag} - {safe}")
         if c.sold_date:
             print(f"     Sold: {c.sold_date}")
         if c.condition:

--- a/lib/apify_ebay.py
+++ b/lib/apify_ebay.py
@@ -91,6 +91,16 @@ DEFAULT_RUN_TIMEOUT_SEC = 300
 VALID_SORTS = {"best_match", "newly_listed", "price_low", "price_high"}
 VALID_LISTING_TYPES = {"all", "auction", "buy_it_now"}
 
+# Short tag per `sort`, used in the run's completion status message shown in
+# the Apify Console. PRICE's dual query uses best_match + price_high.
+SORT_STATUS_TAG = {
+    "best_match": "best",
+    "price_high": "sold_highest",
+    "price_low": "sold_lowest",
+    "newly_listed": "newest",
+}
+DEFAULT_STATUS_TITLE_CHARS = 10    # first N title chars in the status message
+
 # Records the most recent run's provenance so the CLI (and PRICE's research
 # log) can cite concrete proof a query hit the Apify backend: the run id,
 # actor, and comp count. Populated by search_ebay_sold() even when the run
@@ -299,6 +309,63 @@ def _run_actor(actor: str, run_input: dict, timeout_sec: int) -> tuple[list[dict
     items = _api_request("GET", f"datasets/{dataset_id}/items?clean=true&format=json",
                          token, timeout=60)
     return (items or []), run_id
+
+
+# ---------------------------------------------------------------------------
+# Run status message (Console label — cosmetic, best-effort)
+# ---------------------------------------------------------------------------
+
+def build_status_message(sort: str, sku: Optional[str] = None,
+                         title: Optional[str] = None,
+                         query: Optional[str] = None,
+                         title_chars: int = DEFAULT_STATUS_TITLE_CHARS,
+                         query_chars: int = 48) -> str:
+    """Compose the run's completion status message for the Apify Console.
+
+    This is what makes runs diagnosable from the Console's runs LIST (the
+    status-message column) without opening each one. Format:
+    ``[<tag>] <sku> <title[:N]>`` — e.g. ``[best] 588a1313 Vintage In``
+    (tag = 'best' for best_match, 'sold_highest' for price_high). sku/title
+    are optional; whatever is supplied is appended, in that order.
+
+    When NEITHER sku nor title is given (e.g. PRICE runs before a SKU
+    exists), the search query is appended instead so the run is never
+    anonymous: ``[best] vintage Indonesian Balinese carved wood mask``.
+    """
+    tag = SORT_STATUS_TAG.get(sort, sort)
+    parts = [f"[{tag}]"]
+    if sku:
+        parts.append(str(sku))
+    if title:
+        parts.append(str(title)[:title_chars])
+    if not sku and not title and query:
+        parts.append(str(query)[:query_chars])
+    return " ".join(parts)
+
+
+def set_run_status_message(run_id: str, message: str,
+                           token: Optional[str] = None, *,
+                           terminal: bool = True, timeout: int = 30) -> None:
+    """Set a run's status message via `PUT /v2/actor-runs/{runId}`.
+
+    The message is cosmetic (Apify Console only), so callers treat this as
+    best-effort and never let a failure break the actual search. Apify can
+    reject a terminal-flagged update on an already-finished run
+    (`cannot-set-is-status-message-terminal`); we retry once without the
+    terminal flag before giving up.
+    """
+    if token is None:
+        token = get_apify_token()
+    body: dict[str, Any] = {"runId": run_id, "statusMessage": message}
+    if terminal:
+        body["isStatusMessageTerminal"] = True
+    try:
+        _api_request("PUT", f"actor-runs/{run_id}", token, body=body, timeout=timeout)
+    except ApifyError:
+        if not terminal:
+            raise
+        _api_request("PUT", f"actor-runs/{run_id}", token,
+                     body={"runId": run_id, "statusMessage": message}, timeout=timeout)
 
 
 # ---------------------------------------------------------------------------
@@ -545,6 +612,10 @@ def search_ebay_sold(
     on_currency_leak: str = "raise",
     save: bool = True,
     save_dir: Optional[Union[str, Path]] = None,
+    sku: Optional[str] = None,
+    title: Optional[str] = None,
+    status_label: Optional[str] = None,
+    set_status: bool = True,
 ) -> list[CompRecord]:
     """Run the eBay sold-listings Actor and return USD comps.
 
@@ -563,6 +634,13 @@ def search_ebay_sold(
         timeout_sec: max time to wait for the Apify run.
         on_currency_leak: "raise" (default) | "repair" | "ignore" — how to
             handle a run whose prices fail the charm-price USD check.
+        sku, title: optional item identifiers used to build the run's
+            completion status message (Apify Console label); title is
+            truncated to the first DEFAULT_STATUS_TITLE_CHARS chars.
+        status_label: override the full status-message text (ignores sku/title).
+        set_status: post a completion status message labeling the run in the
+            Apify Console runs list (default True). Falls back to the query
+            when sku/title are absent, so every run is labeled. Best-effort.
 
     Returns:
         List of CompRecord objects (USD), ordered as the Actor returns them.
@@ -629,6 +707,23 @@ def search_ebay_sold(
         except OSError as e:
             LAST_RUN["save_error"] = str(e)
 
+    # Post a completion status message to the run so it's identifiable in the
+    # Console runs LIST (the status-message column) — the whole point: diagnose
+    # past runs without a custom UI. Format "[best|sold_highest] <sku>
+    # <title[:10]>", falling back to the query when sku/title aren't supplied,
+    # so NO run is anonymous. Best-effort — a status failure never breaks the
+    # returned comps.
+    if set_status:
+        msg = status_label or build_status_message(
+            sort, sku, title, query=" | ".join(keywords))
+        LAST_RUN["status_message"] = msg
+        try:
+            set_run_status_message(run_id, msg)
+            LAST_RUN["status_message_posted"] = True
+        except (ApifyError, ConfigError) as e:
+            LAST_RUN["status_message_posted"] = False
+            LAST_RUN["status_message_error"] = str(e)
+
     return _check_currency_leak(comps, on_currency_leak)
 
 
@@ -668,6 +763,13 @@ def _cli() -> None:
                         "Tip: pass the shoot dir to save alongside price.txt.")
     parser.add_argument("--no-save", action="store_true",
                         help="Do not save the run results to JSON")
+    parser.add_argument("--sku", help="SKU for the run's completion status message "
+                        "(Console label: '[best|sold_highest] <sku> <title[:10]>')")
+    parser.add_argument("--title", help="Item title; first 10 chars go in the status message")
+    parser.add_argument("--status-label", dest="status_label",
+                        help="Override the full status-message text")
+    parser.add_argument("--no-status", action="store_true",
+                        help="Do not post a completion status message to the run")
     parser.add_argument("--json", action="store_true",
                         help="Output raw JSON instead of human-readable list")
     args = parser.parse_args()
@@ -687,6 +789,10 @@ def _cli() -> None:
             on_currency_leak=args.on_leak,
             save=not args.no_save,
             save_dir=args.save_dir,
+            sku=args.sku,
+            title=args.title,
+            status_label=args.status_label,
+            set_status=not args.no_status,
         )
     except CurrencyLeakError as e:
         if LAST_RUN.get("run_id"):
@@ -733,6 +839,10 @@ def _cli() -> None:
     if LAST_RUN.get("run_id"):
         print(f"Apify run: {LAST_RUN['run_id']}  (actor {LAST_RUN.get('actor')})  "
               f"— proof this query hit the Apify backend")
+    if LAST_RUN.get("status_message"):
+        posted = LAST_RUN.get("status_message_posted")
+        state = "posted" if posted else f"NOT posted ({LAST_RUN.get('status_message_error', 'unknown')})"
+        print(f"Run status message: {LAST_RUN['status_message']!r} — {state}")
     if LAST_RUN.get("saved_path"):
         print(f"Saved results: {LAST_RUN['saved_path']}")
     print(f"Equivalent eBay search: {build_sold_search_url(args.query[0])}")

--- a/lib/config.py
+++ b/lib/config.py
@@ -60,6 +60,10 @@ class ConfigError(RuntimeError):
 
 DEFAULT_APIFY_ACTOR = "automation-lab/ebay-sold-scraper"
 
+# Google Lens reverse-image actor (IDENTIFY's visual second opinion). Chosen for
+# reliability (high success rate) + AI-mode + visual/exact match buckets.
+DEFAULT_LENS_ACTOR = "borderline/google-lens"
+
 DEFAULT_PROFILE = {
     "margin_target": 0.50,
     "buy_point_multiplier": 0.5,
@@ -222,6 +226,20 @@ def get_apify_actor() -> str:
         return str(actor)
 
     return DEFAULT_APIFY_ACTOR
+
+
+def get_lens_actor() -> str:
+    """Google Lens reverse-image Actor ID. Precedence: env > config > default."""
+    env = os.environ.get("APIFY_LENS_ACTOR")
+    if env:
+        return env
+
+    config = load_config()
+    actor = _nested(config, "apify", "lens_actor")
+    if actor:
+        return str(actor)
+
+    return DEFAULT_LENS_ACTOR
 
 
 def get_anthropic_key() -> str:

--- a/lib/lens_id.py
+++ b/lib/lens_id.py
@@ -1,0 +1,317 @@
+"""
+lens_id — Google Lens reverse-image "second opinion" for IDENTIFY.
+
+IDENTIFY makes its own visual call from the photos. This module gives it an
+independent cross-check: it hosts the single best photo at a temporary public
+URL, runs an Apify Google Lens actor on it, and returns a STRUCTURED opinion —
+the visual-match titles plus a maker tally — that IDENTIFY weighs against its
+own read. The split mirrors price_stats.py: this module owns the deterministic
+half (host → search → tally convergence); the prompt owns the judgement (how
+much to trust it).
+
+Why a tally, not a single answer: Google Lens returns a noisy mix (for one
+unmarked music box it surfaced Homco, Jamestown, Precious Moments, Lladro,
+Armani…). Adopting any one of those would repeat the "confidently wrong"
+failure. So this module counts how many DISTINCT visual matches mention each
+known maker and reports the convergent signal — including the common, honest
+verdict "no single maker (widely-copied / likely unmarked)".
+
+Privacy + cost (READ THIS before wiring it to run on every shoot):
+  - The photo is briefly uploaded to a public temp host (tmpfiles.org, which
+    auto-expires within ~1h) and sent to Google via Apify. For product photos
+    that is acceptable, but it IS an external send — gate its use (see
+    prompts/identify.md: run only on unmarked, potentially-collectible items).
+  - ~$0.02-0.05 per call on the Apify account. Not free. Don't run it on a $5
+    generic or a lot of obvious commodities.
+
+Network: needs direct egress to tmpfiles.org + api.apify.com. In a sandbox
+whose proxy blocks api.apify.com, run this with egress enabled (the same way
+lib/apify_ebay.py's CLI path needs network). The Lens actor can alternatively
+be driven via the Apify MCP connector, but the image-HOSTING step always needs
+direct egress.
+
+Standard library only (urllib, json, re).
+
+CLI:
+    python lib/lens_id.py <image.jpg>
+    python lib/lens_id.py <image.jpg> --json
+    python lib/lens_id.py <image.jpg> --question "What maker is this figurine?"
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from config import get_apify_token, get_lens_actor  # noqa: E402
+
+_UA = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+       "(KHTML, like Gecko) Chrome/124.0 Safari/537.36")
+
+# Makers commonly seen on ceramic / figurine / music-box collectibles. Matched
+# as lowercase substrings against Lens match titles. Extend freely — this is the
+# vocabulary the convergence tally is built from, not an exhaustive registry.
+KNOWN_MAKERS = [
+    "homco", "home interiors", "lefton", "napcoware", "napco", "josef originals",
+    "josef", "lladro", "hummel", "goebel", "schmid", "sankyo", "brinn", "otagiri",
+    "precious moments", "enesco", "giuseppe armani", "armani", "capodimonte",
+    "jasco", "jamestown", "royal copenhagen", "bing & grondahl", "roman inc",
+    "fontanini", "cybis", "boehm", "florence ceramics", "ucagco", "arnart",
+    "holt howard", "fitz and floyd", "fitz & floyd", "lenox", "department 56",
+    "san francisco music box", "willitts", "chadwick", "melody in motion", "anri",
+    "beswick", "royal doulton", "wales", "kreiss", "norcrest", "relco", "shafford",
+]
+
+# Country-of-origin hints (NOT makers — reported separately as provenance signal).
+_ORIGIN_HINTS = ["occupied japan", "made in japan", "japan", "taiwan", "korea",
+                 "west germany", "germany", "italy", "china", "hong kong"]
+
+# Marketplace/source noise to ignore when harvesting "titles".
+_SOURCE_NOISE = re.compile(r"^(ebay|etsy|mercari|poshmark|amazon|pinterest|reddit|"
+                           r"facebook|whatnot|1stdibs|chairish|ruby lane|bonanza)",
+                           re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# 1) Host the image at a temporary public URL
+# ---------------------------------------------------------------------------
+
+def host_image_tmpfiles(image_path: str | Path, *, timeout: int = 120) -> str:
+    """Upload a local image to tmpfiles.org; return the direct-download URL.
+
+    tmpfiles auto-expires the file within ~1h (no delete token is issued), which
+    satisfies "public briefly, not forever". Raises on upload failure.
+    """
+    data = Path(image_path).read_bytes()
+    boundary = "----lensidboundary7e3f"
+    pre = (f"--{boundary}\r\n"
+           f'Content-Disposition: form-data; name="file"; filename="lens.jpg"\r\n'
+           f"Content-Type: image/jpeg\r\n\r\n").encode()
+    body = pre + data + f"\r\n--{boundary}--\r\n".encode()
+    req = urllib.request.Request(
+        "https://tmpfiles.org/api/v1/upload", data=body, method="POST",
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}",
+                 "User-Agent": _UA})
+    resp = json.loads(urllib.request.urlopen(req, timeout=timeout).read())
+    page_url = resp["data"]["url"]                     # https://tmpfiles.org/<id>/<name>
+    return page_url.replace("tmpfiles.org/", "tmpfiles.org/dl/", 1)
+
+
+# ---------------------------------------------------------------------------
+# 2) Run the Lens actor on the public URL
+# ---------------------------------------------------------------------------
+
+_DEFAULT_QUESTION = ("What is the brand, manufacturer, or collectible product "
+                     "line of this item? Identify the maker if you can; say so "
+                     "plainly if it appears to be an unbranded/generic design.")
+
+
+def run_lens(image_url: str, *, token: Optional[str] = None,
+             actor: Optional[str] = None, question: str = _DEFAULT_QUESTION,
+             timeout: int = 300) -> list[dict]:
+    """Run the Apify Google Lens actor synchronously; return its dataset items."""
+    token = token or get_apify_token()
+    actor = (actor or get_lens_actor()).replace("/", "~")
+    endpoint = (f"https://api.apify.com/v2/acts/{actor}/run-sync-get-dataset-items"
+                f"?token={token}")
+    payload = {
+        "searchTypes": ["all", "visual-match", "exact-match", "ai-mode"],
+        "imageUrls": [{"url": image_url}],
+        "aiModeQuestions": [question],
+    }
+    req = urllib.request.Request(endpoint, data=json.dumps(payload).encode(),
+                                 method="POST",
+                                 headers={"Content-Type": "application/json"})
+    return json.loads(urllib.request.urlopen(req, timeout=timeout).read())
+
+
+# ---------------------------------------------------------------------------
+# 3) Parse the noisy result into a convergence tally
+# ---------------------------------------------------------------------------
+
+def _harvest_titles(obj: Any, out: list[str], depth: int = 0) -> None:
+    """Recursively collect human-readable 'title'/'name' strings from the result."""
+    if depth > 8:
+        return
+    if isinstance(obj, dict):
+        for key in ("title", "name", "snippet"):
+            v = obj.get(key)
+            if isinstance(v, str) and len(v.strip()) > 3:
+                out.append(v.strip())
+        for v in obj.values():
+            _harvest_titles(v, out, depth + 1)
+    elif isinstance(obj, list):
+        for v in obj:
+            _harvest_titles(v, out, depth + 1)
+
+
+def _harvest_ai_answer(obj: Any, depth: int = 0) -> Optional[str]:
+    """Find the longest AI-mode / overview text the actor returned, if any."""
+    best: Optional[str] = None
+    if depth > 8:
+        return None
+    if isinstance(obj, dict):
+        for key, v in obj.items():
+            kl = key.lower()
+            if isinstance(v, str) and len(v) > 40 and any(
+                    t in kl for t in ("answer", "ai", "overview", "summary", "response")):
+                if best is None or len(v) > len(best):
+                    best = v.strip()
+            sub = _harvest_ai_answer(v, depth + 1)
+            if sub and (best is None or len(sub) > len(best)):
+                best = sub
+    elif isinstance(obj, list):
+        for v in obj:
+            sub = _harvest_ai_answer(v, depth + 1)
+            if sub and (best is None or len(sub) > len(best)):
+                best = sub
+    return best
+
+
+def _clean_title(t: str) -> str:
+    """Strip a leading marketplace name (e.g. 'eBayVintage Boy…' -> 'Vintage Boy…')."""
+    return _SOURCE_NOISE.sub("", t).lstrip(" -|·").strip()
+
+
+def tally_opinion(items: list[dict], *, makers: Optional[list[str]] = None) -> dict:
+    """Turn raw Lens items into a structured, convergence-weighted opinion."""
+    makers = makers or KNOWN_MAKERS
+    raw: list[str] = []
+    for it in items:
+        _harvest_titles(it, raw)
+    # de-dup titles (case-insensitive), clean source prefixes
+    seen: set[str] = set()
+    titles: list[str] = []
+    for t in raw:
+        c = _clean_title(t)
+        k = c.lower()
+        if c and k not in seen and not _SOURCE_NOISE.fullmatch(k or ""):
+            seen.add(k)
+            titles.append(c)
+
+    # tally makers across DISTINCT titles (convergence, not a single guess)
+    maker_hits: dict[str, list[str]] = {}
+    for t in titles:
+        tl = t.lower()
+        for m in makers:
+            if m in tl:
+                maker_hits.setdefault(m, [])
+                if len(maker_hits[m]) < 3:
+                    maker_hits[m].append(t[:90])
+    maker_candidates = sorted(
+        ({"maker": m, "count": tl_count(titles, m), "examples": ex}
+         for m, ex in maker_hits.items()),
+        key=lambda x: x["count"], reverse=True)
+
+    origin_hits = sorted({h for t in titles for h in _ORIGIN_HINTS if h in t.lower()})
+    ai_answer = _harvest_ai_answer(items)
+
+    n = len(titles)
+    branded = sum(c["count"] for c in maker_candidates)
+    top = maker_candidates[0] if maker_candidates else None
+    # Verdict: convergence discipline. A maker only "leads" if it recurs across
+    # several distinct matches AND clearly dominates; otherwise it's the common,
+    # honest "widely-copied / likely unmarked".
+    if top and top["count"] >= 3 and top["count"] >= 0.4 * max(branded, 1) and (
+            len(maker_candidates) == 1 or top["count"] >= 2 * maker_candidates[1]["count"]):
+        verdict = (f"leans {top['maker'].title()} "
+                   f"({top['count']}/{n} matches) — still confirm against a mark")
+    elif n == 0:
+        verdict = "no usable matches (Lens returned nothing for this image)"
+    elif branded <= max(1, n // 6):
+        verdict = ("no single maker — widely-copied / likely unmarked "
+                   f"(only {branded}/{n} matches name a maker)")
+    else:
+        names = ", ".join(c["maker"].title() for c in maker_candidates[:3])
+        verdict = (f"split across makers ({names}); no convergence — "
+                   f"treat as unmarked, use names as keywords only")
+
+    return {
+        "n_matches": n,
+        "match_titles": titles[:25],
+        "maker_candidates": maker_candidates,
+        "origin_hints": origin_hits,
+        "ai_answer": ai_answer,
+        "verdict": verdict,
+    }
+
+
+def tl_count(titles: list[str], maker: str) -> int:
+    return sum(1 for t in titles if maker in t.lower())
+
+
+# ---------------------------------------------------------------------------
+# 4) Orchestrate: host -> search -> tally
+# ---------------------------------------------------------------------------
+
+def lens_opinion(image_path: str | Path, *, token: Optional[str] = None,
+                 actor: Optional[str] = None,
+                 question: str = _DEFAULT_QUESTION) -> dict:
+    """Full pipeline. Returns the opinion dict, or {"error": ...} on failure
+    (never raises — IDENTIFY should degrade gracefully to its own call)."""
+    try:
+        url = host_image_tmpfiles(image_path)
+    except Exception as e:  # noqa: BLE001
+        return {"error": f"host failed: {e}", "image": str(image_path)}
+    try:
+        items = run_lens(url, token=token, actor=actor, question=question)
+    except Exception as e:  # noqa: BLE001
+        return {"error": f"lens run failed: {e}", "hosted_url": url}
+    report = tally_opinion(items)
+    report["hosted_url"] = url
+    report["image"] = str(image_path)
+    return report
+
+
+def render(report: dict) -> str:
+    """Human-readable block IDENTIFY folds into its reasoning."""
+    if report.get("error"):
+        return f"Lens cross-check: UNAVAILABLE — {report['error']}"
+    out = [f"Lens cross-check ({report['n_matches']} visual matches):",
+           f"  Verdict: {report['verdict']}"]
+    if report["maker_candidates"]:
+        out.append("  Maker mentions across matches:")
+        for c in report["maker_candidates"][:5]:
+            out.append(f"    • {c['maker'].title()} ×{c['count']}  e.g. \"{(c['examples'] or [''])[0]}\"")
+    if report["origin_hints"]:
+        out.append(f"  Origin hints: {', '.join(report['origin_hints'])}")
+    if report.get("ai_answer"):
+        out.append(f"  Lens AI guess: {report['ai_answer'][:240]}")
+    out.append("  Top match titles:")
+    for t in report["match_titles"][:8]:
+        out.append(f"    - {t}")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _cli() -> None:
+    import argparse
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:  # pragma: no cover
+        pass
+    ap = argparse.ArgumentParser(description="Google Lens second opinion for IDENTIFY")
+    ap.add_argument("image", help="Path to the best photo of the item")
+    ap.add_argument("--actor", help="Override the Lens actor (default from config)")
+    ap.add_argument("--question", default=_DEFAULT_QUESTION, help="AI-mode question")
+    ap.add_argument("--json", action="store_true", help="Emit the full report as JSON")
+    args = ap.parse_args()
+    report = lens_opinion(args.image, actor=args.actor, question=args.question)
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(render(report))
+    if report.get("error"):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -908,6 +908,161 @@ def create_or_update_listing(draft_path: Path,
 
 
 # ---------------------------------------------------------------------------
+# Field-scoped update — change ONLY the named fields, preserve everything else
+# ---------------------------------------------------------------------------
+#
+# create_or_update_listing() rebuilds the WHOLE inventory item + offer from
+# draft.md and PUTs them, which clobbers any change made on eBay's side that
+# the draft doesn't know about (most painfully, a photo re-order done in the
+# Seller Hub UI). update_listing_fields() instead GETs the current live
+# objects, overlays ONLY the requested field groups from the draft, and PUTs
+# them back — so unrequested fields keep their current eBay value. It never
+# publishes, so it can only edit an existing listing, never push a new one live.
+
+# friendly name -> canonical field group
+_SYNC_FIELD_ALIASES = {
+    "description": "description", "desc": "description", "body": "description",
+    "title": "title",
+    "price": "price",
+    "condition": "condition", "cond": "condition",
+    "aspects": "aspects", "specifics": "aspects", "itemspecifics": "aspects",
+    "photos": "photos", "images": "photos", "pics": "photos",
+    "shipping": "shipping", "weight": "shipping", "dims": "shipping",
+    "quantity": "quantity", "qty": "quantity",
+    "bestoffer": "bestoffer", "best_offer": "bestoffer", "offer": "bestoffer",
+}
+_ITEM_SIDE = {"title", "description", "condition", "aspects", "photos", "shipping", "quantity"}
+_OFFER_SIDE = {"description", "price", "quantity", "bestoffer"}
+# Keys accepted by PUT inventory_item / updateOffer — used to strip read-only
+# echo fields (offerId, listing, status, …) out of the GET response before PUT.
+_WRITABLE_ITEM_KEYS = ("availability", "condition", "conditionDescription",
+                       "packageWeightAndSize", "product")
+_WRITABLE_OFFER_KEYS = ("availableQuantity", "categoryId", "listingDescription",
+                        "listingPolicies", "pricingSummary", "merchantLocationKey",
+                        "marketplaceId", "format", "sku", "tax", "listingDuration",
+                        "quantityLimitPerBuyer", "storeCategoryNames", "listingStartDate",
+                        "secondaryCategoryId", "hideBuyerDetails",
+                        "includeCatalogProductDetails", "lotSize")
+
+
+def _canonical_sync_fields(fields) -> set[str]:
+    """Map user-supplied field names to canonical groups; raise on unknown."""
+    out: set[str] = set()
+    unknown: list[str] = []
+    for raw in fields:
+        key = re.sub(r"[\s_-]+", "", str(raw).strip().lower())
+        canon = _SYNC_FIELD_ALIASES.get(key) or _SYNC_FIELD_ALIASES.get(str(raw).strip().lower())
+        if canon:
+            out.add(canon)
+        elif raw:
+            unknown.append(str(raw))
+    if unknown:
+        valid = sorted(set(_SYNC_FIELD_ALIASES.values()))
+        raise ValueError(f"unknown --fields value(s): {', '.join(unknown)}. "
+                         f"Valid groups: {', '.join(valid)}")
+    if not out:
+        raise ValueError("no fields given — pass --fields description[,price,…]")
+    return out
+
+
+def update_listing_fields(draft_path: Path, fields,
+                          creds: Optional[EbayCredentials] = None) -> list[str]:
+    """Update ONLY the named field groups on an existing eBay item/offer.
+
+    GET-merge-PUT: unrequested fields (incl. photos + their order) keep their
+    current eBay value. Never publishes. Returns the list of fields changed.
+    """
+    creds = creds or load_credentials()
+    if not creds.has_user:
+        raise EbayAuthError("Update needs user-context OAuth. Run `python list_edit.py --setup-check`.")
+    draft_path = _resolve_draft_path(draft_path)
+    draft = parse_draft(draft_path)
+    sku = _sku_for(draft)
+    canon = _canonical_sync_fields(fields)
+    item_fields = canon & _ITEM_SIDE
+    offer_fields = canon & _OFFER_SIDE
+    changed: list[str] = []
+
+    if item_fields:
+        try:
+            cur = api_send("GET", f"/sell/inventory/v1/inventory_item/{sku}", creds=creds)
+        except EbayAPIError as e:
+            raise ValueError(f"no inventory item for SKU {sku} — run a full `--sync` first ({e})")
+        item = {k: cur[k] for k in _WRITABLE_ITEM_KEYS if k in cur}
+        product = item.setdefault("product", {})
+        if "title" in item_fields:
+            product["title"] = str(draft.get("title")); changed.append("title")
+        if "description" in item_fields:
+            product["description"] = _body_to_html(draft.body); changed.append("description")
+        if "aspects" in item_fields:
+            product["aspects"] = _build_aspects(draft); changed.append("aspects")
+        if "condition" in item_fields:
+            cond = str(draft.get("condition") or "")
+            allowed, _r = get_allowed_condition_ids(_resolve_category_id(draft, creds), creds=creds)
+            if allowed:
+                new_enum, reason = _remap_condition_for_category(cond, allowed)
+                if reason:
+                    cond = new_enum
+                    print(f"  [preflight] {reason}")
+            item["condition"] = cond
+            cd = str(draft.get("condition_description") or "").strip()
+            if cd and cond != "NEW":
+                item["conditionDescription"] = cd[:1000]
+            changed.append("condition")
+        if "shipping" in item_fields:
+            full = _build_inventory_item(draft, product.get("imageUrls", []))
+            if "packageWeightAndSize" in full:
+                item["packageWeightAndSize"] = full["packageWeightAndSize"]
+            changed.append("shipping")
+        if "quantity" in item_fields:
+            item.setdefault("availability", {}).setdefault(
+                "shipToLocationAvailability", {})["quantity"] = int(draft.get("quantity") or 1)
+            changed.append("quantity")
+        if "photos" in item_fields:
+            urls = upload_photos_to_eps(resolve_photo_paths(draft), creds=creds)
+            product["imageUrls"] = urls
+            changed.append(f"photos({len(urls)})")
+        api_send("PUT", f"/sell/inventory/v1/inventory_item/{sku}", item, creds=creds)
+
+    if offer_fields:
+        offer_id = _find_offer_id_for_sku(sku, creds)
+        if not offer_id:
+            raise ValueError(f"no offer for SKU {sku} — run a full `--sync` first")
+        cur = api_send("GET", f"/sell/inventory/v1/offer/{offer_id}", creds=creds)
+        offer = {k: cur[k] for k in _WRITABLE_OFFER_KEYS if k in cur}
+        if "description" in offer_fields and "description" not in changed:
+            changed.append("description")
+        if "description" in offer_fields:
+            offer["listingDescription"] = _body_to_html(draft.body)
+        if "price" in offer_fields:
+            offer["pricingSummary"] = {"price": {"value": _to_decimal_str(draft.get("price")),
+                                                 "currency": CURRENCY}}
+            changed.append("price")
+        if "quantity" in offer_fields and "quantity" not in changed:
+            offer["availableQuantity"] = int(draft.get("quantity") or 1); changed.append("quantity")
+        elif "quantity" in offer_fields:
+            offer["availableQuantity"] = int(draft.get("quantity") or 1)
+        if "bestoffer" in offer_fields:
+            lp = offer.setdefault("listingPolicies", {})
+            if draft.get("best_offer.enabled"):
+                terms: dict = {"bestOfferEnabled": True}
+                d = _to_decimal_str(draft.get("best_offer.auto_decline_amount"))
+                a = _to_decimal_str(draft.get("best_offer.auto_accept_amount"))
+                if d:
+                    terms["autoDeclinePrice"] = {"value": d, "currency": CURRENCY}
+                if a:
+                    terms["autoAcceptPrice"] = {"value": a, "currency": CURRENCY}
+                lp["bestOfferTerms"] = terms
+            else:
+                lp.pop("bestOfferTerms", None)
+            changed.append("bestoffer")
+        api_send("PUT", f"/sell/inventory/v1/offer/{offer_id}", offer, creds=creds)
+
+    update_meta(draft_path, {"last_synced": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")})
+    return changed
+
+
+# ---------------------------------------------------------------------------
 # PUBLISH — explicit, manual, confirmation-gated (the one publish path)
 # ---------------------------------------------------------------------------
 
@@ -1223,6 +1378,8 @@ def _cli() -> None:
     ap.add_argument("--sync", metavar="TARGET", help="Create/update the eBay DRAFT (unpublished offer) from a draft.md or shoot dir.")
     ap.add_argument("--publish", metavar="TARGET", help="Publish a synced offer to a LIVE listing. DRY RUN unless --confirm is also given.")
     ap.add_argument("--list", metavar="TARGET", dest="list_target", help="Sync THEN publish in one step (post review-gate). DRY RUN unless --confirm is also given.")
+    ap.add_argument("--update", metavar="TARGET", help="Update ONLY the --fields groups on an existing item/offer (GET-merge-PUT; never publishes; preserves photos + everything else).")
+    ap.add_argument("--fields", metavar="LIST", help="Comma-separated field groups for --update (e.g. description,price). Groups: description,title,price,condition,aspects,photos,shipping,quantity,bestoffer.")
     ap.add_argument("--end", metavar="TARGET", help="End (withdraw) a live listing from a draft. DRY RUN unless --confirm is also given.")
     ap.add_argument("--offers", action="store_true", help="Query ALL offers on the account (sku, offerId, status, listingId, price).")
     ap.add_argument("--withdraw-offer", metavar="OFFER_ID", help="Withdraw (end) a live offer by ID — keeps the offer. DRY RUN unless --confirm.")
@@ -1315,6 +1472,18 @@ def _cli() -> None:
                 print(f"[LIVE] Published offer {res.offer_id} -> listing {res.listing_id}")
                 if res.listing_url: print(f"  {res.listing_url}")
                 print("  This listing is now public and accepting buyers.")
+            return
+        if args.update:
+            if not args.fields:
+                print("[X] --update requires --fields (e.g. --fields description). "
+                      "No implicit 'all' — that's what --sync/--list are for.")
+                sys.exit(1)
+            field_list = [f for f in args.fields.split(",") if f.strip()]
+            changed = update_listing_fields(Path(args.update), field_list)
+            if changed:
+                print(f"[OK] updated {', '.join(changed)} on {args.update} (other fields preserved).")
+            else:
+                print(f"[i] nothing changed on {args.update}.")
             return
         if args.end:
             res = end_listing(Path(args.end), confirm=args.confirm)

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -466,13 +466,72 @@ def _build_weight_lb(draft: Draft) -> Optional[float]:
     return round(total, 2) if total > 0 else None
 
 
+def _md_inline(text: str) -> str:
+    """Escape HTML, then render the inline markdown the templates use."""
+    text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
+    return text
+
+
+def _body_to_html(md: str) -> str:
+    """Convert the markdown subset used in draft bodies (ATX headings, `-`/`*`
+    bullet lists, **bold**, blank-line paragraphs) into HTML.
+
+    eBay renders `product.description` / `listingDescription` as HTML, so a raw
+    markdown body collapses into one run-on paragraph (newlines and `#`/`-`
+    markers are ignored). This restores the intended structure. Stdlib-only —
+    no markdown dependency, matching the rest of lib/.
+    """
+    lines = (md or "").replace("\r\n", "\n").split("\n")
+    out: list[str] = []
+    in_ul = False
+    para: list[str] = []
+
+    def flush_para() -> None:
+        if para:
+            out.append("<p>" + " ".join(_md_inline(p) for p in para) + "</p>")
+            para.clear()
+
+    def close_ul() -> None:
+        nonlocal in_ul
+        if in_ul:
+            out.append("</ul>")
+            in_ul = False
+
+    for raw in lines:
+        stripped = raw.strip()
+        if not stripped:
+            flush_para()
+            close_ul()
+            continue
+        m_h = re.match(r"^(#{1,6})\s+(.*)$", stripped)
+        m_li = re.match(r"^[-*]\s+(.*)$", stripped)
+        if m_h:
+            flush_para()
+            close_ul()
+            level = min(len(m_h.group(1)) + 1, 4)   # "#" -> h2, "##" -> h3, ...
+            out.append(f"<h{level}>{_md_inline(m_h.group(2))}</h{level}>")
+        elif m_li:
+            flush_para()
+            if not in_ul:
+                out.append("<ul>")
+                in_ul = True
+            out.append(f"<li>{_md_inline(m_li.group(1))}</li>")
+        else:
+            close_ul()
+            para.append(stripped)
+    flush_para()
+    close_ul()
+    return "\n".join(out)
+
+
 def _build_inventory_item(draft: Draft, image_urls: list[str]) -> dict:
     item: dict = {
         "availability": {"shipToLocationAvailability": {"quantity": int(draft.get("quantity") or 1)}},
         "condition": str(draft.get("condition")),
         "product": {
             "title": str(draft.get("title")),
-            "description": draft.body,
+            "description": _body_to_html(draft.body),
             "imageUrls": image_urls,
             "aspects": _build_aspects(draft),
         },
@@ -508,7 +567,7 @@ def _build_offer(draft: Draft, sku: str, category_id: str,
         "format": "FIXED_PRICE",
         "availableQuantity": int(draft.get("quantity") or 1),
         "categoryId": str(category_id),
-        "listingDescription": draft.body,
+        "listingDescription": _body_to_html(draft.body),
         "pricingSummary": {"price": {"value": price, "currency": CURRENCY}},
         "merchantLocationKey": location_key,
         "listingPolicies": {

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -157,9 +157,17 @@ def _resolve_draft_path(target: str | Path) -> Path:
     return p
 
 
-def _sku_for(draft: Draft) -> str:
-    """eBay custom label (SKU): an 8-hex-digit hash of the listing title +
-    shoot folder name.
+# The canonical SKU format: exactly 8 lowercase hex digits (see _canonical_sku).
+# Anything else — most commonly a legacy "url-style" label like
+# "ebaybiz-sand-dollars" stamped by an older version of the app — is NOT
+# canonical. Those slugs predate the sku-keyed sync/ledger scheme and must be
+# migrated before they reach eBay (see normalize_draft_identity).
+_CANONICAL_SKU_RE = re.compile(r"^[0-9a-f]{8}$")
+
+
+def _canonical_sku(draft: Draft) -> str:
+    """The deterministic canonical SKU for a draft: an 8-hex-digit hash of the
+    listing title + shoot folder name.
 
     - Unique per item: the folder name is unique per item, so two items that
       happen to share a title still get different SKUs.
@@ -168,14 +176,67 @@ def _sku_for(draft: Draft) -> str:
     - 8 hex digits (32 bits, ~4.3B space) → negligible collision risk at the
       volumes this business lists.
     """
-    # Reuse an already-synced SKU so existing listings keep their label.
-    existing = draft.get("meta.ebay_inventory_sku")
-    if existing:
-        return str(existing)
     title = re.sub(r"\s+", " ", str(draft.get("title") or "")).strip().lower()
     folder = draft.path.parent.name or str(draft.get("meta.item_id") or "item")
     basis = f"{title}\n{folder}".encode("utf-8")
     return hashlib.sha1(basis).hexdigest()[:8]
+
+
+def _sku_for(draft: Draft) -> str:
+    """Resolve a draft's SKU. Prefer an already-stamped CANONICAL sku (so a
+    live listing keeps its label and re-syncs stay idempotent), but never trust
+    a legacy url-style label — recompute the canonical one instead. Drafts from
+    an older app version are migrated in place by normalize_draft_identity()
+    before record/sync; this is the last-line guard so a stale slug can never
+    reach eBay even if normalization was skipped."""
+    existing = str(draft.get("meta.ebay_inventory_sku") or "").strip()
+    if existing and _CANONICAL_SKU_RE.match(existing):
+        return existing
+    return _canonical_sku(draft)
+
+
+def normalize_draft_identity(draft_path: Path) -> dict:
+    """Self-heal a draft carried over from an older app version — NO eBay calls.
+
+    Two fixes, both deterministic from the frontmatter alone:
+      1. **Legacy url-style SKU** (e.g. "ebaybiz-sand-dollars") → rewritten to
+         the canonical 8-hex label. Those slugs don't round-trip through the
+         sku-keyed sync/ledger and must never reach eBay.
+      2. **Orphaned listing/offer ids** — when the SKU is migrated, the
+         ebay_offer_id / ebay_listing_id / published_at it carried belong to the
+         OLD label's listing and are now orphaned, so they're cleared. The next
+         sync then creates a fresh offer under the correct SKU, and publish
+         stamps the real listing id back.
+
+    A missing SKU is just left for record/sync to stamp; an already-canonical
+    SKU is left untouched. Returns a report dict the caller can print/log:
+    {changed, sku_before, sku_after, cleared:[...], note}."""
+    draft_path = _resolve_draft_path(draft_path)
+    draft = parse_draft(draft_path)
+    sku_before = str(draft.get("meta.ebay_inventory_sku") or "").strip()
+    canonical = _canonical_sku(draft)
+    report = {"changed": False, "sku_before": sku_before or None,
+              "sku_after": sku_before or canonical, "cleared": [], "note": ""}
+
+    # Only act on a legacy (present but non-canonical) SKU. Missing → nothing to
+    # migrate; canonical → already good (don't churn a live listing's label).
+    if not sku_before or _CANONICAL_SKU_RE.match(sku_before):
+        return report
+
+    updates: dict[str, str] = {"ebay_inventory_sku": canonical}
+    cleared: list[str] = []
+    for field in ("ebay_offer_id", "ebay_listing_id", "published_at"):
+        if str(draft.get(f"meta.{field}") or "").strip():
+            updates[field] = ""          # "" is the cleared convention (see end_listing)
+            cleared.append(field)
+    note = (f"IDENTITY NORMALIZED: legacy url-style SKU '{sku_before}' -> "
+            f"canonical '{canonical}'"
+            + (f"; cleared orphaned {', '.join(cleared)}" if cleared else ""))
+    notes = str(draft.get("meta.notes") or "")
+    updates["notes"] = (notes + " | " + note).strip(" |")
+    update_meta(draft_path, updates)
+    report.update(changed=True, sku_after=canonical, cleared=cleared, note=note)
+    return report
 
 
 def _to_decimal_str(val: object) -> Optional[str]:
@@ -263,6 +324,9 @@ def record_draft(draft_path: Path) -> tuple[str, Optional[str]]:
     moment a title is chosen; sync/publish later update the same row.
     Returns (sku, ledger_path)."""
     draft_path = _resolve_draft_path(draft_path)
+    norm = normalize_draft_identity(draft_path)   # self-heal legacy url-style sku / orphaned ids
+    if norm["changed"]:
+        print(f"  [normalize] {norm['note']}")
     draft = parse_draft(draft_path)
     sku = _sku_for(draft)
     if str(draft.get("meta.ebay_inventory_sku") or "") != sku:
@@ -327,6 +391,15 @@ def validate_draft_for_sync(draft_path: Path) -> list[str]:
 
     if not str(draft.get("item_specifics.type") or "").strip():
         issues.append("item_specifics.type: required, empty")
+
+    # SKU format: a stamped SKU must be canonical (8 hex). A legacy url-style
+    # slug (e.g. "ebaybiz-sand-dollars" from an older app version) is flagged
+    # here — `--record`/`--sync` auto-heal it via normalize_draft_identity, but
+    # a standalone `--validate` should surface that the draft needs migrating.
+    sku = str(draft.get("meta.ebay_inventory_sku") or "").strip()
+    if sku and not _CANONICAL_SKU_RE.match(sku):
+        issues.append(f"meta.ebay_inventory_sku: {sku!r} — legacy/url-style SKU, "
+                      f"not canonical 8-hex; run `--normalize` (or --record/--sync auto-heals)")
 
     if len(draft.body.strip()) < 20:
         issues.append("description body: empty/too short (V1 missing-description guard)")
@@ -701,6 +774,9 @@ def create_or_update_listing(draft_path: Path,
         raise EbayAuthError("Sync needs user-context OAuth. Run `python list_edit.py --setup-check`.")
 
     draft_path = _resolve_draft_path(draft_path)
+    norm = normalize_draft_identity(draft_path)   # self-heal legacy url-style sku / orphaned ids before anything hits eBay
+    if norm["changed"]:
+        print(f"  [normalize] {norm['note']}")
     issues = validate_draft_for_sync(draft_path)
     if issues:
         raise ValueError("draft is not sync-ready:\n  - " + "\n  - ".join(issues))
@@ -1083,6 +1159,7 @@ def _cli() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
     ap.add_argument("--validate", metavar="TARGET", help="Validate a draft.md or shoot dir (no creds).")
     ap.add_argument("--record", metavar="TARGET", help="DRAFT-time: stamp the SKU into the draft + create its ledger record (DRAFTED). No creds.")
+    ap.add_argument("--normalize", metavar="TARGET", help="Migrate a legacy url-style SKU to canonical 8-hex + clear orphaned offer/listing ids in a draft.md or shoot dir. No creds.")
     ap.add_argument("--preflight", metavar="TARGET", help="Check (and auto-correct) condition + shipping against the eBay category (needs creds).")
     ap.add_argument("--sync", metavar="TARGET", help="Create/update the eBay DRAFT (unpublished offer) from a draft.md or shoot dir.")
     ap.add_argument("--publish", metavar="TARGET", help="Publish a synced offer to a LIVE listing. DRY RUN unless --confirm is also given.")
@@ -1114,6 +1191,15 @@ def _cli() -> None:
             print(f"[OK] recorded DRAFTED — sku {sku}")
             if ledger:
                 print(f"  ledger: {ledger}")
+            return
+        if args.normalize:
+            rep = normalize_draft_identity(Path(args.normalize))
+            if rep["changed"]:
+                print(f"[OK] normalized — sku {rep['sku_before']} -> {rep['sku_after']}")
+                if rep["cleared"]:
+                    print(f"  cleared orphaned: {', '.join(rep['cleared'])}")
+            else:
+                print(f"[OK] no change — sku {rep['sku_after']!r} already canonical (or none stamped)")
             return
         if args.setup_check:
             _print_setup_check()

--- a/lib/price_stats.py
+++ b/lib/price_stats.py
@@ -1,0 +1,665 @@
+"""
+price_stats — distribution-based PRICE tier engine (PRICE strategy v2).
+
+Turns one or two saved Apify run JSON files into a defensible price: it
+characterizes the *cleaned sold distribution* and places three tiers on it,
+instead of hand-picking a few comps. See docs/price-strategy-v2.md.
+
+The shift: from "pick the strongest comps" to "characterize the sold
+distribution, then place tiers on it." This module owns the deterministic,
+reproducible half — the filtering and the statistics — so PRICE's tiers
+trace to a sample + percentiles, not a vibe. The reasoning half (exact-match
+judgement, ceiling vetting prose, authenticity notes) stays in the prompt.
+
+Inputs (saved by apify_ebay.save_run_json):
+    --best-match   <run.json>   representative set (sort=best_match)
+    --price-high   <run.json>   ceiling/outlier set (sort=price_high)
+At least one is required; both is the v2 design (dual query per unit).
+
+Pipeline (mirrors docs/price-strategy-v2.md "Normalize before any stats"):
+    1. Flag (NOT strip) the price_high first row — often out of order; cause
+       unconfirmed, so it's kept and surfaced for the human to judge.
+    2. Unit match (biggest lever): pricing a `single`/`duplicate` excludes
+       multi-item listings (lot/set/bundle/collection/N pcs/multiple years);
+       pricing a `lot`/`set`/`pair` keeps the matching unit.
+    3. Same-item core tokens: require the brand/type tokens from IDENTIFY in
+       the comp title (drops loose keyword matches).
+    4. Condition cohort: bucket New vs Used; price within the like-condition
+       cohort (pool Used grades only when that cohort is thin).
+    5. Exclusions: single-bid auctions, sub-threshold-feedback sellers.
+
+Stats come off the cleaned best_match (representative) set; the price_high
+set supplies the vetted ceiling. Every drop is logged, never silent.
+
+Tier defaults (configurable constants — the proposal's open decisions):
+    Conservative = 25th pct · Recommended = median · Push-high = vetted
+    price_high ceiling, else 90th pct. Thin (n < 3) → caller falls back to
+    the closest-comp method; this module says so rather than inventing
+    percentiles off 2 points.
+
+Standard library only (json, statistics) — runs in minimal/sandboxed envs.
+
+CLI:
+    python price_stats.py --best-match bm.json --price-high ph.json \
+        --unit single --require-tokens needlepoint eagle --condition used
+    python price_stats.py --best-match bm.json --json     # machine-readable
+
+Programmatic:
+    from price_stats import price_from_runs
+    report = price_from_runs(best_match_json="bm.json", unit_type="single",
+                             require_tokens=["needlepoint"], condition="used")
+    print(report["tiers"]["recommended"])
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, Union
+
+# ---------------------------------------------------------------------------
+# Tunable policy (the proposal's "Open decisions" — change here, one place)
+# ---------------------------------------------------------------------------
+
+CONSERVATIVE_PCT = 25       # no-objection floor percentile
+RECOMMENDED_PCT = 50        # working-price percentile (median)
+PUSH_HIGH_FALLBACK_PCT = 90  # ceiling when no price_high comp vets out
+
+THIN_N = 3                  # n < THIN_N like-condition comps → fall back
+GOOD_N = 8                  # n >= GOOD_N (and tight IQR) → confidence "good"
+TIGHT_DISPERSION = 0.50     # IQR/median at/below this is "tight"
+
+# A price_high item above OUTLIER_MULT × median that isn't clearly the same
+# item/condition is an excluded outlier (bundle/mislisting/different model),
+# not a ceiling comp. Logged, never silently dropped.
+OUTLIER_MULT = 2.5
+
+MIN_SELLER_FEEDBACK = 50    # below this feedback count → Tier-C exclusion
+
+# Tokens that mark a listing as multi-item (a "lot"), used by the unit filter.
+_MULTI_ITEM_WORDS = {
+    "lot", "lots", "set", "sets", "bundle", "bundles", "collection",
+    "complete", "pair", "pairs", "group", "grouping", "joblot",
+}
+_YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
+# A digit that touches a quote/inch mark (7" x 6") or a length unit (6 in) is
+# a physical DIMENSION, not a quantity. Used to stop the x-multiplier count
+# patterns from false-positiving on eBay size strings.
+_DIM_AFTER = r'(?:["″′\']|\s*(?:in|inch|inches|cm|mm|ft|feet|foot)\b)'
+# "5 pcs", "lot of 3", "x12", "12 pieces/issues/cards/vols". The x-multiplier
+# forms ("x12" / "12x") only count when the number is NOT a dimension, so
+# 7" x 6" / 13" X 10" stay single-item (see looks_multi_item doctests).
+_COUNT_RE = re.compile(
+    r'\b(?:'
+    r'lot of\s*\d+'
+    r'|set of\s*\d+'
+    r'|\d+\s*(?:pcs?|pieces?|issues?|cards?|vol(?:ume)?s?|pc)'
+    r'|x\s*\d+(?!' + _DIM_AFTER + r')'
+    r'|(?<!["″′\'])\d+\s*x'
+    r')\b',
+    re.IGNORECASE,
+)
+
+# unit_type → does this unit WANT multi-item listings?
+_MULTI_UNITS = {"lot", "set", "pair"}
+_SINGLE_UNITS = {"single", "duplicate"}
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Comp:
+    """A normalized comp, plus the bookkeeping the filters annotate."""
+    title: str
+    price: float                  # the price the stats run on (see price_field)
+    sold_price: float
+    total_price: Optional[float]
+    url: str
+    condition: Optional[str] = None
+    sold_date: Optional[str] = None
+    listing_type: Optional[str] = None
+    bids_count: Optional[int] = None
+    seller_feedback_score: Optional[int] = None
+    source: str = "best_match"    # which run sort this came from
+    is_row0: bool = False         # flagged first price_high row (kept, surfaced)
+    drop_reason: Optional[str] = None  # set when a filter excludes it
+    cohort: Optional[str] = None  # "new" / "used" bucket
+
+    @property
+    def dropped(self) -> bool:
+        return self.drop_reason is not None
+
+
+@dataclass
+class FilterLog:
+    """One filter's effect — what it removed and why (audit trail)."""
+    name: str
+    removed: list = field(default_factory=list)   # (title, price, reason)
+
+    def add(self, comp: "Comp", reason: str) -> None:
+        comp.drop_reason = reason
+        self.removed.append((comp.title, comp.price, reason))
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+def _condition_cohort(condition: Optional[str]) -> str:
+    """Bucket an eBay condition label into 'new' / 'used' / 'unknown'."""
+    if not condition:
+        return "unknown"
+    c = condition.lower()
+    if "new" in c or "sealed" in c or "nwt" in c or "mint" in c:
+        return "new"
+    if any(w in c for w in ("used", "pre-owned", "preowned", "very good",
+                            "good", "acceptable", "refurb", "open box",
+                            "parts", "not work")):
+        return "used"
+    return "unknown"
+
+
+def _load_comps(json_path: Union[str, Path], source: str,
+                price_field: str) -> list["Comp"]:
+    """Read a saved Apify run JSON into Comp objects.
+
+    `source` labels the run sort (best_match / price_high). The first comp of
+    a price_high run is flagged is_row0 (often out of order — kept, surfaced).
+    """
+    data = json.loads(Path(json_path).read_text(encoding="utf-8"))
+    comps: list[Comp] = []
+    for i, c in enumerate(data.get("comps", [])):
+        sold = c.get("sold_price")
+        if sold is None:
+            continue
+        total = c.get("total_price")
+        price = total if (price_field == "total" and total is not None) else sold
+        comps.append(Comp(
+            title=str(c.get("title", "")),
+            price=float(price),
+            sold_price=float(sold),
+            total_price=float(total) if total is not None else None,
+            url=str(c.get("url", "")),
+            condition=c.get("condition"),
+            sold_date=c.get("sold_date"),
+            listing_type=c.get("listing_type"),
+            bids_count=c.get("bids_count"),
+            seller_feedback_score=c.get("seller_feedback_score"),
+            source=source,
+            is_row0=(source == "price_high" and i == 0),
+            cohort=_condition_cohort(c.get("condition")),
+        ))
+    return comps
+
+
+def _run_meta(json_path: Union[str, Path]) -> dict:
+    data = json.loads(Path(json_path).read_text(encoding="utf-8"))
+    return {
+        "run_id": data.get("run_id"),
+        "queries": data.get("queries"),
+        "charm_price_share": data.get("charm_price_share"),
+        "currency_leak_suspected": data.get("currency_leak_suspected"),
+        "path": str(json_path),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Filters (each annotates comps in place and returns a FilterLog)
+# ---------------------------------------------------------------------------
+
+def looks_multi_item(title: str) -> bool:
+    """True if a title reads as a multi-item listing (lot/set/bundle/N pcs).
+
+    The single-item biggest-lever filter: a `single` priced against lots is
+    the classic skew the proposal targets (m-agni $10-$506 → $10-$144).
+
+    Counts ("Lot of 5", "x12", "12x", "3 pcs") flag as multi-item; physical
+    dimensions ('7" x 6"', '13" X 10"', '8 inches') do NOT — a digit touching
+    a quote/inch mark or length unit is a measurement, not a quantity.
+
+    >>> looks_multi_item('Lot of 5 Vintage Postcards')
+    True
+    >>> looks_multi_item('Set of 3 Brass Candlesticks')
+    True
+    >>> looks_multi_item('Magic The Gathering Cards x12')
+    True
+    >>> looks_multi_item('12x Vintage Brass Buttons')
+    True
+    >>> looks_multi_item('RARE Vintage Balinese Topeng Mask 7\" x 6\" Needs Repair')
+    False
+    >>> looks_multi_item('Antique Wood Panel 13\" X 10\" Hand Carved')
+    False
+    >>> looks_multi_item('Sterling Silver Spoon 8 inches Long')
+    False
+    """
+    t = title.lower()
+    words = set(re.findall(r"[a-z]+", t))
+    if words & _MULTI_ITEM_WORDS:
+        return True
+    if _COUNT_RE.search(title):
+        return True
+    # Multiple DISTINCT years in one title → almost always a multi-year lot.
+    years = set(_YEAR_RE.findall(title))
+    if len(years) > 1:
+        return True
+    return False
+
+
+def filter_unit(comps: list["Comp"], unit_type: str) -> FilterLog:
+    """Keep only comps whose selling-unit matches the item being priced."""
+    log = FilterLog("unit_match")
+    unit = (unit_type or "single").lower()
+    for c in comps:
+        if c.dropped:
+            continue
+        multi = looks_multi_item(c.title)
+        if unit in _SINGLE_UNITS and multi:
+            log.add(c, f"multi-item listing; pricing a {unit}")
+        elif unit in _MULTI_UNITS and not multi:
+            log.add(c, f"single-item listing; pricing a {unit}")
+    return log
+
+
+def filter_tokens(comps: list["Comp"], require_tokens: list[str]) -> FilterLog:
+    """Require every core token (brand/type from IDENTIFY) in the comp title."""
+    log = FilterLog("same_item_tokens")
+    tokens = [t.lower() for t in (require_tokens or []) if t.strip()]
+    if not tokens:
+        return log
+    for c in comps:
+        if c.dropped:
+            continue
+        title = c.title.lower()
+        missing = [t for t in tokens if t not in title]
+        if missing:
+            log.add(c, f"title missing core token(s): {', '.join(missing)}")
+    return log
+
+
+def filter_condition(comps: list["Comp"], target: Optional[str],
+                     pool_used_when_thin: bool = True) -> tuple[FilterLog, str]:
+    """Keep comps in the item's condition cohort. Returns (log, cohort_used).
+
+    If the strict target cohort is thin (< THIN_N), and pool_used_when_thin,
+    Used grades pool together rather than starve the sample.
+    """
+    log = FilterLog("condition_cohort")
+    if not target:
+        return log, "any"
+    target_cohort = _condition_cohort(target)
+    if target_cohort == "unknown":
+        return log, "any"
+
+    live = [c for c in comps if not c.dropped]
+    in_cohort = [c for c in live if c.cohort == target_cohort]
+    # Thin strict cohort + Used target → pool all Used grades (already same
+    # bucket here, so "pool" mainly means: don't also drop unknown-condition).
+    pooled = (pool_used_when_thin and target_cohort == "used"
+              and len(in_cohort) < THIN_N)
+    cohort_used = f"{target_cohort} (pooled w/ unknown — thin)" if pooled else target_cohort
+    for c in live:
+        if c.cohort == target_cohort:
+            continue
+        if pooled and c.cohort == "unknown":
+            continue
+        log.add(c, f"condition '{c.condition or '?'}' not in {target_cohort} cohort")
+    return log, cohort_used
+
+
+def filter_exclusions(comps: list["Comp"]) -> FilterLog:
+    """Tier-C exclusions: single-bid auctions, sub-threshold-feedback sellers."""
+    log = FilterLog("exclusions")
+    for c in comps:
+        if c.dropped:
+            continue
+        lt = (c.listing_type or "").lower()
+        if "auction" in lt and c.bids_count is not None and c.bids_count <= 1:
+            log.add(c, "single-bid auction (one bidder set the price)")
+        elif (c.seller_feedback_score is not None
+              and c.seller_feedback_score < MIN_SELLER_FEEDBACK):
+            log.add(c, f"seller feedback {c.seller_feedback_score} < {MIN_SELLER_FEEDBACK}")
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+def percentile(sorted_vals: list[float], pct: float) -> float:
+    """Linear-interpolation percentile (pct in 0..100) on pre-sorted values."""
+    if not sorted_vals:
+        raise ValueError("percentile of empty data")
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    rank = (pct / 100.0) * (len(sorted_vals) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    frac = rank - lo
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * frac
+
+
+def distribution(prices: list[float]) -> dict:
+    """Core distribution stats for a cleaned price set."""
+    vals = sorted(prices)
+    n = len(vals)
+    if n == 0:
+        return {"n": 0}
+    med = statistics.median(vals)
+    p25 = percentile(vals, 25)
+    p75 = percentile(vals, 75)
+    iqr = p75 - p25
+    return {
+        "n": n,
+        "min": round(vals[0], 2),
+        "max": round(vals[-1], 2),
+        "median": round(med, 2),
+        "p25": round(p25, 2),
+        "p75": round(p75, 2),
+        "iqr": round(iqr, 2),
+        # Dispersion: IQR/median (robust). Higher = wider/less confident.
+        "dispersion": round(iqr / med, 3) if med else None,
+        # 1.5×IQR fence — anything outside is an outlier to vet.
+        "fence_low": round(p25 - 1.5 * iqr, 2),
+        "fence_high": round(p75 + 1.5 * iqr, 2),
+    }
+
+
+def _confidence(n: int, dist: dict) -> str:
+    if n < THIN_N:
+        return "thin"
+    disp = dist.get("dispersion")
+    if n >= GOOD_N and disp is not None and disp <= TIGHT_DISPERSION:
+        return "good"
+    return "partial"
+
+
+# ---------------------------------------------------------------------------
+# Ceiling vetting (price_high extremes vs the representative median)
+# ---------------------------------------------------------------------------
+
+def vet_ceiling(price_high_kept: list["Comp"], median: float) -> tuple[Optional["Comp"], bool, list[dict]]:
+    """Pick the highest surviving price_high comp as the ceiling candidate.
+
+    The unit/token/condition filters already ran on these, so a survivor is a
+    plausible same-item top sale. The MODULE does not judge "clearly
+    comparable" (that's the prompt's call) — it surfaces the highest survivor
+    as the ceiling candidate and, when that candidate exceeds OUTLIER_MULT ×
+    median, flags it `needs_vetting` so the prompt confirms it's the same
+    item/condition (else treats it as a bundle/mislisting and falls back to
+    the percentile). Every above-multiple survivor is returned in
+    `to_vet` — logged, never silently dropped.
+
+    Returns (ceiling_candidate, needs_vetting, to_vet).
+    """
+    to_vet: list[dict] = []
+    survivors = sorted(price_high_kept, key=lambda x: x.price, reverse=True)
+    for c in survivors:
+        if median and c.price > OUTLIER_MULT * median:
+            to_vet.append({
+                "title": c.title, "price": c.price, "url": c.url,
+                "ratio": round(c.price / median, 2) if median else None,
+                "reason": (f">{OUTLIER_MULT}× median (${median}) — confirm same "
+                           f"item/condition; else a bundle/mislisting/different model"),
+                "is_row0": c.is_row0,
+            })
+    ceiling = survivors[0] if survivors else None
+    needs_vetting = bool(ceiling and median and ceiling.price > OUTLIER_MULT * median)
+    return ceiling, needs_vetting, to_vet
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestration
+# ---------------------------------------------------------------------------
+
+def price_from_runs(
+    *,
+    best_match_json: Optional[Union[str, Path]] = None,
+    price_high_json: Optional[Union[str, Path]] = None,
+    unit_type: str = "single",
+    require_tokens: Optional[list[str]] = None,
+    condition: Optional[str] = None,
+    price_field: str = "sold",
+    pool_used_when_thin: bool = True,
+) -> dict:
+    """Run the full distribution-based pricing pipeline. Returns a report dict.
+
+    The report carries: run provenance, the filter log (every drop + reason),
+    the cleaned distribution stats, the vetted ceiling + excluded outliers,
+    the three tiers (each with its basis), and a confidence label. When the
+    cleaned representative set is thin (n < THIN_N) the report sets
+    tiers=None and confidence='thin' — the caller falls back to the
+    closest-comp method rather than trust percentiles off too few points.
+    """
+    if not best_match_json and not price_high_json:
+        raise ValueError("provide at least one of best_match_json / price_high_json")
+
+    runs: list[dict] = []
+    bm: list[Comp] = []
+    ph: list[Comp] = []
+    if best_match_json:
+        bm = _load_comps(best_match_json, "best_match", price_field)
+        runs.append({"sort": "best_match", **_run_meta(best_match_json)})
+    if price_high_json:
+        ph = _load_comps(price_high_json, "price_high", price_field)
+        runs.append({"sort": "price_high", **_run_meta(price_high_json)})
+
+    # If only price_high is available (observed: best_match can be empty while
+    # price_high returns data), use it as the representative set too — flagged.
+    rep = bm if bm else ph
+    rep_source = "best_match" if bm else "price_high"
+
+    all_for_filter = rep  # filters annotate the representative set
+    logs: list[FilterLog] = []
+    logs.append(filter_unit(all_for_filter, unit_type))
+    logs.append(filter_tokens(all_for_filter, require_tokens or []))
+    cond_log, cohort_used = filter_condition(all_for_filter, condition, pool_used_when_thin)
+    logs.append(cond_log)
+    logs.append(filter_exclusions(all_for_filter))
+
+    kept = [c for c in all_for_filter if not c.dropped]
+    row0_flags = [
+        {"title": c.title, "price": c.price, "url": c.url}
+        for c in (ph or rep) if c.is_row0
+    ]
+
+    dist = distribution([c.price for c in kept])
+    n = dist.get("n", 0)
+    conf = _confidence(n, dist)
+
+    report: dict[str, Any] = {
+        "runs": runs,
+        "unit_type": unit_type,
+        "require_tokens": require_tokens or [],
+        "condition_target": condition,
+        "condition_cohort_used": cohort_used,
+        "price_field": price_field,
+        "representative_source": rep_source,
+        "n_raw": len(rep),
+        "n_kept": n,
+        "filter_log": [
+            {"filter": lg.name, "removed_count": len(lg.removed),
+             "removed": [{"title": t, "price": p, "reason": r} for t, p, r in lg.removed]}
+            for lg in logs
+        ],
+        "row0_flags": row0_flags,
+        "distribution": dist,
+        "confidence": conf,
+        "kept_comps": [
+            {"title": c.title, "price": c.price, "url": c.url,
+             "condition": c.condition, "sold_date": c.sold_date,
+             "source": c.source}
+            for c in sorted(kept, key=lambda x: x.price)
+        ],
+    }
+
+    if conf == "thin":
+        report["tiers"] = None
+        report["thin_fallback"] = (
+            f"n={n} (< {THIN_N}) after filters — too few to trust percentiles. "
+            f"Fall back to the closest-comp / era-peer method; widen the bracket; "
+            f"flag rarity. Do NOT compute tiers off {n} point(s)."
+        )
+        return report
+
+    median = dist["median"]
+    # Vet the ceiling from the price_high set (filtered the same way), else the
+    # representative set's own high side.
+    ph_pool = ph if ph else rep
+    # Apply the same unit/token/condition gate to the ceiling candidates.
+    filter_unit(ph_pool, unit_type)
+    filter_tokens(ph_pool, require_tokens or [])
+    filter_condition(ph_pool, condition, pool_used_when_thin)
+    filter_exclusions(ph_pool)
+    ph_kept = [c for c in ph_pool if not c.dropped]
+    ceiling, needs_vetting, to_vet = vet_ceiling(ph_kept, median)
+
+    sorted_kept = sorted(c.price for c in kept)
+    p90 = percentile(sorted_kept, PUSH_HIGH_FALLBACK_PCT)
+    push_high = ceiling.price if ceiling else p90
+    if ceiling and needs_vetting:
+        ceiling_basis = (
+            f"ceiling candidate from price_high (VET — confirm same item/cond, "
+            f"else use ${round(p90, 2)}): \"{ceiling.title[:55]}\" ({ceiling.url})")
+    elif ceiling:
+        ceiling_basis = f"vetted ceiling comp from price_high: \"{ceiling.title[:55]}\" ({ceiling.url})"
+    else:
+        ceiling_basis = f"no price_high comp survived filters → {PUSH_HIGH_FALLBACK_PCT}th percentile fallback"
+    report["tiers"] = {
+        "conservative": {
+            "price": round(percentile(sorted_kept, CONSERVATIVE_PCT), 2),
+            "basis": f"{CONSERVATIVE_PCT}th percentile of like-condition sold (no-objection floor)",
+        },
+        "recommended": {
+            "price": round(percentile(sorted_kept, RECOMMENDED_PCT), 2),
+            "basis": "median of like-condition comparable sold (working price)",
+        },
+        "push_high": {
+            "price": round(push_high, 2),
+            "basis": ceiling_basis,
+            "needs_vetting": needs_vetting,
+            "fallback_if_unvetted": round(p90, 2) if needs_vetting else None,
+        },
+    }
+    report["ceiling_comp"] = (
+        {"title": ceiling.title, "price": ceiling.price, "url": ceiling.url,
+         "needs_vetting": needs_vetting}
+        if ceiling else None
+    )
+    report["ceiling_candidates_to_vet"] = to_vet
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Human-readable rendering
+# ---------------------------------------------------------------------------
+
+def render(report: dict) -> str:
+    """Render a report dict as the text block PRICE folds into price.txt."""
+    out: list[str] = []
+    d = report["distribution"]
+    runs = " + ".join(
+        f"{r['sort']}={r.get('run_id', '?')}" for r in report["runs"]
+    )
+    out.append(f"Distribution ({report['representative_source']} set, "
+               f"condition={report['condition_cohort_used']}, "
+               f"unit={report['unit_type']}):")
+    if d.get("n"):
+        out.append(f"  n={d['n']}  median=${d['median']}  "
+                   f"IQR=${d['p25']}–${d['p75']}  min/max=${d['min']}/${d['max']}  "
+                   f"dispersion={d.get('dispersion')}")
+    out.append(f"  raw={report['n_raw']} → kept={report['n_kept']}  "
+               f"runs: {runs}")
+    out.append(f"  Confidence: {report['confidence']}")
+
+    if report["confidence"] == "thin":
+        out.append("")
+        out.append("  THIN: " + report["thin_fallback"])
+        return "\n".join(out)
+
+    t = report["tiers"]
+    out.append("")
+    out.append("Tiers (distribution-based):")
+    out.append(f"  Conservative  ${t['conservative']['price']}  — {t['conservative']['basis']}")
+    out.append(f"  Recommended   ${t['recommended']['price']}  — {t['recommended']['basis']}")
+    out.append(f"  Push-high     ${t['push_high']['price']}  — {t['push_high']['basis']}")
+
+    if report.get("row0_flags"):
+        out.append("")
+        out.append("  Row-0 flag (price_high first row — often out of order; KEPT, judge it):")
+        for r in report["row0_flags"]:
+            out.append(f"    • ${r['price']} — \"{r['title'][:60]}\" — {r['url']}")
+
+    if report.get("ceiling_candidates_to_vet"):
+        out.append("")
+        out.append("  Ceiling candidates to VET (high vs median — confirm same item/cond):")
+        for o in report["ceiling_candidates_to_vet"]:
+            out.append(f"    • ${o['price']} (×{o.get('ratio')}) — \"{o['title'][:60]}\" "
+                       f"— {o['reason']} — {o['url']}")
+
+    dropped = [(lg["filter"], r) for lg in report["filter_log"] for r in lg["removed"]]
+    if dropped:
+        out.append("")
+        out.append(f"  Filters removed {len(dropped)} comp(s):")
+        for filt, r in dropped:
+            out.append(f"    • [{filt}] ${r['price']} — \"{r['title'][:50]}\" — {r['reason']}")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _cli() -> None:
+    import argparse
+    import sys
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:  # pragma: no cover
+        pass
+
+    ap = argparse.ArgumentParser(
+        description="Distribution-based PRICE tiers from saved Apify run JSON")
+    ap.add_argument("--best-match", help="Saved Apify run JSON (sort=best_match)")
+    ap.add_argument("--price-high", help="Saved Apify run JSON (sort=price_high)")
+    ap.add_argument("--unit", default="single",
+                    help="unit_type being priced (single/pair/set/lot/duplicate)")
+    ap.add_argument("--require-tokens", nargs="*", default=[],
+                    help="Core brand/type tokens that MUST appear in a comp title")
+    ap.add_argument("--condition", help="Item condition cohort to price within (e.g. used / new)")
+    ap.add_argument("--price-field", default="sold", choices=["sold", "total"],
+                    help="Price the stats run on: item sold price (default) or sold+shipping")
+    ap.add_argument("--no-pool-used", action="store_true",
+                    help="Do NOT pool Used grades when the strict cohort is thin")
+    ap.add_argument("--json", action="store_true", help="Emit the full report as JSON")
+    args = ap.parse_args()
+
+    if not args.best_match and not args.price_high:
+        ap.error("provide --best-match and/or --price-high")
+
+    try:
+        report = price_from_runs(
+            best_match_json=args.best_match,
+            price_high_json=args.price_high,
+            unit_type=args.unit,
+            require_tokens=args.require_tokens,
+            condition=args.condition,
+            price_field=args.price_field,
+            pool_used_when_thin=not args.no_pool_used,
+        )
+    except (ValueError, OSError, json.JSONDecodeError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        print(render(report))
+
+
+if __name__ == "__main__":
+    _cli()

--- a/prompts/identify.md
+++ b/prompts/identify.md
@@ -42,6 +42,50 @@ Marker discipline (per _shared confidence rule):
   mid-to-late"). No bracket.
 - `Unknown` — no real basis. Not a license to invent the priciest identity.
 
+## Maker / brand attribution (work it HARD — high leverage)
+
+Brand is the single highest-leverage field: a confirmed maker changes the
+PRICE tier, lets PRICE hunt an EXACT maker+pattern comp, sharpens the title
+SEO, and informs authenticity. So `Unknown` is a LAST RESORT after a real
+attribution attempt — never a lazy default. Run this pass on every item before
+settling Brand:
+
+1. **Hunt every mark.** Scan ALL surfaces for any mark — base/underside, foot
+   rim, back, lid underside, inside rim, handle/spout joins, seams, stickers/
+   labels. A mark, stamp, signature, hallmark, trademark, pattern/model number,
+   size code, or registry mark MUST be addressed (read it, decode it, or state
+   it is present-but-illegible). Never silently skip a visible mark.
+2. **Decode it by type.**
+   - **Silver/metal:** distinguish GENUINE assay hallmarks (e.g. lion passant =
+     English sterling, town + date letters) from a MAKER's mark, from EPNS / EP
+     / "quadruple plate" / "silver on copper" plate marks, from pattern + size
+     numbers, and from purely DECORATIVE pseudo-hallmarks. Each tells you
+     something: assay → solid silver + origin/date; trademark roundel + pattern
+     number → a specific plate maker (often catalog-matchable).
+   - **Ceramics/porcelain/pottery:** backstamp, impressed mark, painted mark,
+     pattern name/number; country-of-origin wording dates it ("England" vs
+     "Made in England", post-1891 "country" rule, "Occupied Japan", etc.).
+   - **Other:** logos, model numbers, union/care labels, date codes.
+3. **Research the mark.** Use reference knowledge and web search to MATCH a
+   partial or stylized mark to a maker (silver-mark encyclopedias, pottery-mark
+   references, pattern-number catalogs). A pattern/size number plus a trademark
+   shape is often enough to name the maker even when the legend is worn.
+4. **Commit at the right confidence.** If research yields a likely maker, write
+   `Brand: <maker> [BEST-CASE]` + a Scenario bracket + the exact resolution
+   step (the macro shot or test that would confirm). Only a legible, matched
+   mark earns a maker WITHOUT `[BEST-CASE]`. A genuinely markless piece, or a
+   purely decorative fantasy pseudo-hallmark with no maker name, is honestly
+   `Unknown` — say which it is.
+
+**Honesty guard (unchanged, non-negotiable):** trying harder is NOT license to
+invent. Do not promote a guess to a stated maker, and do not read a maker into
+fantasy/pseudo marks to inflate value. The bar for a named maker is a real,
+decodable signal; the bar for `[BEST-CASE]` is a mark whose style/elements
+genuinely point to one. When the mark is present but you cannot resolve it, set
+`needs_followup_photo: yes` with the SPECIFIC shot (a raking-light macro of the
+mark) and note the downstream value impact — an unread mark is the most
+expensive thing to leave on the table.
+
 ## Output format
 
     SHOOT SUMMARY
@@ -61,8 +105,10 @@ Then one block per item, `--- Item <N> ---`, fields in this order:
 - **Quantity** — integer. 1 for single, 2 for pair, piece count for
   set/lot, copy count for duplicate.
 - **Category** — general bucket (bike, magazine, chess set). Uncapped.
-- **Brand** — visible mark → write it; inferred → `value [BEST-CASE]`;
-  none → `Unknown`. ≤65.
+- **Brand** — run the maker-attribution pass above FIRST. Legible/matched mark
+  → write the maker; mark whose style points to a likely maker → `value
+  [BEST-CASE]` + bracket; genuinely markless or fantasy-marked → `Unknown`
+  (last resort, after the pass). ≤65.
 - **Type** — specific descriptor. Same marker convention. ≤65.
 - **Era** — date/range. `[ASSUMPTION]` if inferred from styling. ≤65.
 - **Collectability** — collectable / vintage / antique / modern /

--- a/prompts/identify.md
+++ b/prompts/identify.md
@@ -86,6 +86,35 @@ genuinely point to one. When the mark is present but you cannot resolve it, set
 mark) and note the downstream value impact — an unread mark is the most
 expensive thing to leave on the table.
 
+5. **Visual second opinion (Google Lens) — for markless / can't-place pieces.**
+   When the piece is markless (or the mark is illegible) AND it's plausibly
+   collectible/branded, get an independent read before settling on `Unknown`.
+   Run [`lib/lens_id.py`](../lib/lens_id.py) on the single **best photo** (the
+   clearest full view, in focus, minimal background):
+
+       python lib/lens_id.py <shoot-dir>/<best-photo>.jpg
+
+   It hosts the photo at a temp public URL, runs an Apify Google Lens actor, and
+   prints a **verdict + a maker tally counted across distinct visual matches**
+   (plus match titles + Lens's AI guess). Weigh it — never obey it:
+   - **`leans <Maker>`** (recurs across several matches AND fits what you see) →
+     `Brand: <Maker> [BEST-CASE]` + scenario bracket, note "Lens-corroborated".
+   - **`split across makers` / `no single maker — widely-copied`** → stay
+     `Unbranded`/`Unknown`; the names are later keywords, NOT a claim. This is
+     the common, honest result — do NOT promote a single stray Lens mention into
+     an attribution (that is the same failure as inventing a maker from a
+     fantasy mark). Lens is evidence about the *design*, not proof of *this*
+     piece's maker.
+   - Record a `Lens cross-check: <verdict>` line on the item and reconcile it
+     with your own visual call in one line (agree / conflict / refined).
+
+   **Gate (cost + privacy):** RUN only when attribution is genuinely uncertain
+   AND would move value/SEO. SKIP for legibly-marked items, obvious low-value
+   commodities, and lots of generics — it sends the photo to Google via a
+   temporary public host (auto-expiring) and spends ~$0.02–0.05 of Apify credit.
+   Needs direct egress (tmpfiles + api.apify.com); in a blocked sandbox, run with
+   egress on, or host via the lib and drive the actor through the Apify MCP.
+
 ## Output format
 
     SHOOT SUMMARY

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -34,6 +34,38 @@ discount to sum-of-parts — single-item comps ×N are Tier C reference
 only); `duplicate` → price one piece (CURATE scales). All quoted prices
 are per-listing-unit except `duplicate` (per-piece).
 
+## Silver — rarity double-check, exact comp, push HIGH (category override)
+
+Silver gets special handling. In practice our silver has been UNDER-priced and
+sells immediately — money left on the table. Whenever IDENTIFY tags an item as
+silver in ANY form — sterling / .925, coin silver, .800/.835/.900 continental,
+hallmarked silver, silver-on-copper, or silverplate — apply ALL of the following
+and OVERRIDE the plain distribution defaults:
+
+1. **Rarity double-check (mandatory).** Before settling a price, explicitly work
+   the maker / hallmark / pattern / assay + (for solid silver) the weight. Ask:
+   is THIS piece scarce — a sought maker (Tiffany, Georg Jensen, Gorham, Jensen,
+   Kirk, etc.), a rare or discontinued pattern, an early assay date, an unusual
+   form, a matched pair/set, or heavy gauge? For solid silver compute the **melt
+   floor** (troy-oz × spot × purity) — price NEVER drops below melt. Record a
+   one-line `Rarity:` verdict in price.txt.
+2. **Hunt the EXACT comp harder.** Do NOT settle for an era-peer on silver. Run
+   the full query ladder, and if Stage B (Apify) is thin, ESCALATE to Stage C
+   (Chrome eBay-sold) rather than falling back — an exact maker+pattern+form comp
+   anchors the ceiling. Silver is identifiable; an exact match usually exists if
+   you dig.
+3. **Push HIGH by default.** For silver the provisional working / list price is
+   the **Push-high (vetted ceiling)** tier, NOT the median — with Best Offer ON
+   and auto-decline at the Recommended/median (the DRAFT Best Offer gate does
+   this automatically once list > Recommended). List at the top of the supported
+   range and let Best Offer capture the market; "sold immediately" means we
+   listed too low. Still bounded by VETTED comps — push to the honest ceiling,
+   never invent value above it (plate / silver-on-copper ceilings stay modest;
+   solid silver never below melt).
+
+State `SILVER: push-high strategy applied` in price.txt so the choice is visible
+at the REVIEW gate.
+
 ## The exact-match hunt (run before any era-peer fallback)
 
 For each item, hunt the exact match, escalating only as each stage dries

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -8,6 +8,17 @@ Find what the same or nearly-identical item actually sold for, establish
 a defensible price, and surface category-specific selling risks. Reads
 IDENTIFY records.
 
+**Pricing model (v2 — distribution-based):** the goal is no longer "pick
+the strongest comp." It is **characterize the cleaned sold distribution,
+then place tiers on it.** Stage B pulls two complementary views of the sold
+market (`best_match` = the representative body; `price_high` = the ceiling),
+[`lib/price_stats.py`](../lib/price_stats.py) does the deterministic
+filtering + statistics, and the tiers trace to a sample size + percentiles
+rather than a hand-picked comp. Full rationale:
+[docs/price-strategy-v2.md](../docs/price-strategy-v2.md). The exact-match
+hunt below still runs — an exact comp, when one exists, short-circuits the
+distribution and anchors Recommended directly.
+
 ## Autonomy (Goal: dig for the exact match, don't ask permission to look)
 
 No step in PRICE gates or stops. v2 made you propose queries and wait,
@@ -39,54 +50,104 @@ stage is autonomous — PRICE never stops to ask.
    web + marketplaces. Tag `[A — WebSearch]`. **Log each usable hit to
    `<shoot-dir>/comps.csv` as stage A** (see "Saved comp artifacts").
 
-3. **Stage B — Apify eBay sold** (the default direct-eBay comp source; no
-   gate). Backend Actor `automation-lab/ebay-sold-scraper` — it **pins a US
-   residential proxy** so eBay returns USD natively, and returns structured
-   comps with per-item URLs, sold dates, condition, listing type / bid
-   count, and seller stats. Tag `[B — Apify]`. ~$0.10/run. **Use whichever
-   execution path your environment supports — try them in this order:**
+3. **Stage B — Apify eBay sold (DUAL QUERY — the v2 core).** The default
+   direct-eBay comp source; no gate. Backend Actor
+   `automation-lab/ebay-sold-scraper` — it **pins a US residential proxy** so
+   eBay returns USD natively, and returns structured comps with per-item
+   URLs, sold dates, condition, listing type / bid count, and seller stats.
+   Tag `[B — Apify]`. ~$0.20/item (two runs). **Run the SAME query twice,
+   once per sort** — this is what makes distribution pricing possible:
 
+   - **`best_match` run** — the representative body of the distribution
+     (`sort:"best_match"`, `maxListingsPerSearch:30`, `maxSearchPages:2`).
+   - **`price_high` run** — the ceiling/outlier set, sorted descending
+     (`sort:"price_high"`, `maxListingsPerSearch:20`, `maxSearchPages:2`).
    - **Path 1 — Apify MCP tool (preferred; works even with no sandbox
      egress).** If an Apify MCP connector is available (e.g. in a Cowork
-     tab), call the actor `automation-lab/ebay-sold-scraper` through that
-     tool with input `{searchQueries:["<query>"], maxListingsPerSearch:30,
-     maxSearchPages:3, sort:"price_high", listingType:"all"}`. It returns
-     the dataset items (fields: `soldPrice`, `soldDate`, `title`, `url`,
-     `condition`, `listingType`, `bidsCount`, `sellerName`,
-     `sellerFeedbackCount`/`Percent`, `shippingCost`). Record the **run id**
-     the tool reports. MCP calls are brokered outside the code sandbox, so
-     this works where direct `api.apify.com` egress is blocked.
+     tab), call `automation-lab/ebay-sold-scraper` through it once per sort
+     with input `{searchQueries:["<query>"], maxListingsPerSearch:<30|20>,
+     maxSearchPages:2, sort:"<best_match|price_high>", listingType:"all"}`.
+     Returned fields: `soldPrice`, `soldDate`, `title`, `url`, `condition`,
+     `listingType`, `bidsCount`, `sellerName`, `sellerFeedbackCount`/
+     `Percent`, `shippingCost`. Record **each run id**. MCP calls are
+     brokered outside the code sandbox, so this works where direct
+     `api.apify.com` egress is blocked. Write each run's items to
+     `<shoot-dir>/apify_<sort>_<runId>.json` in the
+     [`save_run_json`](../lib/apify_ebay.py) shape (a `comps` list of objects
+     with the snake_case fields `sold_price`, `total_price`, `title`, `url`,
+     `condition`, `sold_date`, `listing_type`, `bids_count`,
+     `seller_feedback_score` — `price_stats.py` reads exactly this).
    - **Path 2 — stdlib CLI (when you have a shell + egress to
-     api.apify.com).** Run `python lib/apify_ebay.py "<query>" --save-dir
-     <shoot-dir>` (no pip — standard library only). It saves the raw results
-     JSON beside `price.txt` and prints `Apify run: <id>` + `Saved results:
-     <path>`. Capture both.
-   - **Map + validate (either path):** fields → comps (same shape); drop
-     single-bid / >2× median outliers to Tier C. The CLI auto-runs the
-     charm-price currency check; **on the MCP path you must eyeball it** —
-     genuine USD eBay prices cluster on .99/.95/.00/.50; if they don't,
-     suspect a currency leak and prefer Stage C. Never trust a
-     `currency`/`USD` label; the price pattern is what matters. (The
-     US-proxy actor makes leaks unlikely — the old caffein.dev actor leaked
-     BRL/CZK at ~5× mislabeled USD, which is why we switched.)
-   - **Save the results (both paths).** The CLI auto-saves the run JSON
-     (`--save-dir <shoot-dir>` to place it beside `price.txt`). On the MCP
-     path, write the returned items to `<shoot-dir>/apify_<runId>.json`
-     yourself. This is the audit trail + cache for the comps.
-   - **Proof-of-run is mandatory.** Record the **Apify run id** (from the
-     MCP result or the CLI's `Apify run:` line) AND the saved JSON path in
-     the Research log — both are verifiable. **Never report Stage B as "ran"
-     without a run id.**
-   - Still drop outliers; if Stage B yields <3 usable comps or dispersion
-     disagrees badly with Stage A, treat as LOW confidence → Stage C.
+     api.apify.com).** Run it once per sort, saving each JSON beside
+     `price.txt`, and pass `--sku`/`--title` so each run gets a Console
+     status message:
+     `python lib/apify_ebay.py "<query>" --sort best_match --max 30 --pages 2 --save-dir <shoot-dir> --sku <sku> --title "<listing title>"`
+     and
+     `python lib/apify_ebay.py "<query>" --sort price_high --max 20 --pages 2 --save-dir <shoot-dir> --sku <sku> --title "<listing title>"`.
+     Each prints `Apify run: <id>` + `Saved results: <path>` — capture both
+     for each run. The CLI auto-runs the charm-price currency check.
+     - **`--sku`/`--title`** label the run in the Apify Console runs list
+       (status-message column) as `[best] <sku> <title[:10]>` /
+       `[sold_highest] <sku> <title[:10]>`, so past runs are diagnosable
+       there without opening each one (posted on completion; best-effort,
+       never blocks). The SKU is the deterministic 8-hex hash from
+       `list_edit.py`; if the item isn't recorded yet (PRICE runs before
+       DRAFT), pass the working title alone or the shoot-folder name as
+       `--sku`. Both are OPTIONAL — with neither, the run is still labeled by
+       its query (`[best] <query>`), so no run is anonymous. (No status is
+       posted on the MCP path — the connector only sends the actor input.)
+   - **Currency sanity (both paths):** genuine USD eBay prices cluster on
+     .99/.95/.00/.50. The CLI validates automatically; **on the MCP path
+     eyeball it** — if prices don't cluster on charm endings, suspect a
+     currency leak and prefer Stage C. Never trust a `currency`/`USD` label;
+     the price pattern is what matters. (The US-proxy actor makes leaks
+     unlikely — the old caffein.dev actor leaked BRL/CZK at ~5× mislabeled
+     USD, which is why we switched.)
+   - **Then run the distribution engine** on the two saved JSONs (use the
+     actual `Saved results:` path from each run — the CLI names them
+     `apify_run_<ts>_<runId>.json`; the MCP path uses the
+     `apify_<sort>_<runId>.json` names above):
+
+         python lib/price_stats.py \
+           --best-match <best_match run JSON> \
+           --price-high <price_high run JSON> \
+           --unit <unit_type> --condition <new|used> \
+           --require-tokens <brand/type tokens from IDENTIFY>
+
+     It applies the normalize-before-stats filters (row-0 flag, unit match,
+     same-item core tokens, condition cohort, single-bid/low-feedback
+     exclusions — each drop logged), computes `n / median / IQR / dispersion`
+     off the cleaned `best_match` set, vets the `price_high` ceiling, and
+     emits the three tiers + a confidence label. Fold its text block into
+     `price.txt` and adopt its tiers (see "Distribution-based tiers" below).
+     **No shell?** Do the same filtering + percentiles by hand from the saved
+     JSONs, using the rules in [docs/price-strategy-v2.md](../docs/price-strategy-v2.md)
+     and the constants in `price_stats.py`; show your work.
+   - **Proof-of-run is mandatory.** Record **both Apify run ids** AND both
+     saved JSON paths in the Research log. **Never report Stage B as "ran"
+     without run ids.**
    - **If NEITHER path is available** (no Apify MCP tool AND no
      shell/egress — e.g. a sandbox whose proxy 403s `api.apify.com`):
      record `B — UNAVAILABLE: <reason>` in the Research log and fall through
      to Stage C. Do NOT silently skip B.
 
-4. **If no exact match yet, broaden and re-run A+B:** drop the
-   least-load-bearing keyword (5→3 words), then try a synonym for Type.
-   Iterate 2–3 formulations.
+4. **Thin results → broaden the query (query ladder, NOT a new draft).** The
+   comp *search query* is internal to PRICE; broadening it never changes the
+   `draft.md`, SEO title, SKU, or ledger record. Build queries from
+   IDENTIFY's short Brand / Type / Era / Category fields as a specificity
+   ladder:
+   - **L1 (specific):** Brand + Type + Era [+ one distinguishing word].
+   - **L2 (broader):** Type + material; drop era + modifiers.
+   - **L3 (broadest):** category noun (+ material).
+
+   Run the dual query (`best_match` + `price_high`) at L1. If the combined
+   unique comps that survive `price_stats` filters are **below 3**, step down
+   (L2, then L3) and re-run, until enough comps or the ladder is exhausted.
+   Log each formulation in the Hunt line. Note: `price_high` often returns
+   data when `best_match` is empty (observed: mask-red `best_match`=0,
+   `price_high`=25) — an empty `best_match` doesn't block, since
+   `price_stats` uses `price_high` as the representative set when `best_match`
+   is empty (flagged in its output).
 
 5. **Stage C — Chrome → eBay sold (OPTIONAL — low-confidence only).** The
    browser browse path is no longer routine. Invoke it ONLY when
@@ -122,8 +183,10 @@ commit to it.
 
 ## Apify notes (the Stage B backend)
 
-Apify is the default Stage B source and runs without a gate. The backend
-Actor is `automation-lab/ebay-sold-scraper` (configurable via
+Apify is the default Stage B source and runs without a gate. v2 issues
+**two runs per item** — `best_match` (representative) and `price_high`
+(ceiling) — and feeds both to [`lib/price_stats.py`](../lib/price_stats.py).
+The backend Actor is `automation-lab/ebay-sold-scraper` (configurable via
 `apify.ebay_actor`), chosen because it pins a **US residential proxy** —
 so eBay serves USD natively and the foreign-currency leak that sank the
 previous actor doesn't occur. The CLI/wrapper validates every run with the
@@ -147,8 +210,10 @@ is unset.
 
 The user reviews the raw research, so each stage persists its comps:
 
-- **Stage B (Apify)** → JSON (auto-saved; `--save-dir <shoot-dir>` puts it
-  beside `price.txt`; MCP path: write items to `<shoot-dir>/apify_<runId>.json`).
+- **Stage B (Apify)** → **two** JSONs, one per sort (auto-saved; `--save-dir
+  <shoot-dir>` puts them beside `price.txt`; MCP path: write items to
+  `<shoot-dir>/apify_best_match_<runId>.json` and
+  `<shoot-dir>/apify_price_high_<runId>.json`). `price_stats.py` reads both.
 - **Stages A (WebSearch) and C (Chrome)** → rows in **`<shoot-dir>/comps.csv`**,
   the single spreadsheet the user opens to review every comp across sources.
   Append each usable comp with `lib/comps_csv.py`:
@@ -198,19 +263,21 @@ Don't confuse with the comp-quality "Tier A/B/C" further down.)
 
     Research log — Item <N>
       A · WebSearch : RAN — query "<q>" — <n> hits — <one-line finding> — logged to comps.csv
-      B · Apify     : RAN via <MCP|CLI> — query "<q>" — run <runId> — <n> comps — USD-validated (charm <x>%) — saved <path>.json
+      B · Apify     : RAN via <MCP|CLI> — query "<q>" — best_match run <id> (<n>) + price_high run <id> (<n>) — USD-validated (charm <x>%) — saved 2 JSONs — price_stats n_kept=<n>, conf=<good|partial|thin>
                       [ALT] UNAVAILABLE — <no Apify MCP tool AND no shell/egress | api.apify.com egress blocked (sandbox proxy) | no token | CurrencyLeakError>
-                      (run id comes from the MCP tool result or the CLI's `Apify run:` line; no `pip install` needed)
-      C · Chrome    : NOT TRIGGERED — confidence OK (<n> usable comps from A+B)
-                      [ALT] RAN — <low-confidence trigger> — <n> rows — logged to comps.csv
+                      (run ids come from each sort's MCP result / CLI `Apify run:` line; no `pip install` needed)
+      C · Chrome    : NOT TRIGGERED — confidence OK (price_stats conf good/partial)
+                      [ALT] RAN — <low-confidence trigger: conf=thin or dispersion too wide> — <n> rows — logged to comps.csv
                       [ALT] UNAVAILABLE — <no browser/Chrome MCP in this environment>
 
 Hard rules for the log:
 - **A and B must show `RAN` on every item.** If either is `SKIPPED`/
   `UNAVAILABLE`, that is a flagged problem — also append a line to
   `NEEDS_REVIEW.md` so the user sees research was incomplete.
-- **B's `RAN` line MUST carry a run id** (proof it hit the Apify backend).
-  No run id ⇒ it did not run ⇒ write `UNAVAILABLE — <reason>`, never `RAN`.
+- **B's `RAN` line MUST carry both run ids** (best_match + price_high — proof
+  it hit the Apify backend). No run id ⇒ it did not run ⇒ write
+  `UNAVAILABLE — <reason>`, never `RAN`. (If a thin/empty market means only
+  one sort returned data, note which and why.)
 - **C must be accounted for** — `NOT TRIGGERED` + why, `RAN` + trigger, or
   `UNAVAILABLE` + why. Never omit the C line.
 - The log records what you DID; the tiers below record what you CONCLUDED.
@@ -226,7 +293,15 @@ Per item:
     === PRICE — Item <N> (<short name>) ===
     Comps refreshed: YYYY-MM-DD   ·   Data quality: good / partial / thin
     Research log:  (the A/B/C block above — REQUIRED)
-    Hunt: <one line — formulations tried, sources, exact-match yes/no>
+    Hunt: <one line — ladder levels + formulations tried, sources, exact-match yes/no>
+    Distribution: n=<k> median=$<m> IQR=$<p25>–$<p75> ceiling=$<c> dispersion=<d>
+                  (best_match run <id> + price_high run <id>)
+
+The **Distribution** line is REQUIRED whenever Stage B ran — it is the
+`price_stats.py` output folded in, and it is the proof the tiers came from a
+sample, not a vibe. Also fold in `price_stats`'s row-0 flag, ceiling
+candidates to vet, and the per-filter drop log (so the user sees what was
+excluded and why). If Stage B was UNAVAILABLE / thin, say so here instead.
 
 For each scenario (or just "primary" when no bracket — most items):
 
@@ -234,13 +309,15 @@ For each scenario (or just "primary" when no bracket — most items):
     Tier A — direct match (anchors price):
       • $<price> — "<title>"  ·  Sold <date>, <condition>
                   Match: <one line>   URL: <url>
-    Tier B — branded/mint ceiling:
+    Tier B — branded/mint ceiling (the vetted price_high comp):
       • $<price> — "<title>"  ·  Ceiling note: <why ceiling not anchor>   URL: <url>
     Tier C — excluded:
-      • $<price> — "<title>"  ·  Reason: <single bid / <50 fb seller / >2× median / asking price>   URL: <url>
+      • $<price> — "<title>"  ·  Reason: <single bid / <50 fb seller / wrong unit / wrong condition / >2.5× median / asking price>   URL: <url>
 
-Mark comps >12 months old `[STALE]`. Every Tier C needs a specific
-reason.
+Mark comps >12 months old `[STALE]`. Every Tier C needs a specific reason.
+When Stage B ran, the Tier-C exclusions are exactly `price_stats`'s
+per-filter drop log (unit / token / condition / single-bid / low-feedback) —
+transcribe them rather than re-judging.
 
 ### Comp URLs — verify these yourself (MANDATORY, ends every item)
 
@@ -259,15 +336,36 @@ URL so the list is scannable on its own. Required on every item.
 If NO exact match exists, say so on the "Exact / near-exact" line
 ("none found") and still list the closest era-peers + the sold-search URL.
 
-### Three tiers (always)
+### Distribution-based tiers (always)
 
-- **Conservative** — no-objection floor; closest era-peer / category-mid.
-- **Recommended (max supported)** — the headline; strongest comp (exact
-  match if the hunt found one). **In headless flow this becomes the
-  provisional working price** (SOFT gate — logged to NEEDS_REVIEW, not a
+The three tiers come from `price_stats.py` on the cleaned `best_match`
+distribution. Adopt its numbers; don't re-derive by eye.
+
+- **Conservative** — **25th percentile** of the like-condition cleaned set
+  (no-objection floor).
+- **Recommended (max supported)** — **median** of the like-condition cleaned
+  set (the typical sold price, not the ceiling). **In headless flow this is
+  the provisional working price** (SOFT gate — logged to NEEDS_REVIEW, not a
   stop).
-- **Push-high** — defensible ceiling; highest comparable + the stated
-  premium reason.
+- **Push-high** — the **vetted `price_high` ceiling**: the highest surviving
+  `price_high` comp that you confirm is the same item/condition. If
+  `price_stats` flagged it `needs_vetting` (>2.5× median) and it does NOT
+  vet out as comparable (it's a bundle/mislisting/different model), drop to
+  the **90th-percentile fallback** it prints. State which you used.
+
+**Exact-match short-circuit (keep):** if the hunt found ≥1 *true* exact-match
+comp (same item, same condition), anchor **Recommended** on the median of
+those exact matches instead of the distribution median, and say so. Keep the
+distribution as context. The exact comp beats the distribution — commit to it
+(per _shared).
+
+**Thin market (`price_stats` confidence = `thin`, n<3):** do NOT use
+percentiles. Fall back to today's closest-comp / era-peer method — anchor on
+the nearest comp/era-peer, widen the bracket, flag rarity (see "No-exact-
+match case"). The three tiers still apply, anchored on the era-peer.
+
+**Best Offer gate (unchanged):** enable Best Offer if list > Recommended;
+set auto-decline at Recommended.
 
 ### No-exact-match case
 

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -37,10 +37,14 @@ are per-listing-unit except `duplicate` (per-piece).
 ## Silver — rarity double-check, exact comp, push HIGH (category override)
 
 Silver gets special handling. In practice our silver has been UNDER-priced and
-sells immediately — money left on the table. Whenever IDENTIFY tags an item as
-silver in ANY form — sterling / .925, coin silver, .800/.835/.900 continental,
-hallmarked silver, silver-on-copper, or silverplate — apply ALL of the following
-and OVERRIDE the plain distribution defaults:
+sells immediately — money left on the table. The trigger is the word "silver" in
+ANY form, **regardless of precious-metal content** — base-metal "silver" counts
+too: sterling / .925, coin silver, .800/.835/.900 continental, hallmarked silver,
+silver-on-copper, silverplate / EPNS, AND **nickel silver / German silver /
+alpaca / silver-tone / "silver" plate over base metal**. Do NOT exempt a piece
+just because it isn't precious — push high on all of it. Whenever IDENTIFY tags
+an item as silver in any of these senses, apply ALL of the following and OVERRIDE
+the plain distribution defaults:
 
 1. **Rarity double-check (mandatory).** Before settling a price, explicitly work
    the maker / hallmark / pattern / assay + (for solid silver) the weight. Ask:


### PR DESCRIPTION
## Summary

Implements **PRICE strategy v2 (distribution-based pricing)** and fixes a **legacy-SKU migration bug** surfaced while validating it end-to-end. Two logical commits:

1. `feat(price)` — distribution-based pricing v2 (dual Apify + `price_stats.py`)
2. `fix(list_edit)` — migrate legacy url-style SKUs + clear orphaned listing ids

## 1 · PRICE strategy v2

Moves PRICE from *"pick the strongest comp"* to *"characterize the cleaned sold distribution, then place tiers on it."*

- **`lib/price_stats.py`** (new, stdlib-only) — normalize-before-stats filters (row-0 flag, unit match, same-item tokens, condition cohort, single-bid / low-feedback exclusions — each drop logged), `n / median / IQR / dispersion` off the cleaned `best_match` set, `price_high` ceiling vetting, three tiers + confidence. CLI + `--json`; policy as named constants.
- **`lib/apify_ebay.py`** — dual-sort support + `save_run_json` (the JSON shape `price_stats` reads) + charm-price currency check.
- **`prompts/price.md`** — Stage B is a **dual query** per item (`best_match` + `price_high`), both fed to `price_stats`; query-ladder broaden-back; Research log requires **both** run ids; required Distribution line.
- **`docs/price-strategy-v2.md`** — PROPOSAL → IMPLEMENTED; records shipped policy defaults + the size-cohort lesson below.

## 2 · Legacy-SKU self-heal

Drafts carried over from an older app version stamped a "url-style" SKU (e.g. `ebaybiz-sand-dollars`); `_sku_for` reused it blindly, so a stale slug could reach eBay as the inventory key and a stale listing id could be acted on.

- `_sku_for` now reuses a stored SKU **only if canonical 8-hex**; a legacy slug is recomputed.
- `normalize_draft_identity()` migrates a legacy SKU → canonical and clears the now-orphaned `ebay_offer_id` / `ebay_listing_id` / `published_at`.
- Wired into `record_draft()` + `create_or_update_listing()` (auto-heal before anything hits eBay); `validate_draft_for_sync()` flags it; new `--normalize` CLI.

## Validation

- `price_stats` doctests pass (7/7); `save_run_json` ↔ `price_stats` shape contract verified for **both** Apify paths.
- **Full pipeline ran live** on a lot of 18 white keyhole sand dollars: IDENTIFY → PRICE v2 (dual Apify via MCP, runs `w9MCX3Lxeh3Uf4L9t` + `Nf7lIwE9XNX50QJrm`) → CURATE → INVESTIGATE → DRAFT → REVIEW → publish. The SKU bug was found, fixed, and re-validated (legacy slug migrated to canonical `a353c238`, listing republished).

## Notes for reviewers

- **Policy defaults** (Conservative=25th / Recommended=median / Push-high=vetted-ceiling) are confirmed; tunable as constants in `price_stats.py`.
- **Size-cohort lesson** (documented in the v2 doc): the broad median can *under-price* size-/grade-driven categories because size isn't a filterable token — the exact-match short-circuit is the workaround, with a `↻ revisit` note suggesting a future size-bucket extractor.
- **Coverage gap (not a blocker):** only the Apify **MCP path** was exercised live; the stdlib **CLI path** (`apify_ebay.py` → `api.apify.com`) couldn't run here (sandbox egress blocked) — its output shape is statically verified.
- Working data (`to-id/`, `listings_ledger.csv`) is **gitignored** and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
