### PR TITLE
Local pickup for ship-risky (fragile/heavy/bulky) items

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -91,6 +91,7 @@ Never block on these. Pick the documented default, append ONE line to
 | `lookup_only` value not canonical (e.g. "USA") | substitute closest canonical ("United States") | verify |
 | Required field has no source data | leave empty, flag | fill it |
 | Item below profit floor | route to CURATE SKIPPED with the math | override per category |
+| Item ship-risky (>25 lb or >24 in/side, or fragile) | keep `SHIP`; suggest local pickup, log it | confirm local-pickup (attended: DRAFT asks before assuming) |
 
 **Working price is NOT a HARD gate.** PRICE still records "final price
 deferred to publish time", but headless flow auto-adopts the Recommended

--- a/docs/local-pickup-fragile.md
+++ b/docs/local-pickup-fragile.md
@@ -1,183 +1,92 @@
-# Local pickup for ship-risky items — PLAN (not yet implemented)
+# Local pickup for ship-risky items — IMPLEMENTED
 
-Add a **local-pickup-primary** fulfillment path for items that are risky to
-ship — fragile/breakable (stained glass, blown glass, porcelain, plaster),
-heavy (oversized/freight/movers tiers), or just too bulky. Such items should
-default to **local pickup**, **not offer normal shipping**, and keep a
-**freight/contact-for-quote** fallback for the rare distant buyer.
+Ship-risky items — heavy, oversized, or fragile (stained glass, porcelain) —
+can now be listed as **local pickup only** (no parcel shipping), routed to a
+dedicated eBay fulfillment policy. The freight fallback for distant buyers is
+offered **by quote in the listing description** (see the eBay constraint
+below — pickup and freight can't share one policy).
 
-This document is the plan only. No prompt, template, or library code is
-changed in this PR — review and approve the approach here first.
+## Confirmed decisions (2026-06-14)
 
-## Goal (what the user asked for)
+1. **Soft gate, never assume.** Local-pickup is a SOFT gate: it never blocks a
+   run. Default is always `SHIP`. DRAFT **suggests** pickup but only sets
+   `LOCAL_PICKUP` when the user indicates it (they usually say so up front) or
+   confirms when asked. Headless runs keep `SHIP` and log a NEEDS_REVIEW line.
+2. **Auto-suggest trigger:** estimated weight **> 25 lb** OR any estimated
+   dimension **> 24 in (2 ft)** on a side. (Fragility the user names is also
+   honored at DRAFT; the *automatic* trigger is weight/size, set in IDENTIFY.)
+3. **Freight = fallback** offered by quote in the description, not a formal
+   eBay shipping service (forced by the eBay constraint below).
 
-> Modify the list prompt to use eBay local pickup, and not offer shipping on
-> an item that is easily breakable / fragile, or too big to ship.
+## The eBay constraint we hit (and why the design is what it is)
 
-Confirmed product decisions (2026-06-14):
+We tried to create a single "local pickup + freight" fulfillment policy via the
+Sell Account API. eBay **does not allow it**:
 
-1. **Fulfillment mode = pickup-primary + freight fallback.** Local pickup is
-   the offered method; standard parcel shipping is *not* offered. A
-   freight / "message me for a shipping quote" path stays available so a
-   committed distant buyer isn't fully locked out.
-2. **Decision gate = ask before drafting (attended runs).** When an item
-   looks ship-risky, the pipeline asks the user to confirm pickup-primary vs
-   normal shipping *before* DRAFT writes the shipping block. (Headless
-   reconciliation below — this is the one open point against the existing
-   gate contract.)
-3. **Ship-risk trigger is broad:** weight **and** dimensions **and**
-   fragility — anything genuinely risky to ship. Not just the heavy tiers.
+- `localPickup: true` is **exclusive** — "No other shipping services can be
+  specified with shipping type of Local pick up" (rejects freight, parcel, even
+  a `handlingTime`, which is read as a shipping concept).
+- A `Pickup` *service* inside a `FLAT_RATE`/`CALCULATED` option requires a
+  non-pickup service alongside it; adding freight there silently **drops the
+  pickup** and yields a freight-only policy.
 
-## How shipping works today (baseline)
+So the working, eBay-accepted shape for pickup-only is a minimal policy:
+`localPickup: true`, `categoryTypes`, **no `handlingTime`, no `shippingOptions`**.
+Freight therefore lives in the description as "message me for a freight quote."
 
-- **IDENTIFY** ([prompts/identify.md](../prompts/identify.md)) already
-  estimates per-item **weight** (tiered: light <5 / medium 5–15 / heavy
-  15–25 / oversized 25–50 / freight 50+ / requires-movers) and **dimensions**,
-  and surfaces **material** in Type / Distinguishing marks. So the raw signals
-  for a ship-risk call already exist — they just aren't synthesized into one.
-- **DRAFT** ([prompts/draft.md](../prompts/draft.md), "shipping:") sets
-  `free_shipping: true`, `domestic_shipping_type: FREE_FLAT_RATE`, and a
-  `primary_service` via its **Service map** (Media Mail / Ground Advantage /
-  UPS Ground; freight/movers → blank + flag). Shipping is always assumed.
-- **Template** ([templates/listing-v1.md](../templates/listing-v1.md)) has a
-  `shipping:` block (weight, dims, `free_shipping`, `domestic_shipping_type`,
-  `primary_service`, `handling_time_days`, `item_location_zip`) with a
-  `_field_constraints` map the validator enforces. **There is no
-  local-pickup / fulfillment-mode concept anywhere.**
-- **API path** ([lib/list_edit.py](../lib/list_edit.py)
-  `_resolve_shipping_policy`) routes each item to an account-level
-  **fulfillment policy ID** (default ground, or an optional Media Mail
-  policy). Local pickup would be **a third fulfillment policy**.
-- **Chrome stand-in** ([prompts/list_edit_chrome.md](../prompts/list_edit_chrome.md)
-  step 6) confirms/sets free shipping + service in the eBay UI.
+The policy was created on the **production** account:
+`fulfillment_policy_id_local_pickup = 292766452014`
+("Local pickup only (freight by quote)", `localPickup: true`), and is
+reproducible with `python lib/list_edit.py --create-pickup-policy`.
 
-## Design
+## What changed
 
-### 1. Define the ship-risk classification (one rule, computed in IDENTIFY)
+**eBay API / library**
+- [lib/ebay_client.py](../lib/ebay_client.py) — new `create_local_pickup_policy()`
+  (idempotent by name; encodes the minimal pickup-only payload).
+- [lib/list_edit.py](../lib/list_edit.py) —
+  `_resolve_policies_and_location` reads `fulfillment_policy_id_local_pickup`
+  (optional); `_resolve_shipping_policy` routes `fulfillment_mode: LOCAL_PICKUP`
+  items to it (and treats a no-parcel-service pickup/freight policy as valid);
+  `validate_draft_for_sync` guards the `fulfillment_mode` enum so a typo can't
+  silently ship a fragile item; `build_review_card` shows a **Fulfillment**
+  line; new `--create-pickup-policy` CLI command.
+- [lib/config.example.yaml](../lib/config.example.yaml) — documents the new
+  optional `fulfillment_policy_id_local_pickup`. (Live `config.yaml` has the
+  real id; it is gitignored.)
 
-Add a single explicit field to each IDENTIFY record, derived from signals
-IDENTIFY already gathers — so the judgment is made once, with the photos in
-hand, and threads downstream:
+**Template**
+- [templates/listing-v1.md](../templates/listing-v1.md) — `shipping.fulfillment_mode`
+  (`SHIP` | `LOCAL_PICKUP`, default `SHIP`) + a `local_pickup` block
+  (`freight_quote`, `location_hint`).
 
-```
-ship_risk: none | fragile | oversized | both
-ship_risk_reason: <one line — what makes it risky>
-```
+**Prompts**
+- [prompts/identify.md](../prompts/identify.md) — new **Ship risk** field
+  (`none` | `suggest-pickup`) from the >25 lb / >24 in trigger.
+- [prompts/draft.md](../prompts/draft.md) — the **Local-pickup gate**: suggest
+  (never assume), ask in attended runs, default `SHIP` + log in headless, set
+  the pickup fields + description freight line when `LOCAL_PICKUP`.
+- [prompts/review.md](../prompts/review.md) — card shows fulfillment; confirm
+  pickup items at the gate.
+- [prompts/list_edit_chrome.md](../prompts/list_edit_chrome.md) — UI path
+  selects eBay's local-pickup option (no parcel service) for `LOCAL_PICKUP`.
+- [prompts/_shared.md](../prompts/_shared.md) + [RUN.md](../RUN.md) — the
+  local-pickup suggestion added to the SOFT-gate contract.
+- [lib/SETUP_EBAY_API.md](../lib/SETUP_EBAY_API.md) — how to create/configure
+  the pickup policy.
 
-An item is **ship-risky** when ANY of:
+## Verified
 
-- **Fragile material / form:** stained or leaded glass, blown/pressed glass,
-  porcelain / ceramic / pottery, plaster/chalkware, thin enamel, items with
-  protruding brittle parts (lamp arms, finials, handles, spouts). Material is
-  already read for brand attribution — reuse it.
-- **Heavy:** weight tier is **oversized / freight / requires-movers**
-  (≥25 lb), which DRAFT already half-handles by blanking the service.
-- **Bulky (dimensional/girth):** large longest-side or length+girth even when
-  light — large lampshades, framed art, mirrors, big ceramics. Add a simple
-  dimensional threshold (e.g. longest side > ~30 in, or length+girth > ~100
-  in) so big-but-light items qualify too.
+- `--create-pickup-policy` is idempotent (returns the existing `292766452014`).
+- Routing: `LOCAL_PICKUP` → pickup policy; `SHIP` → default ground (tested
+  against the live account).
+- Validator: rejects a `fulfillment_mode` typo; accepts `LOCAL_PICKUP`;
+  existing drafts (no field → default `SHIP`) still validate.
 
-`none` is the default; the field is only non-`none` when a real signal fires.
-This keeps every existing (small, durable) item shipping exactly as today.
+## Not done / follow-up
 
-### 2. The fulfillment gate (attended runs ask; headless defaults)
-
-Per the user's choice, in an **attended** run the pipeline **asks before
-DRAFT writes the shipping block** whenever `ship_risk != none`:
-
-> *"<item> looks <reason> — risky to ship. List as **local pickup
-> (+ freight/quote fallback)**, or ship normally?"*
-
-The answer sets the fulfillment mode (below). **Headless reconciliation
-(open point — see end):** RUN.md's gate contract says REVIEW is the *only*
-hard stop. In an unattended run there is no one to ask, so a ship-risk item
-**defaults to pickup-primary + freight**, logs one line to `NEEDS_REVIEW.md`,
-and the choice is surfaced again on the REVIEW card for the user to confirm
-or flip. This keeps headless runs non-blocking while honoring "ask" in
-attended runs.
-
-### 3. Data model — new template fields
-
-Extend the `shipping:` block in
-[templates/listing-v1.md](../templates/listing-v1.md):
-
-```yaml
-shipping:
-  fulfillment_mode: SHIP        # SHIP | LOCAL_PICKUP   (new; default SHIP)
-  local_pickup:                 # only meaningful when fulfillment_mode == LOCAL_PICKUP
-    pickup_only: true           # no parcel shipping offered
-    freight_quote: true         # allow "message for freight quote" fallback
-    location_hint: ""           # city/region shown to buyers (from seller profile)
-  # ...existing weight / package_in / free_shipping / domestic_shipping_type /
-  #    primary_service / handling_time_days / item_location_zip unchanged...
-```
-
-When `fulfillment_mode == LOCAL_PICKUP`:
-- `free_shipping` → **false**, `domestic_shipping_type` → a new
-  `LOCAL_PICKUP` value (or left blank + handled by policy), `primary_service`
-  → blank.
-- Weight/dims are still recorded (useful for a freight quote), just not used
-  for a parcel service.
-
-Add a `_field_constraints` entry validating `fulfillment_mode` against the
-enum `{SHIP, LOCAL_PICKUP}` (extend the validator to support an `enum` flag,
-or treat it as a `lookup_only` string).
-
-### 4. eBay mechanics — account-level local-pickup fulfillment policy
-
-eBay models local pickup as a **fulfillment policy** with pickup enabled and
-(optionally) a freight service, *not* as a per-listing free-text field. Plan:
-
-- Create one **"Local pickup (+ freight)" fulfillment policy** on the eBay
-  account: `pickupDropOff`/local-pickup enabled, parcel services removed, and
-  a **Freight** shipping service added for the quote fallback (or pickup-only
-  with a description note if Freight isn't desired).
-- Add `fulfillment_policy_id_local_pickup` to `lib/config.example.yaml` (under
-  each store's `ebay:` block, alongside `fulfillment_policy_id` and
-  `fulfillment_policy_id_media`).
-- `lib/list_edit.py:_resolve_shipping_policy` gains a branch: when
-  `draft.shipping.fulfillment_mode == LOCAL_PICKUP`, route to the local-pickup
-  policy (with the same "policy exists / offers a service" validation it does
-  today, and a clear message if the policy isn't configured).
-- Ensure the **merchant location** used has a real pickup address (already
-  required by `_resolve_policies_and_location`).
-
-`SETUP_EBAY_API.md` gains a short section on creating this policy and pasting
-its ID, mirroring the Media Mail policy instructions.
-
-### 5. Prompt + doc changes (the actual edits, in a follow-up PR)
-
-| File | Change |
-|---|---|
-| [prompts/identify.md](../prompts/identify.md) | Add the `ship_risk` + `ship_risk_reason` fields to the output format; add a short "ship-risk assessment" rule (material + weight tier + dimensional threshold). |
-| [prompts/draft.md](../prompts/draft.md) | New "Fulfillment mode" rule: read `ship_risk`; run the attended gate / headless default; when LOCAL_PICKUP, set the new shipping fields, blank the parcel service, and add a **local-pickup + freight-quote** note to the description body. Update the Service map note. |
-| [templates/listing-v1.md](../templates/listing-v1.md) | Add `fulfillment_mode` + `local_pickup` fields and the `_field_constraints` enum entry. |
-| [prompts/review.md](../prompts/review.md) | Surface fulfillment mode on the decision card (so the user confirms pickup-primary at the REVIEW gate). |
-| [prompts/list_edit_chrome.md](../prompts/list_edit_chrome.md) | Step 6: when LOCAL_PICKUP, choose eBay's local-pickup option instead of free shipping; don't set a parcel service. |
-| [lib/list_edit.py](../lib/list_edit.py) | `_resolve_shipping_policy`: route LOCAL_PICKUP items to `fulfillment_policy_id_local_pickup`; validate it's configured. |
-| [lib/config.example.yaml](../lib/config.example.yaml) | Add `fulfillment_policy_id_local_pickup`. |
-| [lib/SETUP_EBAY_API.md](../lib/SETUP_EBAY_API.md) | Document creating the local-pickup (+ freight) policy. |
-| [prompts/_shared.md](../prompts/_shared.md) + [RUN.md](../RUN.md) | Document the fulfillment gate (attended ask, headless SOFT-gate default) in the gate contract. |
-
-### 6. Validation / testing
-
-- Walk an existing fragile item (e.g. `inventory/fenton-lamps/` — glass lamps)
-  through IDENTIFY → DRAFT and confirm it classifies `fragile`, asks, and
-  produces a LOCAL_PICKUP draft with no parcel service.
-- Confirm a normal small durable item is untouched (`ship_risk: none`, ships
-  as today).
-- `lib/list_edit.py --sync` dry-run against a LOCAL_PICKUP draft routes to the
-  pickup policy and validates cleanly; clear error when the policy ID is
-  missing from config.
-
-## Open point for the reviewer
-
-**The gate contract.** RUN.md currently states the REVIEW gate is the *only*
-hard stop, and every other "ask the user" moment is a SOFT gate (default +
-log, never block). "Ask before drafting" introduces a second interactive
-prompt in attended runs. The plan reconciles this by making the ask a
-**SOFT gate with a default** (pickup-primary + freight, logged, re-surfaced at
-REVIEW) so headless runs never block — the "ask" only materializes when a
-human is present. **Confirm this reconciliation**, or say whether you'd rather
-it be a true hard stop even in headless runs (which would change the
-headless contract).
+- No item has been listed pickup-only end-to-end yet (no live publish in this
+  change). First real fragile item (e.g. the Fenton glass lamps) will exercise
+  the full DRAFT → REVIEW → `--list` path.
+- Sandbox has no pickup policy configured — run `--create-pickup-policy` there
+  if/when sandbox listing is needed.

--- a/docs/local-pickup-fragile.md
+++ b/docs/local-pickup-fragile.md
@@ -1,0 +1,183 @@
+# Local pickup for ship-risky items — PLAN (not yet implemented)
+
+Add a **local-pickup-primary** fulfillment path for items that are risky to
+ship — fragile/breakable (stained glass, blown glass, porcelain, plaster),
+heavy (oversized/freight/movers tiers), or just too bulky. Such items should
+default to **local pickup**, **not offer normal shipping**, and keep a
+**freight/contact-for-quote** fallback for the rare distant buyer.
+
+This document is the plan only. No prompt, template, or library code is
+changed in this PR — review and approve the approach here first.
+
+## Goal (what the user asked for)
+
+> Modify the list prompt to use eBay local pickup, and not offer shipping on
+> an item that is easily breakable / fragile, or too big to ship.
+
+Confirmed product decisions (2026-06-14):
+
+1. **Fulfillment mode = pickup-primary + freight fallback.** Local pickup is
+   the offered method; standard parcel shipping is *not* offered. A
+   freight / "message me for a shipping quote" path stays available so a
+   committed distant buyer isn't fully locked out.
+2. **Decision gate = ask before drafting (attended runs).** When an item
+   looks ship-risky, the pipeline asks the user to confirm pickup-primary vs
+   normal shipping *before* DRAFT writes the shipping block. (Headless
+   reconciliation below — this is the one open point against the existing
+   gate contract.)
+3. **Ship-risk trigger is broad:** weight **and** dimensions **and**
+   fragility — anything genuinely risky to ship. Not just the heavy tiers.
+
+## How shipping works today (baseline)
+
+- **IDENTIFY** ([prompts/identify.md](../prompts/identify.md)) already
+  estimates per-item **weight** (tiered: light <5 / medium 5–15 / heavy
+  15–25 / oversized 25–50 / freight 50+ / requires-movers) and **dimensions**,
+  and surfaces **material** in Type / Distinguishing marks. So the raw signals
+  for a ship-risk call already exist — they just aren't synthesized into one.
+- **DRAFT** ([prompts/draft.md](../prompts/draft.md), "shipping:") sets
+  `free_shipping: true`, `domestic_shipping_type: FREE_FLAT_RATE`, and a
+  `primary_service` via its **Service map** (Media Mail / Ground Advantage /
+  UPS Ground; freight/movers → blank + flag). Shipping is always assumed.
+- **Template** ([templates/listing-v1.md](../templates/listing-v1.md)) has a
+  `shipping:` block (weight, dims, `free_shipping`, `domestic_shipping_type`,
+  `primary_service`, `handling_time_days`, `item_location_zip`) with a
+  `_field_constraints` map the validator enforces. **There is no
+  local-pickup / fulfillment-mode concept anywhere.**
+- **API path** ([lib/list_edit.py](../lib/list_edit.py)
+  `_resolve_shipping_policy`) routes each item to an account-level
+  **fulfillment policy ID** (default ground, or an optional Media Mail
+  policy). Local pickup would be **a third fulfillment policy**.
+- **Chrome stand-in** ([prompts/list_edit_chrome.md](../prompts/list_edit_chrome.md)
+  step 6) confirms/sets free shipping + service in the eBay UI.
+
+## Design
+
+### 1. Define the ship-risk classification (one rule, computed in IDENTIFY)
+
+Add a single explicit field to each IDENTIFY record, derived from signals
+IDENTIFY already gathers — so the judgment is made once, with the photos in
+hand, and threads downstream:
+
+```
+ship_risk: none | fragile | oversized | both
+ship_risk_reason: <one line — what makes it risky>
+```
+
+An item is **ship-risky** when ANY of:
+
+- **Fragile material / form:** stained or leaded glass, blown/pressed glass,
+  porcelain / ceramic / pottery, plaster/chalkware, thin enamel, items with
+  protruding brittle parts (lamp arms, finials, handles, spouts). Material is
+  already read for brand attribution — reuse it.
+- **Heavy:** weight tier is **oversized / freight / requires-movers**
+  (≥25 lb), which DRAFT already half-handles by blanking the service.
+- **Bulky (dimensional/girth):** large longest-side or length+girth even when
+  light — large lampshades, framed art, mirrors, big ceramics. Add a simple
+  dimensional threshold (e.g. longest side > ~30 in, or length+girth > ~100
+  in) so big-but-light items qualify too.
+
+`none` is the default; the field is only non-`none` when a real signal fires.
+This keeps every existing (small, durable) item shipping exactly as today.
+
+### 2. The fulfillment gate (attended runs ask; headless defaults)
+
+Per the user's choice, in an **attended** run the pipeline **asks before
+DRAFT writes the shipping block** whenever `ship_risk != none`:
+
+> *"<item> looks <reason> — risky to ship. List as **local pickup
+> (+ freight/quote fallback)**, or ship normally?"*
+
+The answer sets the fulfillment mode (below). **Headless reconciliation
+(open point — see end):** RUN.md's gate contract says REVIEW is the *only*
+hard stop. In an unattended run there is no one to ask, so a ship-risk item
+**defaults to pickup-primary + freight**, logs one line to `NEEDS_REVIEW.md`,
+and the choice is surfaced again on the REVIEW card for the user to confirm
+or flip. This keeps headless runs non-blocking while honoring "ask" in
+attended runs.
+
+### 3. Data model — new template fields
+
+Extend the `shipping:` block in
+[templates/listing-v1.md](../templates/listing-v1.md):
+
+```yaml
+shipping:
+  fulfillment_mode: SHIP        # SHIP | LOCAL_PICKUP   (new; default SHIP)
+  local_pickup:                 # only meaningful when fulfillment_mode == LOCAL_PICKUP
+    pickup_only: true           # no parcel shipping offered
+    freight_quote: true         # allow "message for freight quote" fallback
+    location_hint: ""           # city/region shown to buyers (from seller profile)
+  # ...existing weight / package_in / free_shipping / domestic_shipping_type /
+  #    primary_service / handling_time_days / item_location_zip unchanged...
+```
+
+When `fulfillment_mode == LOCAL_PICKUP`:
+- `free_shipping` → **false**, `domestic_shipping_type` → a new
+  `LOCAL_PICKUP` value (or left blank + handled by policy), `primary_service`
+  → blank.
+- Weight/dims are still recorded (useful for a freight quote), just not used
+  for a parcel service.
+
+Add a `_field_constraints` entry validating `fulfillment_mode` against the
+enum `{SHIP, LOCAL_PICKUP}` (extend the validator to support an `enum` flag,
+or treat it as a `lookup_only` string).
+
+### 4. eBay mechanics — account-level local-pickup fulfillment policy
+
+eBay models local pickup as a **fulfillment policy** with pickup enabled and
+(optionally) a freight service, *not* as a per-listing free-text field. Plan:
+
+- Create one **"Local pickup (+ freight)" fulfillment policy** on the eBay
+  account: `pickupDropOff`/local-pickup enabled, parcel services removed, and
+  a **Freight** shipping service added for the quote fallback (or pickup-only
+  with a description note if Freight isn't desired).
+- Add `fulfillment_policy_id_local_pickup` to `lib/config.example.yaml` (under
+  each store's `ebay:` block, alongside `fulfillment_policy_id` and
+  `fulfillment_policy_id_media`).
+- `lib/list_edit.py:_resolve_shipping_policy` gains a branch: when
+  `draft.shipping.fulfillment_mode == LOCAL_PICKUP`, route to the local-pickup
+  policy (with the same "policy exists / offers a service" validation it does
+  today, and a clear message if the policy isn't configured).
+- Ensure the **merchant location** used has a real pickup address (already
+  required by `_resolve_policies_and_location`).
+
+`SETUP_EBAY_API.md` gains a short section on creating this policy and pasting
+its ID, mirroring the Media Mail policy instructions.
+
+### 5. Prompt + doc changes (the actual edits, in a follow-up PR)
+
+| File | Change |
+|---|---|
+| [prompts/identify.md](../prompts/identify.md) | Add the `ship_risk` + `ship_risk_reason` fields to the output format; add a short "ship-risk assessment" rule (material + weight tier + dimensional threshold). |
+| [prompts/draft.md](../prompts/draft.md) | New "Fulfillment mode" rule: read `ship_risk`; run the attended gate / headless default; when LOCAL_PICKUP, set the new shipping fields, blank the parcel service, and add a **local-pickup + freight-quote** note to the description body. Update the Service map note. |
+| [templates/listing-v1.md](../templates/listing-v1.md) | Add `fulfillment_mode` + `local_pickup` fields and the `_field_constraints` enum entry. |
+| [prompts/review.md](../prompts/review.md) | Surface fulfillment mode on the decision card (so the user confirms pickup-primary at the REVIEW gate). |
+| [prompts/list_edit_chrome.md](../prompts/list_edit_chrome.md) | Step 6: when LOCAL_PICKUP, choose eBay's local-pickup option instead of free shipping; don't set a parcel service. |
+| [lib/list_edit.py](../lib/list_edit.py) | `_resolve_shipping_policy`: route LOCAL_PICKUP items to `fulfillment_policy_id_local_pickup`; validate it's configured. |
+| [lib/config.example.yaml](../lib/config.example.yaml) | Add `fulfillment_policy_id_local_pickup`. |
+| [lib/SETUP_EBAY_API.md](../lib/SETUP_EBAY_API.md) | Document creating the local-pickup (+ freight) policy. |
+| [prompts/_shared.md](../prompts/_shared.md) + [RUN.md](../RUN.md) | Document the fulfillment gate (attended ask, headless SOFT-gate default) in the gate contract. |
+
+### 6. Validation / testing
+
+- Walk an existing fragile item (e.g. `inventory/fenton-lamps/` — glass lamps)
+  through IDENTIFY → DRAFT and confirm it classifies `fragile`, asks, and
+  produces a LOCAL_PICKUP draft with no parcel service.
+- Confirm a normal small durable item is untouched (`ship_risk: none`, ships
+  as today).
+- `lib/list_edit.py --sync` dry-run against a LOCAL_PICKUP draft routes to the
+  pickup policy and validates cleanly; clear error when the policy ID is
+  missing from config.
+
+## Open point for the reviewer
+
+**The gate contract.** RUN.md currently states the REVIEW gate is the *only*
+hard stop, and every other "ask the user" moment is a SOFT gate (default +
+log, never block). "Ask before drafting" introduces a second interactive
+prompt in attended runs. The plan reconciles this by making the ask a
+**SOFT gate with a default** (pickup-primary + freight, logged, re-surfaced at
+REVIEW) so headless runs never block — the "ask" only materializes when a
+human is present. **Confirm this reconciliation**, or say whether you'd rather
+it be a true hard stop even in headless runs (which would change the
+headless contract).

--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -232,7 +232,7 @@ step). That preserves the firewall's intent — no accidental or automated
 publication — while giving you a one-command way to take a reviewed offer
 live.
 
-## Shipping policies (ground default + optional Media Mail)
+## Shipping policies (ground default + optional Media Mail + optional local pickup)
 
 `--sync` runs a **preflight** that picks the fulfillment policy per item:
 
@@ -243,6 +243,18 @@ live.
   it; otherwise it falls back to the ground policy. To create one, add a
   fulfillment policy with shipping service `USPSMedia` (free flat-rate) and
   paste its ID here.
+- **`fulfillment_policy_id_local_pickup`** *(optional)* — a **local-pickup-only**
+  policy for ship-risky items (heavy / oversized / fragile) that DRAFT marks
+  `fulfillment_mode: LOCAL_PICKUP`. When set, those items list as local pickup
+  with no parcel shipping (the freight fallback is offered by quote in the
+  description). Create it idempotently with:
+
+      python lib/list_edit.py --create-pickup-policy
+
+  then paste the printed ID under the active `ebay.<env>` block. (eBay quirk:
+  a local-pickup policy carries `localPickup: true` and **no** `handlingTime`
+  or shipping services — local pickup is exclusive and can't be combined with
+  parcel/freight in one policy; `create_local_pickup_policy()` handles this.)
 
 The same preflight also (a) **auto-remaps the condition** to one the item's
 category accepts (e.g. `USED_GOOD` → `USED_EXCELLENT`/"Used" for non-media

--- a/lib/config.example.yaml
+++ b/lib/config.example.yaml
@@ -69,6 +69,10 @@ ebay:
     fulfillment_policy_id: null          # default (ground) shipping policy
     fulfillment_policy_id_media: null    # optional: Media Mail policy; used for
                                          # books/magazines/comics/music/movies
+    fulfillment_policy_id_local_pickup: null  # optional: local-pickup-only policy;
+                                         # used for ship-risky items (fragile/over-
+                                         # sized) marked fulfillment_mode LOCAL_PICKUP.
+                                         # Create via `--create-pickup-policy`.
     payment_policy_id: null
     return_policy_id: null
 
@@ -82,6 +86,10 @@ ebay:
     fulfillment_policy_id: null          # default (ground) shipping policy
     fulfillment_policy_id_media: null    # optional: Media Mail policy; used for
                                          # books/magazines/comics/music/movies
+    fulfillment_policy_id_local_pickup: null  # optional: local-pickup-only policy;
+                                         # used for ship-risky items (fragile/over-
+                                         # sized) marked fulfillment_mode LOCAL_PICKUP.
+                                         # Create via `--create-pickup-policy`.
     payment_policy_id: null
     return_policy_id: null
 

--- a/lib/ebay_client.py
+++ b/lib/ebay_client.py
@@ -532,6 +532,39 @@ def get_fulfillment_policies(marketplace: str = DEFAULT_MARKETPLACE,
     return data.get("fulfillmentPolicies") or []
 
 
+def create_local_pickup_policy(name: str = "Local pickup only (freight by quote)",
+                               marketplace: str = DEFAULT_MARKETPLACE,
+                               creds: Optional[EbayCredentials] = None) -> dict:
+    """Create (or reuse) a LOCAL-PICKUP-ONLY fulfillment policy and return it.
+
+    eBay treats local pickup as exclusive: a policy with `localPickup: true`
+    may carry NO other shipping services, and (verified the hard way) must NOT
+    include `handlingTime` — its presence is read as a shipping service and the
+    request is rejected with LOCAL_PICKUP_ONLY_ERROR. So the payload is
+    deliberately minimal. Freight for distant buyers is offered by quote in the
+    listing description, not by this policy (pickup + freight can't coexist).
+
+    Idempotent by name: if a policy with `name` already exists, it's returned
+    instead of creating a duplicate.
+    """
+    existing = next((p for p in get_fulfillment_policies(marketplace, creds=creds)
+                     if p.get("name") == name), None)
+    if existing:
+        return existing
+    body = {
+        "name": name,
+        "description": ("Local pickup only — no standard parcel shipping. For "
+                        "distant buyers, freight is available by quote (message)."),
+        "marketplaceId": marketplace,
+        "categoryTypes": [{"name": "ALL_EXCLUDING_MOTORS_VEHICLES"}],
+        "localPickup": True,
+        # NB: NO handlingTime — see docstring.
+    }
+    return api_send("POST", "/sell/account/v1/fulfillment_policy",
+                    body=body, creds=creds, marketplace=None,
+                    extra_headers={"X-EBAY-C-MARKETPLACE-ID": marketplace})
+
+
 def get_payment_policies(marketplace: str = DEFAULT_MARKETPLACE,
                          creds: Optional[EbayCredentials] = None) -> list[dict]:
     data = api_send("GET", f"/sell/account/v1/payment_policy?marketplace_id={marketplace}",

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -88,6 +88,7 @@ from ebay_client import (
     EbayAuthError,
     EbayCredentials,
     api_send,
+    create_local_pickup_policy,
     delete_inventory_item,
     delete_offer,
     get_allowed_condition_ids,
@@ -393,6 +394,11 @@ def validate_draft_for_sync(draft_path: Path) -> list[str]:
     if not str(draft.get("item_specifics.type") or "").strip():
         issues.append("item_specifics.type: required, empty")
 
+    # Fulfillment mode: a typo must not silently ship a ship-risky item.
+    mode = str(draft.get("shipping.fulfillment_mode") or "SHIP").strip().upper()
+    if mode not in ("SHIP", "LOCAL_PICKUP"):
+        issues.append(f"shipping.fulfillment_mode: {mode!r} — must be SHIP or LOCAL_PICKUP")
+
     # SKU format: a stamped SKU must be canonical (8 hex). A legacy url-style
     # slug (e.g. "ebaybiz-sand-dollars" from an older app version) is flagged
     # here — `--record`/`--sync` auto-heal it via normalize_draft_identity, but
@@ -608,9 +614,12 @@ def _resolve_policies_and_location(creds: EbayCredentials) -> tuple[dict, str]:
     # Optional: a Media Mail fulfillment policy used for media items (books,
     # magazines, comics, music, movies). Not required — falls back to default.
     policies["fulfillment_media"] = _ebay_extra("fulfillment_policy_id_media")
+    # Optional: a Local-pickup-only policy used for ship-risky items (fragile /
+    # oversized). Not required — only items the user marks LOCAL_PICKUP need it.
+    policies["fulfillment_local_pickup"] = _ebay_extra("fulfillment_policy_id_local_pickup")
     location = _ebay_extra("merchant_location_key")
     for k, v in policies.items():
-        if k == "fulfillment_media":
+        if k in ("fulfillment_media", "fulfillment_local_pickup"):
             continue  # optional
         if not v:
             missing.append(f"ebay.{k}_policy_id")
@@ -728,17 +737,32 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
                              creds: EbayCredentials) -> tuple[str, list[str]]:
     """Choose the fulfillment policy for THIS item and validate it.
 
-    Routing: if the draft's `primary_service` is Media Mail (DRAFT sets this
-    for books/magazines/comics/music/movies) AND a media policy is configured,
-    use it; otherwise use the default (USPS Ground) policy. Returns
-    (chosen_fulfillment_id, messages).
+    Routing, in order:
+    1. If the draft is `fulfillment_mode: LOCAL_PICKUP` (DRAFT sets this for
+       ship-risky items the user confirmed as local-pickup), use the
+       local-pickup policy.
+    2. Else if `primary_service` is Media Mail (DRAFT sets this for
+       books/magazines/comics/music/movies) AND a media policy is configured,
+       use it.
+    3. Else use the default (USPS Ground) policy.
+    Returns (chosen_fulfillment_id, messages).
     """
     default_fid = str(policies.get("fulfillment") or "")
     media_fid = str(policies.get("fulfillment_media") or "")
+    pickup_fid = str(policies.get("fulfillment_local_pickup") or "")
+    mode = str(draft.get("shipping.fulfillment_mode") or "SHIP").strip().upper()
     want = str(draft.get("shipping.primary_service") or "").strip()
     msgs: list[str] = []
 
-    if _is_media_service(want):
+    if mode == "LOCAL_PICKUP":
+        if pickup_fid:
+            chosen, label = pickup_fid, "local pickup (pickup-only policy)"
+        else:
+            chosen, label = default_fid, "default ground (NO local-pickup policy configured)"
+            msgs.append("shipping: item is LOCAL_PICKUP but ebay.fulfillment_policy_id_local_pickup "
+                        "is unset — falling back to the default ground policy. Add a local-pickup "
+                        "policy (see SETUP_EBAY_API.md) so ship-risky items list as pickup-only.")
+    elif _is_media_service(want):
         if media_fid:
             chosen, label = media_fid, "Media Mail (media policy)"
         else:
@@ -758,10 +782,15 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
             offered = [s.get("shippingServiceCode")
                        for opt in (pol.get("shippingOptions") or [])
                        for s in (opt.get("shippingServices") or []) if s.get("shippingServiceCode")]
-            if not offered:
+            # A local-pickup-only / freight policy legitimately carries no parcel
+            # shippingServices — pickup/freight are top-level flags, not services.
+            pickup_or_freight = bool(pol.get("localPickup") or pol.get("freightShipping"))
+            if not offered and not pickup_or_freight:
                 msgs.append(f"shipping: policy '{pol.get('name')}' offers no services — publish may fail")
             else:
-                msgs.insert(0, f"shipping: using {label} -> '{pol.get('name')}' ({', '.join(offered)})")
+                desc = ", ".join(offered) if offered else (
+                    "local pickup" if pol.get("localPickup") else "freight")
+                msgs.insert(0, f"shipping: using {label} -> '{pol.get('name')}' ({desc})")
     except (EbayAPIError, EbayAuthError) as e:
         msgs.append(f"shipping: could not verify fulfillment policy ({e})")
     return chosen, msgs
@@ -853,6 +882,12 @@ def build_review_card(draft_path: Path,
         bo = f"on @ auto-decline ${_decl}" if _decl else "on"
     else:
         bo = "off"
+    _mode = str(draft.get("shipping.fulfillment_mode") or "SHIP").strip().upper()
+    if _mode == "LOCAL_PICKUP":
+        _hint = str(draft.get("shipping.local_pickup.location_hint") or "").strip()
+        fulfill = f"LOCAL PICKUP only{(' · ' + _hint) if _hint else ''} (no parcel shipping; freight by quote)"
+    else:
+        fulfill = "Ship" + (f" · {draft.get('shipping.primary_service')}" if draft.get("shipping.primary_service") else "")
 
     # Comps to verify: prefer structured comps.csv, else URL lines from price.txt.
     comps: list[str] = []
@@ -893,6 +928,7 @@ def build_review_card(draft_path: Path,
         f"Price:     ${price}  ·  Best Offer: {bo}",
         f"Condition: {cond}",
         f"Quantity:  {qty}   ·   Photos: {len(photos)} (hero: {hero})",
+        f"Fulfillment: {fulfill}",
         "Preflight (condition / shipping / insurance):",
         *[f"  • {m}" for m in pf],
         "Comps (open to verify):",
@@ -1480,6 +1516,7 @@ def _cli() -> None:
     ap.add_argument("--delete-item", metavar="SKU", help="Delete an inventory item (SKU) AND all its offers (permanent). DRY RUN unless --confirm.")
     ap.add_argument("--confirm", action="store_true", help="Required with --publish/--list/--end/--withdraw-offer/--delete-offer/--delete-item to actually act (otherwise dry runs).")
     ap.add_argument("--setup-check", action="store_true", help="Verify creds and list account policy IDs.")
+    ap.add_argument("--create-pickup-policy", action="store_true", help="Create (idempotent) a LOCAL-PICKUP-ONLY fulfillment policy and print its ID to paste into config (ebay.fulfillment_policy_id_local_pickup).")
     ap.add_argument("--check", action="store_true", help="Print module/credential status.")
     args = ap.parse_args()
 
@@ -1512,6 +1549,13 @@ def _cli() -> None:
             return
         if args.setup_check:
             _print_setup_check()
+            return
+        if args.create_pickup_policy:
+            pol = create_local_pickup_policy()
+            pid = pol.get("fulfillmentPolicyId")
+            print(f"[OK] local-pickup policy: {pid}  ({pol.get('name')!r}, localPickup={pol.get('localPickup')})")
+            print(f"  Paste into config.yaml under the active ebay.<env> block:")
+            print(f"    fulfillment_policy_id_local_pickup: \"{pid}\"")
             return
         if args.preflight:
             print(f"Preflight {args.preflight}:")

--- a/prompts/_shared.md
+++ b/prompts/_shared.md
@@ -149,7 +149,10 @@ Full contract in [RUN.md](../RUN.md); summary:
   runs automatically as Stage B of the comp hunt.)
 - **SOFT — proceed with default, log to `NEEDS_REVIEW.md`:** grouping
   questions, unit_type ambiguity, INVESTIGATE open questions, working-
-  price selection, lookup-value substitutions, missing required fields.
+  price selection, lookup-value substitutions, missing required fields,
+  the **local-pickup suggestion** for ship-risky items (heavy/oversized/
+  fragile — DRAFT suggests pickup-only but never assumes it; default
+  `SHIP`, see [draft.md](draft.md) "Local-pickup gate").
 
 A SOFT gate never blocks. Pick the documented default, write a one-line
 entry to `NEEDS_REVIEW.md`, keep going.

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -76,7 +76,35 @@ down to it.
 
 **shipping:** weight/dims from IDENTIFY (round up); `free_shipping` true →
 `domestic_shipping_type` FREE_FLAT_RATE; `primary_service` per Service
-map; `handling_time_days` 1; `item_location_zip` blank.
+map; `handling_time_days` 1; `item_location_zip` blank. **Set
+`fulfillment_mode` per the Local-pickup gate below** — default `SHIP`.
+
+**Local-pickup gate (SOFT — suggest, never assume).** Some items are
+awkward or unsafe to parcel-ship (heavy, oversized, or fragile like stained
+glass). For these we list as **local pickup** (no parcel shipping; freight
+offered by quote in the description), routed to the account's local-pickup
+fulfillment policy. Decide `fulfillment_mode`:
+
+- **Default `SHIP`.** Most items ship normally — leave `fulfillment_mode:
+  SHIP` and fill the shipping fields as usual.
+- **Set `LOCAL_PICKUP` only when the user has indicated it** — either they
+  said so for this item ("local only", "pickup only", "too fragile to ship"),
+  or you asked and they confirmed. The user usually says so up front.
+- **When to ASK (and you must ask before assuming):** if IDENTIFY's **Ship
+  risk** is `suggest-pickup` (weight > 25 lb or any side > 24 in), OR the item
+  is clearly fragile (stained/blown glass, thin porcelain), surface the
+  suggestion: *"This looks <reason> — risky to ship. List as local pickup
+  (freight by quote), or ship normally?"* **Attended:** ask and honor the
+  answer. **Headless (no one to ask):** keep `SHIP` (the safe non-blocking
+  default), and append a NEEDS_REVIEW line suggesting local pickup so it's
+  raised again at REVIEW. Never silently flip an item to pickup-only.
+- **When `LOCAL_PICKUP`:** set `fulfillment_mode: LOCAL_PICKUP`,
+  `free_shipping: false`, `domestic_shipping_type` blank, `primary_service`
+  blank (no parcel service); still record weight/dims (useful for a freight
+  quote). Set `local_pickup.location_hint` from the seller's city/region if
+  known. Add a short closing line to the description body: *"Local pickup only
+  — <location_hint>. Not local? Message me for a freight quote."* Log the
+  decision (+ trigger) in `meta.notes`.
 
 **photos:** image files in shoot dir, lexicographic (first = hero). If
 INVESTIGATE references photos by number, honor that order.
@@ -90,9 +118,12 @@ reads it.
 the only case eBay quantity > 1.
 
 ### Service map
+Applies only when `fulfillment_mode: SHIP`. (LOCAL_PICKUP offers no parcel
+service — leave `primary_service` blank.)
 Books/catalogs/magazines/media → `USPSMediaMail`. ≤15 lb non-media →
 `USPSGroundAdvantage`. >15 lb / oversized → `UPSGround`. freight/movers →
-blank + flag (needs a quote).
+blank + flag (needs a quote) — also a strong local-pickup candidate (gate
+above).
 
 ## Markdown body (description)
 

--- a/prompts/identify.md
+++ b/prompts/identify.md
@@ -186,6 +186,14 @@ Then one block per item, `--- Item <N> ---`, fields in this order:
 - **Estimated dimensions** — item size (not packed). Box `~L×W×H in`;
   cylinder `~dia×h in`; furniture `~W×D×H in`; flat `~L×W in`; irregular
   free-text w/ key measurements. Range when unsure.
+- **Ship risk** — `none` or `suggest-pickup`. Set `suggest-pickup` when the
+  item is awkward/unsafe to parcel-ship: estimated weight **> 25 lb** OR any
+  estimated dimension **> 24 in (2 ft)** on a side. Add a short reason
+  (`too heavy ~40 lb` / `> 2 ft long (38 in)`). This is only a *signal* for
+  DRAFT's local-pickup suggestion — IDENTIFY never decides fulfillment. If you
+  can't estimate weight/dims, leave `none` and rely on `needs_followup_photo`.
+  (Fragility the user names is honored at DRAFT too, but the auto-trigger here
+  is purely weight/size.)
 - **Distinguishing marks** — free-text, uncapped catch-all: cover text,
   dated copyright, photographer credit, model number, materials, the rich
   context that does NOT fit the capped fields above.

--- a/prompts/list_edit_chrome.md
+++ b/prompts/list_edit_chrome.md
@@ -165,8 +165,14 @@ typing + Enter (via `form_input`/`computer`), not a JS value set.
    (= the Recommended tier). Leave auto-accept empty. If
    `best_offer.enabled` is false (list price ≤ Recommended), leave offers
    off.
-6. **Shipping:** confirm/set free shipping + `primary_service` (three-dot
-   → Change service → search → select → Done). Weight/dims already set.
+6. **Shipping:** if `shipping.fulfillment_mode` is **LOCAL_PICKUP**, do NOT
+   set a parcel service — instead choose eBay's **local pickup** option
+   ("No shipping — local pickup only" / enable "Local pickup") and leave the
+   shipping service empty; weight/dims can stay for reference. The draft's
+   description already carries the "freight by quote" line. Otherwise
+   (**SHIP**, the default): confirm/set free shipping + `primary_service`
+   (three-dot → Change service → search → select → Done). Weight/dims already
+   set.
 7. **Photos:** see "Photo upload" below — use the first method that's
    available; never fake success.
 8. **Settle + verify before save (MANDATORY — this is what stops missing

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -32,6 +32,7 @@ Present that card to the user **verbatim** and STOP. It contains:
 
     ━━ REVIEW: <item> (sku … · ledger …) ━━
     Title [N/80] · Price · Best Offer · Condition · Quantity · Photos
+    Fulfillment (Ship · service, OR LOCAL PICKUP only — confirm pickup items)
     Preflight (condition · shipping · insurance)
     Comps (open to verify) — each with a URL
     Condition detail (every flagged defect, verbatim — never softened)

--- a/templates/listing-v1.md
+++ b/templates/listing-v1.md
@@ -105,6 +105,17 @@ best_offer:
 # Dimensions: inches, all maxLen=5. eBay form fields [57][58][59].
 # Round UP. Use packed dims (including box + padding), not bare item dims.
 shipping:
+  # Fulfillment mode: SHIP (default — parcel shipping, fields below apply) or
+  # LOCAL_PICKUP (ship-risky item — fragile/oversized — the USER confirmed as
+  # pickup-only). DRAFT sets LOCAL_PICKUP only after an explicit user OK (see
+  # the soft-gate suggestion in draft.md). LOCAL_PICKUP routes to the account's
+  # local-pickup fulfillment policy (ebay.fulfillment_policy_id_local_pickup);
+  # eBay treats local pickup as exclusive, so no parcel shipping is offered —
+  # the freight fallback is offered by quote in the description body.
+  fulfillment_mode: "SHIP"     # SHIP | LOCAL_PICKUP
+  local_pickup:                # only meaningful when fulfillment_mode == LOCAL_PICKUP
+    freight_quote: true        # invite distant buyers to message for a freight quote
+    location_hint: ""          # city/region shown to buyers (from seller profile)
   weight:
     major_lb: 0                # maxLen=3
     minor_oz: 0                # maxLen=2
@@ -112,7 +123,7 @@ shipping:
     length: 0                  # maxLen=5
     width:  0                  # maxLen=5
     depth:  0                  # maxLen=5
-  free_shipping: true          # eBay form field [61] — default ON
+  free_shipping: true          # eBay form field [61] — default ON; ignored when LOCAL_PICKUP
   # CALCULATED | FLAT_RATE | FREE_FLAT_RATE
   # When free_shipping is true this is FREE_FLAT_RATE.
   domestic_shipping_type: "FREE_FLAT_RATE"


### PR DESCRIPTION
## Implemented — local pickup for ship-risky items

Heavy, oversized, or fragile items (stained glass, porcelain) can now be listed as **local pickup only** (no parcel shipping), routed to a dedicated eBay fulfillment policy. The freight fallback for distant buyers is offered **by quote in the listing description**.

### Decisions (from the requester)
- **Soft gate, never assume.** Default is always `SHIP`. DRAFT *suggests* pickup but only sets `LOCAL_PICKUP` when the user indicates it or confirms when asked. Headless runs keep `SHIP` and log to `NEEDS_REVIEW`.
- **Auto-suggest trigger:** weight **> 25 lb** OR any side **> 24 in (2 ft)** (set in IDENTIFY). User-named fragility is also honored at DRAFT.
- **Freight = fallback by quote** in the description.

### ⚠️ eBay constraint we hit (shaped the design)
eBay does **not** allow a single "pickup + freight" policy:
- `localPickup: true` is **exclusive** — rejects freight, parcel, *and even `handlingTime`* ("No other shipping services can be specified with Local pick up").
- A `Pickup` *service* alongside freight silently **drops the pickup** → freight-only.

So the working pickup-only policy is minimal: `localPickup: true`, no `handlingTime`, no `shippingOptions`. Freight therefore lives in the description.

**Created on production:** `fulfillment_policy_id_local_pickup = 292766452014` ("Local pickup only (freight by quote)"). Reproducible via `python lib/list_edit.py --create-pickup-policy` (idempotent).

### What changed
- **lib/ebay_client.py** — `create_local_pickup_policy()` (idempotent).
- **lib/list_edit.py** — route `fulfillment_mode: LOCAL_PICKUP` to the pickup policy; enum guard so a typo can't silently ship a fragile item; `Fulfillment` line on the review card; `--create-pickup-policy` CLI; pickup/freight policies count as valid (no parcel service).
- **templates/listing-v1.md** — `shipping.fulfillment_mode` + `local_pickup` block.
- **prompts/** — IDENTIFY ship-risk signal; DRAFT local-pickup gate; REVIEW card; Chrome stand-in; `_shared.md`/`RUN.md` soft-gate contract.
- **lib/config.example.yaml** + **lib/SETUP_EBAY_API.md** — new optional `fulfillment_policy_id_local_pickup`.

### Verified
- `--create-pickup-policy` idempotent (returns `292766452014`).
- Routing: `LOCAL_PICKUP` → pickup policy; `SHIP` → ground (live account).
- Validator: rejects a `fulfillment_mode` typo; existing drafts still pass.

### Not done
- No live pickup-only listing published yet — the first fragile item (e.g. the Fenton glass lamps) will exercise DRAFT → REVIEW → `--list` end-to-end.
- Sandbox has no pickup policy configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
