### PR TITLE
feat(identify): stop-and-ask maker-mark gate for mark-likely categories

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -71,7 +71,19 @@ Reclassify every "ask the user" moment as HARD or SOFT.
    "ok"/"looks good"/silence. (This replaced the old absolute no-publish
    firewall — publishing is now gated here, not forbidden.)
 
-This is the ONLY reason a run stops. PRICE's Apify call (Stage B) used to
+2. **The IDENTIFY maker-mark gate (interactive only).** In a gate category —
+   jewelry, precious metals, glass, pottery/ceramics (editable list in
+   [prompts/identify.md](prompts/identify.md)) — when a maker's mark is plausibly
+   present but undecisive from the photos, IDENTIFY STOPS and asks the user to
+   read the inside/underside marking before spending on searches/Lens or settling
+   Brand. A clear no-mark-likely item (plain modern glass, generic terracotta)
+   takes a logged exception and proceeds. This gate exists only when a human is
+   at the keyboard; in a headless run (cron, `full`/`list` with no one to answer)
+   it degrades to the SOFT path — `needs_followup_photo` + a `NEEDS_REVIEW.md`
+   line — and the run proceeds.
+
+REVIEW is the only thing that stops a **headless** run (the maker-mark gate
+above is interactive-only). PRICE's Apify call (Stage B) used to
 be a second HARD gate; it no longer is — Apify runs automatically as part
 of the comp hunt (`automation-lab/ebay-sold-scraper`, ~$0.10/run), no cost
 confirmation. See PRICE for the Stage-A/B/C ordering and the currency-leak
@@ -107,6 +119,7 @@ Append (don't overwrite) one line per deferred decision:
 Example:
 
     [IDENTIFY] items 2-3 — kept as 2 singles (default); possible brass-candlestick pair
+    [IDENTIFY] silver-pot — Brand left Unknown; mark present but illegible, needs base macro (maker-mark gate degraded, headless)
     [PRICE] iron — adopted Recommended $48 as working price; no exact comp, era-peer anchor
     [INVESTIGATE] iron — committed "Size 5 sad iron"; maker stamp not photographed
 

--- a/prompts/_shared.md
+++ b/prompts/_shared.md
@@ -140,13 +140,21 @@ never version-controlled**.
 
 ## Gate contract (what may stop a headless run)
 
-ONE gate stops a run. Everything else proceeds with a logged default.
-Full contract in [RUN.md](../RUN.md); summary:
+In a headless run, ONE gate stops it — REVIEW; everything else proceeds with a
+logged default. An **interactive** run adds one more: IDENTIFY's maker-mark
+stop-and-ask. Full contract in [RUN.md](../RUN.md); summary:
 
 - **HARD — stop and ask:** the REVIEW gate — after DRAFT, present the
   review card and STOP; publish LIVE only on explicit approval
   ([review.md](review.md)). (PRICE's Apify call is no longer a gate — it
   runs automatically as Stage B of the comp hunt.)
+- **HARD (interactive only) — stop and ask:** IDENTIFY's maker-mark gate —
+  in a gate category (jewelry, precious metals, glass, pottery — editable list in
+  [identify.md](identify.md)) with a mark that's likely-present but undecisive,
+  stop and ask the user to read the inside marking before searches or settling
+  Brand. A clear no-mark-likely exception may skip it (logged). Headless (no
+  user to ask) → degrades to SOFT (`needs_followup_photo` + a `NEEDS_REVIEW.md`
+  line, then proceed).
 - **SOFT — proceed with default, log to `NEEDS_REVIEW.md`:** grouping
   questions, unit_type ambiguity, INVESTIGATE open questions, working-
   price selection, lookup-value substitutions, missing required fields.

--- a/prompts/identify.md
+++ b/prompts/identify.md
@@ -50,6 +50,46 @@ SEO, and informs authenticity. So `Unknown` is a LAST RESORT after a real
 attribution attempt — never a lazy default. Run this pass on every item before
 settling Brand:
 
+**Stop-and-ask gate (mark-likely categories, interactive runs).** Some
+categories almost always carry a maker's mark that swings value hard. These are
+the **gate categories** — the editable list that arms the stop-and-ask (grow it
+as you learn; "for now" it is):
+
+- **Jewelry** — incl. gemstone & costume pieces (maker / karat / assay / stone
+  marks, usually on the clasp, gallery, or inner band).
+- **Precious metals** — silver/sterling, gold, platinum (holloware, flatware,
+  plate; hallmarks, assay/karat marks, EPNS/EP, maker roundels + pattern
+  numbers).
+- **Glass** — anything made of glass (art, pressed, cut, studio; pontil,
+  acid-etched, or sticker marks).
+- **Pottery / ceramics / porcelain** — backstamps, impressed/painted marks,
+  pattern names/numbers, country-of-origin wording.
+
+When an item is in a gate category AND a mark is **plausibly present but you
+cannot decisively read it from the photos** (illegible, obscured, or on a
+surface this shoot doesn't show), **STOP and ask the user to read the
+inside/underside marking before you spend on searches/Lens or settle Brand.**
+The user is holding the piece; their close-read of the mark beats any web or
+Lens guess and is the cheapest path to a confirmed maker. Ask specifically —
+name the surface and what to look for ("Can you read the mark on the base of the
+silver pot? Any lion/letters, 'STERLING'/'EPNS', or a number?"). Resume the pass
+below with whatever they report; only if they decline or genuinely can't read it
+do you fall through to research → Lens → (last resort) Unknown.
+
+**Exception (skip the stop).** A gate category is a *default* to stop, not an
+absolute. If THIS specific piece is plainly mass-produced / unmarked / low-value
+such that a maker's mark is genuinely unlikely AND a maker wouldn't move
+value or SEO — a plain modern drinking glass, a generic unmarked terracotta pot,
+a strand of costume beads — you MAY proceed without asking. Log the carve-out in
+one line (`exception: <why a mark is unlikely here>`) so the skip is auditable.
+When genuinely in doubt, stop and ask: a missed mark is the most expensive thing
+to leave on the table.
+
+This is a HARD stop in an **interactive** run. In a **headless** run (no user to
+ask) it degrades to the SOFT path: set `needs_followup_photo: yes` naming the
+exact macro shot, log the question to `NEEDS_REVIEW.md`, and proceed with the
+attribution pass below.
+
 1. **Hunt every mark.** Scan ALL surfaces for any mark — base/underside, foot
    rim, back, lid underside, inside rim, handle/spout joins, seams, stickers/
    labels. A mark, stamp, signature, hallmark, trademark, pattern/model number,
@@ -75,7 +115,10 @@ settling Brand:
    step (the macro shot or test that would confirm). Only a legible, matched
    mark earns a maker WITHOUT `[BEST-CASE]`. A genuinely markless piece, or a
    purely decorative fantasy pseudo-hallmark with no maker name, is honestly
-   `Unknown` — say which it is.
+   `Unknown` — say which it is. Reach `Unknown`/`Unbranded` only AFTER you have
+   genuinely worked at least two SPECIFIC maker candidates — name each, then rule
+   it out against an observable — never as a first-pass shrug. Note the
+   candidates you considered and why each failed so the rejection is auditable.
 
 **Honesty guard (unchanged, non-negotiable):** trying harder is NOT license to
 invent. Do not promote a guess to a stated maker, and do not read a maker into


### PR DESCRIPTION
## What

Adds an **interactive stop-and-ask maker-mark gate** to IDENTIFY. For mark-likely, high-leverage **gate categories** — jewelry, precious metals, glass, pottery/ceramics — when a maker's mark is plausibly present but undecisive from the photos, IDENTIFY **stops and asks the user to read the inside/underside marking** before spending on searches/Lens or settling Brand. The user is holding the piece, so their close-read beats any web/Lens guess and is the cheapest path to a confirmed maker.

## Why

Brand is the single highest-leverage field (changes PRICE tier, enables exact maker+pattern comps, sharpens SEO). The old flow silently defaulted unreadable marks to a soft follow-up; this elevates the highest-value cases to a real stop so we don't leave a confirmable maker on the table.

## Behavior

- **Interactive run:** HARD stop — ask the user to read the mark.
- **Headless run** (cron / `full` / `list`, no user to ask): degrades to the existing SOFT path — `needs_followup_photo` + a `NEEDS_REVIEW.md` line — and proceeds. So the "REVIEW is the only thing that stops a headless run" contract still holds.
- **Exception valve:** skip the stop (logged, one line) when a specific piece is plainly mass-produced / unmarked / low-value so a mark is genuinely unlikely *and* a maker wouldn't move value/SEO (plain modern glass, generic terracotta, costume beads).
- **Unknown bar raised:** `Unknown`/`Unbranded` now requires genuinely working ≥2 specific maker candidates first, each ruled out against an observable — never a first-pass shrug.

## Files

- `prompts/identify.md` — the gate, the editable gate-categories list, the exception valve, the raised Unknown bar.
- `prompts/_shared.md` — gate-contract summary updated (adds the interactive-only HARD gate).
- `RUN.md` — full gate contract + a `NEEDS_REVIEW.md` example for the headless-degraded case.

The gate-categories list lives in `prompts/identify.md` and is meant to be grown over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
