### PR TITLE
Run v3 pipeline on parts-washer shoot (through REVIEW gate)

### DIFF
--- a/samples/parts-washer-3p5gal/NEEDS_REVIEW.md
+++ b/samples/parts-washer-3p5gal/NEEDS_REVIEW.md
@@ -1,0 +1,9 @@
+# NEEDS_REVIEW — parts-washer-3p5gal
+
+[IDENTIFY] item 1 — Brand left "Unknown" (no brand on spec plate); form/specs match Chicago Electric / Harbor Freight 35740 family. Confirm brand if you know it (adds SEO/title value).
+[IDENTIFY] item 1 — needs_followup_photo: full exterior + lid + cord/switch shot, and the flexible nozzle/spout, would confirm completeness; powered shot would confirm the pump works.
+[PRICE] item 1 — adopted Recommended $35 as provisional working price; NO exact sold comp (Apify Stage B + Chrome Stage C both UNAVAILABLE in this environment — research incomplete on direct-eBay sold data). Confirm/refine price before publish.
+[PRICE] item 1 — Apify (Stage B) and Chrome (Stage C) both UNAVAILABLE: only WebSearch active-asking comps gathered. Re-run with Apify/browser access for true sold comps.
+[PRICE] item 1 — shipping economics: ~15-20 lb unit ships ~$18-28; free-shipping default erodes a ~$35 sale. Recommend LOCAL PICKUP or CALCULATED shipping (buyer pays) instead.
+[INVESTIGATE] item 1 — pump functional status NOT photographed; committed to FOR_PARTS_OR_NOT_WORKING (untested, per condition rubric). Upgrade grade + price if you can confirm it powers/pumps.
+[INVESTIGATE] item 1 — completeness (lid, fusible link, flexible nozzle, power cord) not visible in photos; listing claims only what's shown (tank + pump). Confirm what's included.

--- a/samples/parts-washer-3p5gal/comps.csv
+++ b/samples/parts-washer-3p5gal/comps.csv
@@ -1,0 +1,6 @@
+captured_at,item,stage,query,price,title,sold_date,condition,listing_type,url,note
+2026-06-10,1,A,3.5 gallon parts washer benchtop electric pump used,,3.5 Gallon Electric Benchtop Parts Washer Solvent Pump Portable Cleaner,,New,active,https://www.ebay.com/itm/335466397200,active asking — new import unit; ceiling context only
+2026-06-10,1,A,3.5 gallon parts washer benchtop electric pump,97.00,3.5 Gallon Portable Parts Washer Electric Solvent Pump (4x $24.25),,New,active,https://www.ebay.com/p/571551760,active asking ~$97 new; ceiling not anchor (new vs used/untested)
+2026-06-10,1,A,3.5 gallon automotive parts washer new,29.99,3.5 Gallon Automotive Parts Washer Cleaner Electric Solvent Pump New,,New,active,https://www.ebay.com/itm/175636482472,active asking — low-end new import; new floor
+2026-06-10,1,A,vintage chicago electric 3.5 gallon parts washer used,,Vintage Chicago Electric Power Tools Portable Parts Washer 3.5 Gallon,,Used,active,https://www.ebay.com/itm/295778799035,nearest-form used unit (Chicago Electric/HF 35740 family); no captured sold price
+2026-06-10,1,A,harbor freight chicago 3.5 gallon parts washer 35740,,Harbor Freight Chicago 3.5 Gallon Bench Top Parts Washer 35740,,Used,catalog,https://www.ebay.com/p/1842326524,eBay catalog page for the matching model 35740; spec source

--- a/samples/parts-washer-3p5gal/draft.md
+++ b/samples/parts-washer-3p5gal/draft.md
@@ -1,0 +1,148 @@
+---
+template_version: v1
+
+meta:
+  item_id:              "parts-washer-3p5gal"
+  shoot_dir:            "samples/parts-washer-3p5gal"
+  drafted_at:           "2026-06-10T00:00:00Z"
+  ebay_offer_id:        null
+  ebay_inventory_sku: "016fec0d"
+  last_synced:          null
+  notes: >
+    Title = INVESTIGATE claim #1 [74/80]. Condition FOR_PARTS_OR_NOT_WORKING
+    (condition-rubric tie-break: electric pump never shown powered -> untested ->
+    lower grade; passed up USED_ACCEPTABLE). Working price $35 = PRICE Recommended
+    tier (provisional; no exact sold comp, Apify+Chrome unavailable). Best Offer
+    gate: price ($35) == Recommended ($35), NOT above it -> Best Offer DISABLED,
+    both amounts null. Weight: item ~15.5-20 lb (matches 35740-family spec 15.5 lb);
+    packed 22 lb (rounded up). Dims packed ~20x17x12 in (item 17-3/8x14-1/4x8-3/4 +
+    padding). Service UPSGround (>15 lb). Shipping set CALCULATED (buyer pays) not
+    free: ~15-20 lb steel unit ships ~$18-28, would erase a $35 sale (see PRICE
+    shipping flag + NEEDS_REVIEW). Photo order: hero set to 02 (clear interior+pump)
+    because 01 is motion-blurred; 01 placed last. country_of_origin "China" canonical.
+    No brand, working, or completeness claim — none defensible from photos.
+
+title: "3.5 Gallon Benchtop Parts Washer w/ Electric Solvent Pump - Untested AS-IS"
+
+category_id:            ""
+category_path:          "Business & Industrial > Automotive Tools & Supplies > Shop Equipment & Supplies > Parts Washers"
+
+condition: "FOR_PARTS_OR_NOT_WORKING"
+
+condition_description: "Used. Sold as-is for parts or repair. The electric recirculating pump was NOT tested - it is not shown running and is not guaranteed to work. The steel tank is dirty inside and out and will need cleaning; the basin has sediment and debris. Red paint has scuffs and scratches throughout. No through-rust seen. The pump unit and its supply hose are present (sitting in the basin in photos). The lid, fusible link, flexible nozzle/spigot, and power cord/switch are NOT clearly shown and are not guaranteed present or intact. Ships empty - no solvent or cleaning fluid included. Please review all photos; condition is as pictured."
+
+item_specifics:
+  type:                       "Parts Washer"
+  brand:                      "Unbranded"
+  upc:                        ""
+  collection:                 ""
+  subject:                    ""
+  material:                   "Steel"
+  character_family:           ""
+  occasion:                   ""
+  color:                      "Red"
+  country_of_origin:          "China"
+  pattern:                    ""
+  theme:                      ""
+  style:                      ""
+  size:                       ""
+  department:                 ""
+  time_period_manufactured:   ""
+  finish:                     ""
+  extra:
+    Capacity: "3.5 Gallon"
+    Power Source: "Electric (Corded)"
+    Type of Tool: "Benchtop Parts Washer"
+
+format: "FIXED_PRICE"
+price: "35.00"
+cost_of_goods: null
+quantity: 1
+best_offer:
+  enabled: false
+  auto_decline_amount: null
+  auto_accept_amount: null
+
+shipping:
+  weight:
+    major_lb: 22
+    minor_oz: 0
+  package_in:
+    length: 20
+    width:  17
+    depth:  12
+  free_shipping: false
+  domestic_shipping_type: "CALCULATED"
+  primary_service: "UPSGround"
+  handling_time_days: 1
+  item_location_zip: ""
+
+photos:
+  - "02-IMG_0854.jpeg"
+  - "04-IMG_0856.jpeg"
+  - "03-IMG_0855.jpeg"
+  - "01-IMG_0853.jpeg"
+
+returns_policy_id: ""
+
+promoted:
+  general:  false
+  priority: false
+
+_field_constraints:
+  title:                                    { required: true, max_len: 80 }
+  quantity:                                 { required: true, max_len: 5,  numeric: true }
+  price:                                    { required: true, max_len: 13, numeric: true }
+  cost_of_goods:                            { max_len: 13, numeric: true }
+  best_offer.auto_decline_amount:           { max_len: 13, numeric: true }
+  best_offer.auto_accept_amount:            { max_len: 13, numeric: true }
+  condition_description:                    { max_len: 1000 }
+  item_specifics.type:                      { required: true, max_len: 65 }
+  item_specifics.brand:                     { max_len: 65 }
+  item_specifics.upc:                       { max_len: 20 }
+  item_specifics.collection:                { max_len: 65 }
+  item_specifics.subject:                   { max_len: 65 }
+  item_specifics.material:                  { max_len: 65 }
+  item_specifics.character_family:          { max_len: 65 }
+  item_specifics.occasion:                  { max_len: 65 }
+  item_specifics.color:                     { max_len: 65 }
+  item_specifics.country_of_origin:         { max_len: 65, lookup_only: true }
+  item_specifics.pattern:                   { max_len: 65 }
+  item_specifics.theme:                     { max_len: 65 }
+  item_specifics.style:                     { max_len: 65 }
+  item_specifics.size:                      { max_len: 65 }
+  item_specifics.department:                { max_len: 65, lookup_only: true }
+  item_specifics.time_period_manufactured:  { max_len: 65 }
+  item_specifics.finish:                    { max_len: 65 }
+  shipping.weight.major_lb:                 { max_len: 3, numeric: true }
+  shipping.weight.minor_oz:                 { max_len: 2, numeric: true }
+  shipping.package_in.length:               { max_len: 5, numeric: true }
+  shipping.package_in.width:                { max_len: 5, numeric: true }
+  shipping.package_in.depth:                { max_len: 5, numeric: true }
+---
+
+# Description
+
+Used 3.5-gallon benchtop parts washer with an electric recirculating solvent pump — a compact shop unit for cleaning small automotive and mechanical parts. Sold as-is, untested, for parts or repair.
+
+## What's Included
+
+- One red steel 3.5-gallon benchtop parts washer tank
+- Electric recirculating solvent pump unit with supply hose (present, untested)
+- Spec plate reads: "3.5 Gallon Parts Washer, Made in China, No. 002798"
+- Ships EMPTY — no solvent or cleaning fluid is included
+- Lid, fusible link, flexible nozzle/spigot, and power cord are NOT confirmed in photos — do not assume included
+
+## Condition
+
+This is a used, working-shop tool sold honestly and as-is — it will need cleaning and the pump has not been tested.
+
+- Electric pump is UNTESTED — not shown running, no working guarantee; sold for parts or repair.
+- Tank is dirty inside and out, with sediment and debris in the basin — needs cleaning.
+- Red enamel paint is scuffed and scratched throughout; no through-rust seen.
+- Pump unit and its supply hose are present (shown sitting in the basin).
+- Lid, fusible link, flexible nozzle, and power cord/switch are not clearly pictured and are not guaranteed present or intact.
+
+## About this item
+
+A common, no-frills import-style benchtop parts washer (the red-steel, fusible-link, recirculating-pump design). A low-cost candidate for a hobbyist or shop willing to clean it up and test/replace the pump. Please review every photo — what you see is what ships.

--- a/samples/parts-washer-3p5gal/identify.txt
+++ b/samples/parts-washer-3p5gal/identify.txt
@@ -1,0 +1,58 @@
+SHOOT SUMMARY
+Photos processed: 4
+Shoot mode:       single (auto — one item, multiple angles/details)
+Distinct items:   1
+Photo caveats:    Photo 1 (01-IMG_0853) is heavily motion-blurred — usable
+                  only for color/material context, not detail.
+Needs user confirmation:
+  none (single item, no grouping question)
+
+--- Item 1 ---
+Unit type:     single
+Quantity:      1
+Category:      Parts washer (automotive / shop cleaning equipment)
+Brand:         Unknown
+               (no brand mark visible; spec plate reads only "3.5 GALLON
+               PARTS WASHER / MADE IN CHINA / NO. 002798". Form factor —
+               red steel benchtop tank, fusible-link lid, recirculating
+               pump — matches the import 3-1/2 gal washers sold by Harbor
+               Freight / Central Machinery and similar [BEST-CASE], but
+               nothing in the photos confirms a seller brand.)
+Type:          3.5 gallon benchtop parts washer w/ electric recirculating pump
+Era:           Unknown (no date visible) [ASSUMPTION] modern import, post-2000
+Collectability: modern (utility tool, not collectable)
+Condition:
+  - Steel tank exterior: red enamel with scattered scratches, scuffs and
+    grime; light surface dirt throughout (photo 2, 4). No through-rust seen.
+  - Tank interior: heavy dirt/sediment and debris in the basin floor; dried
+    residue and what look like seed/grit fragments (photo 2). Used, unwashed.
+  - Pump/motor unit: grey-and-red recirculating pump sitting loose in the
+    basin, threaded fluid outlet visible, black supply hose attached; printed
+    spec label on motor body (photo 2). Not seen mounted/operating.
+  - Mounting bracket on right interior wall: 4 studs with nuts, light surface
+    rust on hardware (photo 2).
+  - Cannot assess: pump/motor function (electrical — never shown powered;
+    treat as untested), presence/condition of the flexible nozzle/spout,
+    presence of the lid, fusible link, and any power cord/switch — none of
+    these are clearly shown.
+Estimated weight: ~15-20 lb (heavy tier 15-25 lb) — small steel benchtop
+                  tank + pump, empty of fluid. [ASSUMPTION] from typical
+                  3.5 gal import washers.
+Estimated dimensions: ~19 x 14 x 10 in (L x W x H) tank [ASSUMPTION] — typical
+                  3.5 gal benchtop footprint; not measurable from photos.
+Distinguishing marks:
+  - Spec plate (photo 4): "3.5 GALLON / PARTS WASHER / MADE IN CHINA /
+    NO. 002798".
+  - Warning decal (photo 3): "WARNING POSSIBLE FLAMMABLE LIQUID — NO
+    SMOKING. Solvent fumes may be toxic. Use only recommended cleaning
+    solvents. Use only in a well-ventilated area. Never use volatile
+    solvents such as gasoline, kerosene or diesel. CAUTION — Use safe
+    protective measures at all times. Always wear safety glasses and rubber
+    gloves. Avoid solvent contact with skin and eyes. Fusible link must be
+    intact at all times." (Fusible-link warning confirms a heat-release
+    self-closing lid design — standard safety feature on solvent washers.)
+  - Color: red tank, grey/red pump.
+needs_followup_photo: yes — full exterior shot showing whole tank + lid +
+                  cord/switch; a clear shot of the flexible nozzle/spout if
+                  present; pump powered/running if testable. These confirm
+                  completeness and working status (both currently unknown).

--- a/samples/parts-washer-3p5gal/investigate.txt
+++ b/samples/parts-washer-3p5gal/investigate.txt
@@ -1,0 +1,93 @@
+=== INVESTIGATION — 3.5 Gallon Benchtop Parts Washer ===
+Photos: 4 (motion-blurred overview, basin+pump interior, warning decal, spec plate)
+
+## Summary
+A used red-steel 3.5-gallon benchtop parts washer with an electric recirculating
+solvent pump. The spec plate reads only "3.5 GALLON PARTS WASHER / MADE IN CHINA /
+NO. 002798" — no seller brand is shown. It's dirty inside and out, the pump sits
+loose in the basin, and the pump was never shown powered, so it must go out as
+untested / for parts or repair. Honest call: a cheap, common import washer sold
+as-is.
+
+## Directly observable
+- Red enamel steel tank/basin with a recirculating pump unit inside (photo 2).
+- Pump/motor is grey-and-red with a threaded fluid outlet and a black supply hose
+  attached; it carries its own printed spec label (photo 2).
+- Interior mounting bracket on the right wall: four studs with nuts (photo 2).
+- Spec plate: "3.5 GALLON / PARTS WASHER / MADE IN CHINA / NO. 002798" (photo 4).
+- Safety decal warns of flammable-liquid use and states "Fusible link must be
+  intact at all times" (photo 3) — i.e. a heat-release self-closing lid design.
+- Heavy dirt, sediment and debris in the basin; scuffs/scratches on the red paint
+  (photos 2, 4). No through-rust visible.
+
+## Safe baseline (true regardless of scenario)
+A used, dirty 3.5-gallon steel benchtop parts washer of Chinese manufacture, with
+an electric recirculating solvent pump present. Cosmetically worn (scratched paint,
+soiled basin). Functional status of the pump is unknown — it was not shown running —
+so it is sold strictly as untested / for parts or repair, with no working claim.
+
+## Scenarios (most likely -> less likely, evidence-ranked)
+### Scenario 1 — MOST LIKELY
+Generic import 3.5-gal benchtop parts washer (Chicago Electric / Harbor Freight
+35740 family or an identical clone)  ·  Evidence: red steel benchtop tank, fusible-
+link flammable decal, recirculating pump, "3.5 GALLON / MADE IN CHINA" plate — all
+match that model family's form and specs (17-3/8x14-1/4x8-3/4 in, ~15.5 lb).
+Probability: high
+### Scenario 2 — Possible
+A differently-branded but mechanically identical import washer  ·  Evidence: no
+brand mark on the plate, so the specific seller brand is unconfirmed; many vendors
+sell the same OEM unit.  Probability: moderate
+
+## Confident assessment
+Most defensibly a used, untested generic 3.5-gallon import benchtop parts washer
+with electric pump. List it on the model-agnostic facts on the plate ("3.5 Gallon,
+Made in China") plus what's visible (steel tank, electric recirculating pump),
+graded FOR PARTS / UNTESTED. The one observable that would shift this is a photo of
+the pump running (would allow a working claim + higher price) or a brand mark
+(would allow a brand in the title). Both are logged to NEEDS_REVIEW, not asked.
+
+## NOT defensible from these photos
+- That the pump/motor works — never shown powered. Untested only.
+- Any seller brand (Chicago Electric, Harbor Freight, etc.) — no brand on the plate.
+- Completeness: the lid, fusible link, flexible nozzle/spigot, and power cord/switch
+  are not clearly shown — cannot claim they are present or intact.
+- Capacity beyond the "3.5 GALLON" printed on the plate (no measurement taken).
+- Any model number beyond the plate's serial "NO. 002798".
+
+## Listing-safe claims (DRAFT consumes)
+Title claims — strongest first, each <=80:
+  - 3.5 Gallon Benchtop Parts Washer w/ Electric Solvent Pump - Untested AS-IS [74/80]
+  - Red Steel 3.5 Gal Parts Washer Electric Recirculating Pump - For Parts/Repair [78/80]
+  - 3.5 Gallon Auto Parts Washer Cleaner Electric Pump - Made in China - Untested [78/80]
+Description claims — self-contained sentences:
+  - Used 3.5-gallon benchtop parts washer with an electric recirculating solvent pump.
+  - Red enamel steel tank; spec plate reads "3.5 Gallon Parts Washer, Made in China".
+  - The pump was not tested and is sold as-is for parts or repair.
+  - Tank is dirty inside and out and will need cleaning; paint is scuffed/scratched.
+  - Safety decal notes flammable-solvent use and a fusible-link self-closing lid.
+  - Ships empty — no solvent or cleaning fluid is included.
+Item specifics — canonical short value, each <=65:
+  - Brand: Unbranded [9/65]
+  - Type: Parts Washer [13/65]
+  - Material: Steel [5/65]
+  - Capacity: 3.5 Gallon [10/65]
+  - Power Source: Electric (Corded) [17/65]
+  - Country/Region of Manufacture: China [5/65]
+  - Color: Red [3/65]
+Condition: Used; dirty, cosmetically worn, electric pump untested -> FOR_PARTS_OR_NOT_WORKING.
+
+Pre-emit check: every title <=80 (74/78/78), every specific <=65 — OK.
+
+## Open questions (would strengthen claims)
+- Does the pump power on and circulate fluid? (Resolves working-status -> could lift
+  grade to USED_GOOD and price toward the $50 ceiling.)
+- Is there a seller brand anywhere on the unit not in these photos? (Adds a title brand.)
+- Are the lid, fusible link, flexible nozzle, and power cord present/intact?
+  (Confirms completeness — currently unclaimable.)
+
+## Listing approach
+Lead the title with the directly-defensible spec ("3.5 Gallon Benchtop Parts Washer
+w/ Electric Solvent Pump") and the honest condition flag ("Untested / AS-IS"). Use
+the body for the plate text and the flammable-solvent/fusible-link safety note, and
+to state plainly it ships empty and the pump is untested. Do NOT include a brand,
+a working claim, or a completeness claim — none are supported by the photos.

--- a/samples/parts-washer-3p5gal/price.txt
+++ b/samples/parts-washer-3p5gal/price.txt
@@ -1,0 +1,74 @@
+Max supported price: $50   [anchored on: era-peer / matching-model new+used asking, no exact sold comp captured]
+
+=== PRICE — Item 1 (3.5 gal benchtop parts washer) ===
+Comps refreshed: 2026-06-10   ·   Data quality: thin (active asking prices only; no sold comp captured)
+Research log:
+  A · WebSearch : RAN — queries "3.5 gallon parts washer benchtop electric pump used price ebay",
+                  "Harbor Freight 3-1/2 gallon parts washer price", "3.5 gallon parts washer used sold
+                  worth", "Chicago Electric 35740 ... specifications" — 4 searches — found the matching
+                  model (Chicago Electric/HF 35740, specs 17-3/8x14-1/4x8-3/4 in, 15.5 lb, .7A 110V,
+                  50 GPH) + active asking prices; no per-item SOLD price exposed — logged to comps.csv
+  B · Apify     : UNAVAILABLE — no Apify MCP tool AND no APIFY_TOKEN / shell egress to api.apify.com in
+                  this environment. (Flagged to NEEDS_REVIEW — no direct-eBay sold comps gathered.)
+  C · Chrome    : UNAVAILABLE — no browser/Chrome MCP in this environment.
+Hunt: 4 WebSearch formulations; identified exact matching model family (Chicago Electric/HF 35740 clone);
+      NO exact SOLD comp captured (Apify+Chrome unavailable). Anchoring on era-peer asking-price band.
+
+Query: 3.5 gallon benchtop parts washer electric pump (used/new)   Source(s): A
+Tier A — direct match (anchors price):
+  • (none — no SOLD comp captured; Apify/Chrome unavailable this run)
+Tier B — branded/new ceiling:
+  • $97.00 — "3.5 Gallon Portable Parts Washer Electric Solvent Pump" (4x $24.25)
+              Ceiling note: NEW retail asking; our unit is used/untested/dirty — well below this.
+              URL: https://www.ebay.com/p/571551760
+  • $29.99 — "3.5 Gallon Automotive Parts Washer Cleaner Electric Solvent Pump New"
+              Ceiling note: low-end NEW import asking; sets the new-unit floor.
+              URL: https://www.ebay.com/itm/175636482472
+Tier C — excluded:
+  • Vintage Chicago Electric 3.5 Gal (used) — Reason: matching-form used comp but NO price captured;
+              reference only.   URL: https://www.ebay.com/itm/295778799035
+
+### Comp URLs — verify these yourself
+  Comp URLs — Item 1 (open to verify):
+    Exact / near-exact match:
+      • none found with a captured sold price — closest is the same model family (used):
+        • Vintage Chicago Electric Portable Parts Washer 3.5 Gallon — https://www.ebay.com/itm/295778799035
+        • Harbor Freight Chicago 35740 (catalog/spec match) — https://www.ebay.com/p/1842326524
+    Ceiling / context (new asking):
+      • $97 — "3.5 Gal Portable Parts Washer Electric Pump" — https://www.ebay.com/p/571551760
+      • $29.99 — "3.5 Gal Automotive Parts Washer New" — https://www.ebay.com/itm/175636482472
+      • "3.5 Gal Electric Benchtop Parts Washer" — https://www.ebay.com/itm/335466397200
+    All sold results (eBay search): https://www.ebay.com/sch/i.html?_nkw=3.5+gallon+parts+washer&LH_Sold=1&LH_Complete=1&_sop=3
+
+### Three tiers
+- Conservative: $20  — no-objection floor for a dirty, untested, possibly-incomplete used unit;
+  local-pickup / for-parts buyer.
+- Recommended (max supported): $35  — used import washer with pump present, sold as untested/as-is;
+  sits well under the ~$30-97 new band, fair for a working-condition-unknown unit. ← provisional working price.
+- Push-high: $50  — defensible ceiling IF the pump is confirmed working and unit is complete (lid +
+  nozzle present); premium reason = functional + clean. Not supported by current photos.
+
+### No-exact-match case
+No exact SOLD comp was captured this run (Apify + Chrome both unavailable; WebSearch surfaces active
+asking prices, not sold). Anchored on the closest era-peer: the same model family (Chicago Electric/HF
+35740) sells NEW ~$30-97; used/untested units trade well below that. The matching-model used listing
+(295778799035) is the nearest peer but exposed no price. Rarity signal: none — common import tool, steady
+supply. Suggest the user save the eBay SOLD search above as a watch to firm the anchor before publish.
+
+### Research notes
+- Authenticity & fakes — N/A (utility tool, no counterfeit market).
+- Restrictions & legal — Ships domestically fine; tank is empty (no solvent shipped). No hazmat as listed
+  empty/clean. Note in listing it ships WITHOUT solvent. Heavy-ish (15-20 lb) → real shipping cost.
+- Scams & buyer issues — "didn't work" / INAD returns on untested electrical items. Protection: list
+  condition as FOR PARTS / UNTESTED explicitly, "sold as-is", no returns or as-is disclosure up front.
+- Authenticity Guarantee — N/A (not a covered category at this value).
+- Disclosure — REQUIRED: pump untested (never shown powered), unit is dirty/needs cleaning, completeness
+  unconfirmed (lid / flexible nozzle / cord not shown in photos). State all three up front.
+
+### Shipping economics flag
+At ~15-20 lb a 3.5 gal steel washer ships ~$18-28 domestically — a large fraction of a ~$35 item.
+Free-shipping default erodes most of the margin. Recommend LOCAL PICKUP or CALCULATED shipping (buyer
+pays) instead of free flat-rate. Flagged to NEEDS_REVIEW.
+
+Working price (provisional): $35 (Recommended tier). Final price is the user's call at publish time;
+recorded here for review.

--- a/samples/parts-washer-3p5gal/review_card.md
+++ b/samples/parts-washer-3p5gal/review_card.md
@@ -1,0 +1,48 @@
+━━ REVIEW: 3.5 Gallon Benchtop Parts Washer (sku 016fec0d · ledger DRAFTED) ━━
+
+Title [74/80]: 3.5 Gallon Benchtop Parts Washer w/ Electric Solvent Pump - Untested AS-IS
+Price:        $35.00  (FIXED_PRICE · provisional working price = PRICE Recommended tier)
+Best Offer:   OFF  (price == Recommended tier; no negotiation headroom)
+Condition:    FOR_PARTS_OR_NOT_WORKING  (electric pump never shown powered → untested; lower-grade tie-break)
+Quantity:     1  (single)
+Photos:       4  (hero = 02 clear interior+pump; 01 motion-blurred, placed last)
+
+Preflight (assembled by hand — API unavailable, not the --review command):
+  · condition  : FOR_PARTS_OR_NOT_WORKING — accepted by Parts Washers category (verify at sync)
+  · shipping   : CALCULATED via UPSGround, packed 22 lb / 20×17×12 in — NOT free
+                 (15-20 lb steel unit ships ~$18-28; free shipping would erase a $35 sale)
+  · insurance  : not flagged (item < $100)
+  · category   : Business & Industrial > Automotive Tools > Shop Equipment > Parts Washers (category_id blank — eBay suggests at list)
+
+Comps (open to verify — NO exact sold comp captured; Apify + Chrome unavailable this run):
+  Near-exact (same model family, used):
+    • Vintage Chicago Electric Portable Parts Washer 3.5 Gal — https://www.ebay.com/itm/295778799035
+    • Harbor Freight Chicago 35740 (spec/model match) — https://www.ebay.com/p/1842326524
+  Ceiling / context (NEW asking):
+    • $97 — 3.5 Gal Portable Parts Washer Electric Pump — https://www.ebay.com/p/571551760
+    • $29.99 — 3.5 Gal Automotive Parts Washer New — https://www.ebay.com/itm/175636482472
+  All sold results: https://www.ebay.com/sch/i.html?_nkw=3.5+gallon+parts+washer&LH_Sold=1&LH_Complete=1&_sop=3
+  Tiers: Conservative $20 · Recommended $35 · Push-high $50 (only if pump confirmed working + complete)
+
+Condition detail (verbatim — every flagged defect, not softened):
+  • Electric pump UNTESTED — not shown running, no working guarantee; sold for parts or repair.
+  • Tank dirty inside and out; sediment and debris in the basin — needs cleaning.
+  • Red enamel paint scuffed and scratched throughout; no through-rust seen.
+  • Pump unit + supply hose present (shown sitting in the basin).
+  • Lid, fusible link, flexible nozzle/spigot, power cord/switch NOT clearly pictured — not guaranteed present/intact.
+  • Ships EMPTY — no solvent or cleaning fluid included.
+
+⚠ Needs review / manual intervention (from NEEDS_REVIEW.md):
+  1. Brand left "Unknown" — form/specs match Chicago Electric / HF 35740 family; confirm if known (title SEO).
+  2. PRICE $35 is provisional — NO exact sold comp; Apify (Stage B) + Chrome (Stage C) both UNAVAILABLE here.
+     Research incomplete on direct-eBay sold data. Confirm/refine price before publish.
+  3. Shipping: chose CALCULATED + local-pickup-friendly over free (weight-to-value). Confirm preference.
+  4. Pump working status unknown → graded FOR PARTS. A powered-on test photo could lift grade + price (~$50).
+  5. Completeness (lid/nozzle/cord/fusible link) unconfirmed — listing claims only the tank + pump shown.
+  6. Follow-up photos suggested: full exterior + lid + cord, the flexible nozzle, pump running.
+
+→ Approve publishes this LIVE at $35.00. On your explicit approval I would run:
+      python lib/list_edit.py --list samples/parts-washer-3p5gal --confirm
+  NOTE: publishing also requires eBay API credentials (~/.ebaybiz/config.yaml), which are NOT set in this
+  environment — so even on approval, a live publish cannot complete here until credentials are configured
+  (see lib/SETUP_EBAY_API.md). The draft, comps, and card are complete and ready.


### PR DESCRIPTION
## What

Ran the v3 headless pipeline (`RUN.md`) in **`list` mode** on a 4-photo single-item shoot — a used **3.5 gallon benchtop parts washer**. Carried it IDENTIFY → PRICE → INVESTIGATE → DRAFT → REVIEW, stopping at the HARD publish gate (no publish — the run awaits explicit approval, and eBay creds aren't configured here anyway).

Artifacts land in `samples/parts-washer-3p5gal/` (photos are gitignored as heavy binaries):

| File | Phase |
|---|---|
| `identify.txt` | IDENTIFY |
| `price.txt` + `comps.csv` | PRICE |
| `investigate.txt` | INVESTIGATE |
| `draft.md` | DRAFT (SKU `016fec0d` stamped via `--record`) |
| `review_card.md` | REVIEW (decision card) |
| `NEEDS_REVIEW.md` | SOFT-gate deferrals |

## Headline calls

- **No brand** on the spec plate ("3.5 GALLON PARTS WASHER / MADE IN CHINA / NO. 002798"); form + specs match the **Chicago Electric / Harbor Freight 35740** family (17⅜×14¼×8¾ in, 15.5 lb, 0.7A 110V, 50 GPH). Listed brand-agnostic.
- **Condition `FOR_PARTS_OR_NOT_WORKING`** — electric pump never shown powered (condition-rubric lower-grade tie-break); dirty basin, scuffed paint, completeness unconfirmed.
- **Price $35** provisional (Recommended tier). **No exact sold comp**: Apify (Stage B) and Chrome (Stage C) both `UNAVAILABLE` in this environment, so only WebSearch active-asking comps were gathered — flagged in `NEEDS_REVIEW.md`.
- **Best Offer off** (price == Recommended, no headroom). **Calculated shipping** instead of free (15–20 lb steel unit ships ~$18–28, would erase a $35 sale).

## Gate status

Stopped at the REVIEW gate. Nothing published. Publishing additionally requires eBay API credentials (`~/.ebaybiz/config.yaml`, see `lib/SETUP_EBAY_API.md`), which are not set here.

https://claude.ai/code/session_01Eb9X2eXBQoHZUiSjK7Mxtn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb9X2eXBQoHZUiSjK7Mxtn)_