### PR TITLE
perf(runs): cut per-run time and tokens

### DIFF
--- a/lib/apify_ebay.py
+++ b/lib/apify_ebay.py
@@ -747,8 +747,19 @@ def _cli() -> None:
     parser = argparse.ArgumentParser(
         description="Apify eBay sold-listings search (automation-lab/ebay-sold-scraper)"
     )
-    parser.add_argument("query", nargs="+",
-                        help="One or more search keywords (each runs a separate search)")
+    parser.add_argument("query", nargs="*",
+                        help="One or more search keywords (each runs a separate search). "
+                             "Optional with --ingest.")
+    parser.add_argument("--ingest", metavar="RAW_JSON",
+                        help="Skip the live Actor call: read raw scraper items from a "
+                             "JSON file (the Apify MCP tool's result — a dict with an "
+                             "'items' list, or a bare list of items) and write the same "
+                             "saved-run JSON that a live run produces (normalized comps "
+                             "with total_price + charm/currency check). Use on the MCP "
+                             "path so no JSON is hand-authored.")
+    parser.add_argument("--run-id", dest="run_id",
+                        help="Run id to stamp on an --ingest save (default: the file's "
+                             "runId/run_id, else 'ingested').")
     parser.add_argument("--max", type=int, default=DEFAULT_MAX_LISTINGS, dest="max_listings",
                         help=f"Max results per keyword (default: {DEFAULT_MAX_LISTINGS})")
     parser.add_argument("--pages", type=int, default=DEFAULT_MAX_PAGES,
@@ -782,6 +793,50 @@ def _cli() -> None:
     parser.add_argument("--json", action="store_true",
                         help="Output raw JSON instead of human-readable list")
     args = parser.parse_args()
+
+    # --- Ingest path: normalize raw MCP items into a saved run JSON, no live call ---
+    if args.ingest:
+        try:
+            raw = json.loads(Path(args.ingest).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"ERROR: cannot read --ingest file: {e}", file=sys.stderr)
+            sys.exit(1)
+        if isinstance(raw, dict):
+            items = raw.get("items") or raw.get("raw_items") or raw.get("comps") or []
+            run_id = args.run_id or raw.get("runId") or raw.get("run_id") or "ingested"
+            file_queries = raw.get("queries") or raw.get("searchQueries")
+        else:
+            items = raw
+            run_id = args.run_id or "ingested"
+            file_queries = None
+        actor = args.actor or "automation-lab/ebay-sold-scraper"
+        queries = args.query or file_queries or []
+        comps = [c for c in (_map_to_comp_record(it, None) for it in items) if c]
+        if not comps:
+            print(f"ERROR: no usable comps in {args.ingest} "
+                  f"(expected a dict with an 'items' list, or a bare list of scraper items)",
+                  file=sys.stderr)
+            sys.exit(1)
+        prices = [c.sold_price for c in comps if c.sold_price]
+        charm = _charm_share(prices) if prices else None
+        leak = bool(len(prices) >= _MIN_SAMPLES_FOR_LEAK_CHECK
+                    and charm is not None and charm < _CHARM_LEAK_THRESHOLD)
+        if args.no_save:
+            print(json.dumps([_comp_to_dict(c) for c in comps], indent=2, default=str))
+            return
+        path = save_run_json(run_id, actor, queries, items, comps, save_dir=args.save_dir)
+        print(f"Ingested {len(comps)} comp(s) from {args.ingest} (no live Apify call)")
+        print(f"Apify run: {run_id}  (actor {actor})  — ingested")
+        print(f"Saved results: {path}")
+        if charm is not None:
+            note = ("  -> CURRENCY LEAK SUSPECTED: prices don't cluster on USD charm "
+                    "endings; verify or prefer Chrome (Stage C)" if leak
+                    else "  (USD charm pattern OK)")
+            print(f"Charm-price share: {charm:.0%}{note}")
+        return
+
+    if not args.query:
+        parser.error("a search query is required unless --ingest is given")
 
     try:
         comps = search_ebay_sold(

--- a/prompts/identify.md
+++ b/prompts/identify.md
@@ -9,6 +9,18 @@ Enumerate the distinct items across a shoot's photos and write one
 structured record each. Speculative-upward: surface best-case identity so
 the user can see upside, with the verification path attached.
 
+## Photo intake (read the decisive set, not every frame)
+
+Full-res photos are the biggest token cost in a shoot, so read the frames that
+decide the record — not every angle. A single-item shoot is usually decided by
+4–6: the **hero / full-form** shot, the **underside / backstamp / mark** shot(s),
+**1–2 detail** shots (condition, a distinguishing feature), and any **ruler /
+scale** frame. Skip near-duplicate angles — they add cost, not evidence.
+Coverage still wins where it matters: on wide/group shoots read enough to
+enumerate every item, and never skip a frame that shows a mark you must read
+(see "Hunt every mark"). Glance at the filename list to pick; fully read only
+what you need.
+
 ## Shoot mode
 
 One mode per shoot. Source: CLI flag → profile default → auto-detect.

--- a/prompts/investigate.md
+++ b/prompts/investigate.md
@@ -22,6 +22,10 @@ isn't visible, treat it as nonexistent. No "the back probably…", no
 hidden-side speculation. Suspected-but-unphotographed evidence goes to
 Open questions, not into a claim.
 
+Re-read only the decisive frames (hero + mark + the defects you'll claim), per
+IDENTIFY's "Photo intake" rule — don't re-open every angle you already saw at
+IDENTIFY. IDENTIFY's record tells you which frames matter.
+
 ## Unit-type phrasing
 
 Thread `unit_type` into every title/description: `single` singular noun;

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -120,85 +120,31 @@ stage is autonomous — PRICE never stops to ask.
    `<shoot-dir>/comps.csv` as stage A** (see "Saved comp artifacts").
 
 3. **Stage B — Apify eBay sold (DUAL QUERY — the v2 core).** The default
-   direct-eBay comp source; no gate. Backend Actor
-   `automation-lab/ebay-sold-scraper` — it **pins a US residential proxy** so
-   eBay returns USD natively, and returns structured comps with per-item
-   URLs, sold dates, condition, listing type / bid count, and seller stats.
-   Tag `[B — Apify]`. ~$0.20/item (two runs). **Run the SAME query twice,
-   once per sort** — this is what makes distribution pricing possible:
-
-   - **`best_match` run** — the representative body of the distribution
-     (`sort:"best_match"`, `maxListingsPerSearch:30`, `maxSearchPages:2`).
-   - **`price_high` run** — the ceiling/outlier set, sorted descending
-     (`sort:"price_high"`, `maxListingsPerSearch:20`, `maxSearchPages:2`).
-   - **Path 1 — Apify MCP tool (preferred; works even with no sandbox
-     egress).** If an Apify MCP connector is available (e.g. in a Cowork
-     tab), call `automation-lab/ebay-sold-scraper` through it once per sort
-     with input `{searchQueries:["<query>"], maxListingsPerSearch:<30|20>,
-     maxSearchPages:2, sort:"<best_match|price_high>", listingType:"all"}`.
-     Returned fields: `soldPrice`, `soldDate`, `title`, `url`, `condition`,
-     `listingType`, `bidsCount`, `sellerName`, `sellerFeedbackCount`/
-     `Percent`, `shippingCost`. Record **each run id**. MCP calls are
-     brokered outside the code sandbox, so this works where direct
-     `api.apify.com` egress is blocked. Write each run's items to
-     `<shoot-dir>/apify_<sort>_<runId>.json` in the
-     [`save_run_json`](../lib/apify_ebay.py) shape (a `comps` list of objects
-     with the snake_case fields `sold_price`, `total_price`, `title`, `url`,
-     `condition`, `sold_date`, `listing_type`, `bids_count`,
-     `seller_feedback_score` — `price_stats.py` reads exactly this).
-   - **Path 2 — stdlib CLI (when you have a shell + egress to
-     api.apify.com).** Run it once per sort, saving each JSON beside
-     `price.txt`, and pass `--sku`/`--title` so each run gets a Console
-     status message:
-     `python lib/apify_ebay.py "<query>" --sort best_match --max 30 --pages 2 --save-dir <shoot-dir> --sku <sku> --title "<listing title>"`
-     and
-     `python lib/apify_ebay.py "<query>" --sort price_high --max 20 --pages 2 --save-dir <shoot-dir> --sku <sku> --title "<listing title>"`.
-     Each prints `Apify run: <id>` + `Saved results: <path>` — capture both
-     for each run. The CLI auto-runs the charm-price currency check.
-     - **`--sku`/`--title`** label the run in the Apify Console runs list
-       (status-message column) as `[best] <sku> <title>` /
-       `[sold_highest] <sku> <title>` (full title — the Console auto-truncates
-       it in the runs-list column), so past runs are diagnosable
-       there without opening each one (posted on completion; best-effort,
-       never blocks). The SKU is the deterministic 8-hex hash from
-       `list_edit.py`; if the item isn't recorded yet (PRICE runs before
-       DRAFT), pass the working title alone or the shoot-folder name as
-       `--sku`. Both are OPTIONAL — with neither, the run is still labeled by
-       its query (`[best] <query>`), so no run is anonymous. (No status is
-       posted on the MCP path — the connector only sends the actor input.)
-   - **Currency sanity (both paths):** genuine USD eBay prices cluster on
-     .99/.95/.00/.50. The CLI validates automatically; **on the MCP path
-     eyeball it** — if prices don't cluster on charm endings, suspect a
-     currency leak and prefer Stage C. Never trust a `currency`/`USD` label;
-     the price pattern is what matters. (The US-proxy actor makes leaks
-     unlikely — the old caffein.dev actor leaked BRL/CZK at ~5× mislabeled
-     USD, which is why we switched.)
-   - **Then run the distribution engine** on the two saved JSONs (use the
-     actual `Saved results:` path from each run — the CLI names them
-     `apify_run_<ts>_<runId>.json`; the MCP path uses the
-     `apify_<sort>_<runId>.json` names above):
-
-         python lib/price_stats.py \
-           --best-match <best_match run JSON> \
-           --price-high <price_high run JSON> \
-           --unit <unit_type> --condition <new|used> \
-           --require-tokens <brand/type tokens from IDENTIFY> \
-           --price-field total   # DELIVERED basis (sold+shipping) for a free-ship
-                                 # listing — our default; use 'sold' only if the
-                                 # listing will charge buyer-paid/calculated shipping
-
-     It applies the normalize-before-stats filters (row-0 flag, unit match,
-     same-item core tokens, condition cohort, single-bid/low-feedback
-     exclusions — each drop logged), computes `n / median / IQR / dispersion`
-     off the cleaned `best_match` set, vets the `price_high` ceiling, and
-     emits the three tiers + a confidence label. Fold its text block into
-     `price.txt` and adopt its tiers (see "Distribution-based tiers" below).
-     **No shell?** Do the same filtering + percentiles by hand from the saved
-     JSONs, using the rules in [docs/price-strategy-v2.md](../docs/price-strategy-v2.md)
-     and the constants in `price_stats.py`; show your work.
-   - **Proof-of-run is mandatory.** Record **both Apify run ids** AND both
-     saved JSON paths in the Research log. **Never report Stage B as "ran"
-     without run ids.**
+   direct-eBay comp source; no gate. Tag `[B — Apify]`. ~$0.20/item. Run the
+   SAME query twice — `best_match` (representative body, `--max 30`) and
+   `price_high` (ceiling set, `--max 20`), both `--pages 2`. The dual pull is
+   what makes distribution pricing possible. Pick the path your environment
+   allows; exact commands live in "Tooling — CLI contracts" below.
+   - **MCP connector** (preferred; works with no egress): call the actor once
+     per sort, dump each raw result to `<shoot-dir>/raw_<sort>.json`, then
+     `apify_ebay.py --ingest` it. Run id = the MCP result's `runId`.
+   - **stdlib CLI** (shell + egress): one `apify_ebay.py` live run per sort.
+     Optionally `--sku`/`--title` to label the run in the Apify Console (else
+     it's labeled by the query; SKU is `list_edit.py`'s 8-hex hash, or use the
+     working title / shoot-folder name since PRICE precedes DRAFT).
+   - **Currency sanity:** genuine USD prices cluster on .99/.95/.00/.50; each
+     save's `charm_price_share` / `currency_leak_suspected` flags a leak. The
+     US-proxy actor makes leaks unlikely (the old caffein.dev actor leaked
+     BRL/CZK at ~5× mislabeled USD — why we switched). On a suspected leak
+     prefer Stage C; trust the price pattern, never a `currency`/`USD` label.
+   - **Run the distribution engine** on the two saved JSONs (`--price-field
+     total` for free-ship — the default), fold its block into `price.txt`,
+     adopt its tiers. **No shell?** Do the filtering + percentiles by hand per
+     [docs/price-strategy-v2.md](../docs/price-strategy-v2.md) (Conservative=25th
+     pct · Recommended=median · Push-high=vetted ceiling else 90th pct; drop
+     single-bid auctions & <50-feedback sellers; flag >2.5× median); show work.
+   - **Proof-of-run is mandatory:** record both run ids AND both saved JSON
+     paths in the Research log — never report B as "ran" without run ids.
    - **If NEITHER path is available** (no Apify MCP tool AND no
      shell/egress — e.g. a sandbox whose proxy 403s `api.apify.com`):
      record `B — UNAVAILABLE: <reason>` in the Research log and fall through
@@ -254,39 +200,34 @@ and then state how hard you looked ("3 formulations, A+B+C, no exact
 match"). Per _shared, an exact match found this way beats any era-peer;
 commit to it.
 
-## Apify notes (the Stage B backend)
+## Tooling — CLI contracts (use these; do NOT read the .py source)
 
-Apify is the default Stage B source and runs without a gate. v2 issues
-**two runs per item** — `best_match` (representative) and `price_high`
-(ceiling) — and feeds both to [`lib/price_stats.py`](../lib/price_stats.py).
-The backend Actor is `automation-lab/ebay-sold-scraper` (configurable via
-`apify.ebay_actor`), chosen because it pins a **US residential proxy** —
-so eBay serves USD natively and the foreign-currency leak that sank the
-previous actor doesn't occur. The CLI/wrapper validates every run with the
-charm-price currency check (defense in depth) and raises `CurrencyLeakError`
-if a run ever looks FX-converted.
+Everything PRICE needs from `lib/` is below — treat it as the interface and
+don't open the implementation files (reading them is wasted tokens). Stage B
+runs the Actor `automation-lab/ebay-sold-scraper` (US residential proxy → native
+USD; configurable via `apify.ebay_actor`), twice per item (`best_match` +
+`price_high`), and every save runs the charm-price currency check + flags a
+suspected FX leak. Two execution paths: the **MCP connector** (restricted /
+no-egress envs — brokered outside the sandbox) and the **stdlib CLI** (shell +
+egress to `api.apify.com` + Apify token). Neither available ⇒ Stage B
+`UNAVAILABLE` → Chrome (Stage C).
 
-**Two execution paths, by environment (see Stage B above):**
-- **Apify MCP connector** — preferred in restricted environments (e.g. a
-  Cowork tab) whose sandbox proxy blocks `api.apify.com`. MCP calls are
-  brokered outside the sandbox, so they reach Apify when raw HTTPS can't.
-  No pip, no wrapper file, token lives in the connector.
-- **stdlib CLI** (`python lib/apify_ebay.py`) — for shell environments with
-  egress. No third-party package (standard library only); needs Python +
-  network to `api.apify.com` + the Apify token.
+`python lib/apify_ebay.py` — run OR ingest a sold-comp search:
+- live run: `"<query>" --sort <best_match|price_high> --max <30|20> --pages 2 --save-dir <shoot-dir> [--sku <sku> --title "<title>"]`
+- ingest (MCP path): `--ingest <shoot-dir>/raw_<sort>.json --save-dir <shoot-dir>` — normalizes the MCP tool's raw items into the canonical saved JSON, no live call.
+- both print `Apify run: <id>` + `Saved results: <path>`. Saved JSON has a `comps` list with `sold_price`, `total_price` (=sold+shipping), `shipping_cost`, `title`, `url`, `condition`, `sold_date`, `listing_type`, `bids_count`, `seller_feedback_score`, plus top-level `charm_price_share` / `currency_leak_suspected`.
 
-If neither is available (no MCP tool, no shell/egress), Stage B is
-`UNAVAILABLE` and PRICE routes to Chrome (Stage C). Same if the Apify token
-is unset.
+`python lib/price_stats.py` — distribution tiers from the saved JSON(s):
+- `--best-match <bm.json> [--price-high <ph.json>] --unit <single|pair|set|lot|duplicate> --condition <new|used> [--require-tokens <tok>...] [--price-field <sold|total>]`
+- prints the Distribution line (n / median / IQR / dispersion), vetted ceiling, the three tiers, a confidence label, and the per-filter drop log. `--price-field total` for free-ship listings (default — see Delivered-price basis). Fold its block into `price.txt`; n<3 ⇒ confidence `thin`, fall back to the closest era-peer (it says so).
 
 ## Saved comp artifacts (every stage leaves a reviewable record)
 
 The user reviews the raw research, so each stage persists its comps:
 
-- **Stage B (Apify)** → **two** JSONs, one per sort (auto-saved; `--save-dir
-  <shoot-dir>` puts them beside `price.txt`; MCP path: write items to
-  `<shoot-dir>/apify_best_match_<runId>.json` and
-  `<shoot-dir>/apify_price_high_<runId>.json`). `price_stats.py` reads both.
+- **Stage B (Apify)** → **two** JSONs, one per sort, saved beside `price.txt`
+  by `--save-dir <shoot-dir>` (live run auto-saves; MCP path saves via
+  `--ingest`). `price_stats.py` reads both.
 - **Stages A (WebSearch) and C (Chrome)** → rows in **`<shoot-dir>/comps.csv`**,
   the single spreadsheet the user opens to review every comp across sources.
   Append each usable comp with `lib/comps_csv.py`:
@@ -309,19 +250,13 @@ gets a row — leave `price` blank and say why in `note`.
 
 ## URLs (mandatory — the user verifies comps by clicking them)
 
-Every comp carries a clickable source URL inline (a comp without a URL is
-not a comp). In ADDITION, every PRICE output ends with a consolidated
-**Comp URLs** list (see Output) so the user can click straight through and
-view the comps themselves — **exact / near-exact matches first**, then
-ceiling/context comps, then the eBay sold-search URL for the whole result
-set. These live in `price.txt` (persisted), so they're saved for reference.
-
-- Use **direct per-item eBay listing URLs** (`ebay.com/itm/<id>`) for exact
-  matches whenever you have them (Stage B/Apify returns one per comp;
-  Stage A/WebSearch and direct Chrome hrefs too).
-- Only when a per-item href genuinely can't be captured (e.g. Chrome
-  `get_page_text`) may you fall back to the sold-search URL — and say so.
-- Never list a bare price without its URL in this section.
+A comp without a URL is not a comp. Use **direct per-item** `ebay.com/itm/<id>`
+URLs (Stage B returns one per comp; Stage A / Chrome hrefs too); fall back to the
+sold-search URL only when a per-item href genuinely can't be captured (e.g.
+Chrome `get_page_text`) — and say so. Every output also ends with the
+consolidated **Comp URLs** block (exact/near-exact first, then ceiling/context,
+then the sold-search URL — format under Output); never list a bare price without
+its URL there.
 
 ## Research log (MANDATORY — proof every search type actually ran)
 


### PR DESCRIPTION
@
## Goal

Reduce the **time and token cost of each pipeline run**, targeting the sinks observed on a real `run quail-plate`: reading lib *source* to learn interfaces, hand-authoring Apify run JSON on the MCP path, reading every full-res photo, and duplicated Stage-A/B/C prose.

## Changes

**`apify_ebay.py --ingest <raw.json>` (code).** Normalizes the Apify MCP tools raw items into the canonical saved-run JSON — `total_price` (= sold + shipping) and the charm/currency check — by reusing the existing `_map_to_comp_record` + `save_run_json`. On the MCP path you now dump the tools `items` to `raw_<sort>.json` and run one command, instead of hand-writing ~160 lines of JSON per run. Verified end-to-end (ingest → `price_stats --price-field total`).

**`price.md` (489 → 424 lines).**
- New **"Tooling — CLI contracts"** section documenting `apify_ebay.py` + `price_stats.py` (flags, fields, I/O) so the model uses the interface and never opens the 665-line `price_stats.py` source.
- Collapsed the duplicated Stage-B command blocks (MCP/CLI) — they now point at the contract — and routed the MCP path through `--ingest`.
- Compressed the overlapping "URLs" prose.

**`identify.md` / `investigate.md`.** New **"Photo intake"** rule: read the decisive frames (hero + mark/underside + key defects + ruler), skip near-duplicate angles. Cuts image tokens on photo-heavy shoots while preserving the "hunt every mark" / coverage mandates.

## Safety

Behavior preserved — this cuts **intake, not guidance**. The `total_price` plumbing already existed; `--ingest` just exposes it. Net: `4 files, +128 / −122`, with the per-run savings concentrated in *avoided* reads (source files, hand-authored JSON, redundant photos) that dont show up in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@