### PR TITLE
feat: extensible category-specialization system + marbles module

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -188,6 +188,9 @@ only pass `--confirm` on an explicit yes. Use `--offers` to find IDs.
 Cross-cutting depth rules:
 - Condition analysis in IDENTIFY and INVESTIGATE uses
   [prompts/condition-rubric.md](prompts/condition-rubric.md).
+- IDENTIFY loads a category **specialization** (expert field guide) when an
+  item matches one — registry + modules in
+  [specializations/README.md](specializations/README.md) (e.g. marbles).
 - PRICE runs the autonomous exact-match hunt (Stage A WebSearch → Stage B
   Apify eBay-sold → optional Stage C Chrome when confidence is low) before
   any era-peer fallback; see its prompt.

--- a/lib/config.example.yaml
+++ b/lib/config.example.yaml
@@ -74,6 +74,10 @@ ebay:
                                          # sized) marked fulfillment_mode LOCAL_PICKUP.
                                          # Create via `--create-pickup-policy`.
     payment_policy_id: null
+    payment_policy_id_auction: null      # optional: a payment policy with immediate
+                                         # payment OFF; required for AUCTION offers
+                                         # (eBay forbids immediate-pay on auctions).
+                                         # Falls back to payment_policy_id if unset.
     return_policy_id: null
 
   production:
@@ -91,6 +95,10 @@ ebay:
                                          # sized) marked fulfillment_mode LOCAL_PICKUP.
                                          # Create via `--create-pickup-policy`.
     payment_policy_id: null
+    payment_policy_id_auction: null      # optional: a payment policy with immediate
+                                         # payment OFF; required for AUCTION offers
+                                         # (eBay forbids immediate-pay on auctions).
+                                         # Falls back to payment_policy_id if unset.
     return_policy_id: null
 
 # ---------------------------------------------------------------------------

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -568,14 +568,14 @@ def _build_inventory_item(draft: Draft, image_urls: list[str]) -> dict:
 def _build_offer(draft: Draft, sku: str, category_id: str,
                  location_key: str, policies: dict) -> dict:
     price = _to_decimal_str(draft.get("price"))
+    fmt = str(draft.get("format") or "FIXED_PRICE").upper()
     offer: dict = {
         "sku": sku,
         "marketplaceId": DEFAULT_MARKETPLACE,
-        "format": "FIXED_PRICE",
+        "format": fmt,
         "availableQuantity": int(draft.get("quantity") or 1),
         "categoryId": str(category_id),
         "listingDescription": _body_to_html(draft.body),
-        "pricingSummary": {"price": {"value": price, "currency": CURRENCY}},
         "merchantLocationKey": location_key,
         "listingPolicies": {
             "fulfillmentPolicyId": policies["fulfillment"],
@@ -583,15 +583,30 @@ def _build_offer(draft: Draft, sku: str, category_id: str,
             "returnPolicyId": policies["return"],
         },
     }
-    if draft.get("best_offer.enabled"):
-        terms: dict = {"bestOfferEnabled": True}
-        decline = _to_decimal_str(draft.get("best_offer.auto_decline_amount"))
-        accept = _to_decimal_str(draft.get("best_offer.auto_accept_amount"))
-        if decline:
-            terms["autoDeclinePrice"] = {"value": decline, "currency": CURRENCY}
-        if accept:
-            terms["autoAcceptPrice"] = {"value": accept, "currency": CURRENCY}
-        offer["listingPolicies"]["bestOfferTerms"] = terms
+    if fmt == "AUCTION":
+        # Auctions: the start bid goes in auctionStartPrice (NOT price); a
+        # listingDuration is REQUIRED (DAYS_1..DAYS_10); availableQuantity is
+        # rejected (always 1 implicitly); Best Offer is not permitted. eBay also
+        # forbids immediate-payment on auctions, so use the auction-specific
+        # payment policy (no immediate pay) when configured.
+        offer.pop("availableQuantity", None)
+        offer["pricingSummary"] = {
+            "auctionStartPrice": {"value": price, "currency": CURRENCY}
+        }
+        offer["listingDuration"] = str(draft.get("listing_duration") or "DAYS_7").upper()
+        if policies.get("payment_auction"):
+            offer["listingPolicies"]["paymentPolicyId"] = policies["payment_auction"]
+    else:
+        offer["pricingSummary"] = {"price": {"value": price, "currency": CURRENCY}}
+        if draft.get("best_offer.enabled"):
+            terms: dict = {"bestOfferEnabled": True}
+            decline = _to_decimal_str(draft.get("best_offer.auto_decline_amount"))
+            accept = _to_decimal_str(draft.get("best_offer.auto_accept_amount"))
+            if decline:
+                terms["autoDeclinePrice"] = {"value": decline, "currency": CURRENCY}
+            if accept:
+                terms["autoAcceptPrice"] = {"value": accept, "currency": CURRENCY}
+            offer["listingPolicies"]["bestOfferTerms"] = terms
     return offer
 
 
@@ -617,9 +632,13 @@ def _resolve_policies_and_location(creds: EbayCredentials) -> tuple[dict, str]:
     # Optional: a Local-pickup-only policy used for ship-risky items (fragile /
     # oversized). Not required — only items the user marks LOCAL_PICKUP need it.
     policies["fulfillment_local_pickup"] = _ebay_extra("fulfillment_policy_id_local_pickup")
+    # Optional: a payment policy WITHOUT immediate-payment, required for AUCTION
+    # offers (eBay forbids immediate-pay on auctions — error 25003). Only auction
+    # listings need it; falls back to the default payment policy otherwise.
+    policies["payment_auction"] = _ebay_extra("payment_policy_id_auction")
     location = _ebay_extra("merchant_location_key")
     for k, v in policies.items():
-        if k in ("fulfillment_media", "fulfillment_local_pickup"):
+        if k in ("fulfillment_media", "fulfillment_local_pickup", "payment_auction"):
             continue  # optional
         if not v:
             missing.append(f"ebay.{k}_policy_id")
@@ -1225,7 +1244,8 @@ def publish_offer(draft_path: Path, creds: Optional[EbayCredentials] = None,
 
     off = api_send("GET", f"/sell/inventory/v1/offer/{offer_id}", creds=creds)
     status = str(off.get("status") or "UNKNOWN")
-    price = str(((off.get("pricingSummary") or {}).get("price") or {}).get("value") or "?")
+    _ps = off.get("pricingSummary") or {}
+    price = str((_ps.get("price") or _ps.get("auctionStartPrice") or {}).get("value") or "?")
     sku = str(off.get("sku") or draft.get("meta.ebay_inventory_sku") or "")
     title = str(draft.get("title") or "")
     if not title and sku:

--- a/prompts/condition-rubric.md
+++ b/prompts/condition-rubric.md
@@ -87,3 +87,26 @@ its decisions.
   one-line condition summary feed "Listing-safe claims"; un-assessables
   go in "NOT defensible". DRAFT writes every flagged defect into the
   listing's Condition section — defects always survive any trim.
+
+### `condition_description` field — write it telegraphic
+
+The eBay `condition_description` is a **factual defect disclosure, not
+sales copy**. Absolute minimum information that protects against an INAD
+return. Sentence fragments are correct; full warm sentences are not.
+
+Order, each part only if it applies:
+1. **Defects** — every flagged defect, as `<location>: <defect>`
+   fragments. Severity word only when it changes buyer expectation
+   (`hairline crack`, `light shelf wear`). This part never gets trimmed.
+2. **Grade-relevant clears** — one terse `No <defects> noted.` covering
+   the defects a buyer would reasonably fear for this material/grade
+   (e.g. `No chips, cracks, or repairs.`). Skip clears that don't bear on
+   the grade.
+3. **Can't-assess** — untested function, undersides/interior unseen,
+   smoke-free not verifiable from photos. One fragment.
+
+**Never** include: narrative ("removed from box only to photograph"),
+marketing adjectives, decorative description of the item itself (that's
+the title/specifics), or what's-included (that's the body's What's
+Included). If a clause doesn't disclose a defect, a grade-relevant clear,
+or a limit of inspection, it does not belong in this field.

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -45,8 +45,11 @@ repeat a claim INVESTIGATE confirmed.
 - `category_id` blank (eBay suggests at LIST) · `category_path` from
   INVESTIGATE/IDENTIFY category (human-readable only).
 - `condition` — map INVESTIGATE's grade (already from condition-rubric)
-  to `CONDITION_ENUM`. · `condition_description` from INVESTIGATE's
-  observable condition lines; ≤1000; **every flagged defect survives**.
+  to `CONDITION_ENUM`. · `condition_description` — telegraphic factual
+  disclosure per condition-rubric's "write it telegraphic" spec: defect
+  fragments → one grade-relevant `No … noted.` → can't-assess. No
+  narrative, marketing, decorative description, or what's-included.
+  ≤1000 but aim far shorter; **every flagged defect survives**.
 
 **item_specifics:** from INVESTIGATE's "Item specifics" section ONLY. If
 INVESTIGATE listed it, copy; else `""` — do NOT fall back to IDENTIFY.
@@ -131,9 +134,10 @@ Compose from INVESTIGATE's claim set only:
 - **Hook** (1–2 sentences) from INVESTIGATE Summary, buyer-facing.
 - **What's Included** — bullets from observable components; unit-type
   vocabulary.
-- **Condition** — one warm framing sentence + bullets enumerating EVERY
-  defect INVESTIGATE flagged (no minimizing); context sentence for
-  vintage wear.
+- **Condition** — factual, minimal. Bullets enumerating EVERY defect
+  INVESTIGATE flagged (no minimizing), each as `<location>: <defect>`.
+  At most one short context line for expected vintage wear; no warm
+  framing sentence, no marketing. Defects always survive any trim.
 - **About this item** — 1–2 sentence collector hook from INVESTIGATE's
   listing-approach.
 
@@ -154,8 +158,9 @@ Satisfy by **rephrasing, never mid-word truncation:**
   words. Always keep brand (or "Vintage"/"Unbranded") + the noun.
 - item_specifics: shortest correct canonical form (`Store Catalog`, not a
   prose sentence).
-- condition_description: trim redundancy first, then least-critical
-  observations; defects always stay; end at a sentence boundary.
+- condition_description: already telegraphic, so rarely near the cap. If
+  over, drop grade-relevant clears first, then can't-assess; defects
+  always stay; end at a fragment boundary.
 - numeric fields: the cap is on the string form. If a real value won't
   fit, the input is wrong (round/re-measure/flag) — never drop digits.
 - `lookup_only` (`country_of_origin`, `department`): substitute closest

--- a/prompts/identify.md
+++ b/prompts/identify.md
@@ -54,6 +54,33 @@ Marker discipline (per _shared confidence rule):
   mid-to-late"). No bracket.
 - `Unknown` — no real basis. Not a license to invent the priciest identity.
 
+## Category specializations (load expert knowledge on a match)
+
+Some categories have a dedicated **specialization module** — a self-contained
+expert field guide under [`../specializations/`](../specializations/). After you
+form an item's first-pass Category, check the registry table in
+[`../specializations/README.md`](../specializations/README.md): match the item's
+category / material / keywords against each module's **Triggers**. On a hit, the
+item is *in specialization* — **read that module file and apply it** before
+settling this item's fields.
+
+A loaded module gives you, for that item: the maker/type taxonomy and visual
+tells, the named high-value types to watch for, the category's own condition
+vocabulary, the authentication/fake tests, and a coarse **value tier**. Use it
+to:
+
+- settle Brand / Type / Era / Condition with specialist precision;
+- record the module's **value tier** in Distinguishing marks (so PRICE/CURATE
+  know which items deserve the exact-comp hunt vs which are filler);
+- set `needs_followup_photo` to the SPECIFIC inspection shot the module names
+  (e.g. a pontil/seam macro) when the confident call needs an inspection the
+  photos don't show.
+
+A specialization **refines, never overrides** the honesty rules and the
+maker-attribution discipline below: still no inventing, still `[BEST-CASE]` +
+scenario bracket for value-swing inferences, still the maker-mark gate. If no
+module's triggers match, proceed with the general pass as normal.
+
 ## Maker / brand attribution (work it HARD — high leverage)
 
 Brand is the single highest-leverage field: a confirmed maker changes the

--- a/specializations/README.md
+++ b/specializations/README.md
@@ -1,0 +1,93 @@
+# Specializations — category-expert knowledge modules
+
+A **specialization** is a self-contained expert field guide for one category
+of item (marbles, fountain pens, pocket knives…). When IDENTIFY meets an item
+whose category matches a module's triggers, it **loads that module and applies
+its rules** — turning a generalist identification into a specialist one:
+better attribution, the named high-value types flagged, the right condition
+vocabulary, the inspection shots a specialist would ask for, and a coarse
+value tier so PRICE and CURATE start from an informed anchor.
+
+This is prompt-driven, like the rest of v3 — a module is just a Markdown file
+the pipeline reads on demand. No code, no build step. Adding the next
+specialization is: drop a new file in here, add one row to the registry below.
+
+---
+
+## Registry (the index IDENTIFY checks)
+
+IDENTIFY reads THIS table to decide whether a specialization applies. Match an
+item's category/material against the **Triggers** column; on a hit, load that
+module before settling the item's fields. Keep this table in sync with the
+files in this directory — it is the single source of truth for what's active.
+
+| Module | Triggers (category / material / keyword match) | Status |
+|---|---|---|
+| [marbles.md](marbles.md) | marble, marbles, shooter, swirl, sulphide, agate (as a marble), "glass ball" toy, marble lot/jar/collection | active |
+
+_Add a row per new module. Triggers should be specific enough not to fire on
+unrelated items (e.g. "agate" alone is also a gemstone — qualify it)._
+
+---
+
+## How IDENTIFY uses a module (the contract)
+
+1. **Detect.** After forming a first-pass Category for an item, scan this
+   registry's Triggers. On a match, the item is *in specialization* — load the
+   module file.
+2. **Apply.** Use the module's taxonomy, value drivers, condition vocabulary,
+   and authentication tests to settle Brand / Type / Era / Condition and the
+   distinguishing-marks field. The module **refines**, never overrides, the
+   honesty rules in [`../prompts/_shared.md`](../prompts/_shared.md) and the
+   maker-attribution discipline in
+   [`../prompts/identify.md`](../prompts/identify.md): still no inventing, still
+   `[BEST-CASE]` + scenario brackets for value-swing inferences.
+3. **Flag value.** Emit the module's **value tier** for the item (its coarse
+   triage band) in Distinguishing marks, so PRICE/CURATE know which items
+   deserve the exact-comp hunt and which are filler.
+4. **Request the right shots.** If the confident call needs an inspection the
+   photos don't show, set `needs_followup_photo` to the SPECIFIC shot the
+   module names (e.g. for marbles, a pontil/seam macro), not a generic "more
+   photos".
+
+A specialization adds expertise; it does not change the gate contract. The
+maker-mark stop-and-ask, the SOFT-gate defaults, and the publish firewall all
+still apply exactly as in [`../RUN.md`](../RUN.md).
+
+---
+
+## Module file schema
+
+Every module follows [`_template.md`](_template.md) so they stay
+interchangeable. Required sections:
+
+- **Front matter** — `triggers`, `version`, `last_reviewed`, source list.
+- **When this applies** — the precise trigger conditions + carve-outs.
+- **Fast triage** — the 30-second-per-item pass for sorting a big lot into
+  "look closer" vs "filler". This is the workhorse for a 1000+ item pile.
+- **Taxonomy** — makers/types and how to recognize each.
+- **The money types** — the named high-value items and their tells.
+- **Value drivers** — what moves price, in priority order.
+- **Condition grading** — the category's own vocabulary + how defects cut value.
+- **Authentication & fakes** — antique vs modern/repro; common forgeries.
+- **Price tiers** — coarse bands ($ / $$ / $$$ / $$$$) with what lands in each.
+- **Inspection shots** — the macro/lighting the specialist asks for.
+- **Output hooks** — how the module's findings map onto IDENTIFY's fields.
+- **Sources** — the reputable references behind the module.
+
+Keep modules **evidence-based and dated**: cite the source class (specialist
+society, auction house, standard reference book) and record `last_reviewed` so
+stale market claims can be refreshed. Prices are tiers and signals, not
+quotes — the live PRICE phase still hunts real comps.
+
+---
+
+## Adding a new specialization
+
+1. Copy `_template.md` to `<category>.md`.
+2. Research it from reputable, specialist sources (society/club references,
+   established auction houses, standard reference books — not random listings).
+   The `deep-research` skill is a good way to gather and fact-check the body.
+3. Fill every section; set `version: 1` and today's `last_reviewed`.
+4. Add a row to the registry table above with specific triggers.
+5. That's it — IDENTIFY will pick it up on the next run that hits the triggers.

--- a/specializations/_template.md
+++ b/specializations/_template.md
@@ -1,0 +1,77 @@
+# <Category> — specialization module
+
+<!--
+Copy this file to <category>.md and fill every section. Then add a row to
+README.md's registry. Keep it evidence-based and dated. Delete these comments.
+-->
+
+```yaml
+triggers: [<keyword>, <keyword>, <category>, <material>]   # what activates this module in IDENTIFY
+version: 1
+last_reviewed: <YYYY-MM-DD>
+sources:
+  - <specialist society / club reference>
+  - <established auction house>
+  - <standard reference book — author, title>
+```
+
+## When this applies
+
+Precise trigger conditions and carve-outs. When does an item count as in-scope,
+and when does a look-alike NOT (e.g. material overlaps with another category)?
+
+## Fast triage (the big-lot pass)
+
+The 30-seconds-per-item sort: the few cues that move an item from "filler" to
+"look closer". Optimized for triaging a large collection fast. End with the
+rule: when in doubt, pull it for a closer look.
+
+## Taxonomy — makers / types and how to recognize each
+
+The maker/type landscape with the concrete visual tells for each.
+
+## The money types (named high-value items)
+
+The specific named types/patterns that command real money, each with its
+identifying features and why it's valuable. This is the watch-list.
+
+## Value drivers (priority order)
+
+What moves price, ranked. How the drivers interact.
+
+## Condition grading
+
+The category's own grading vocabulary and how each defect class cuts value.
+
+## Authentication & fakes
+
+Antique/genuine vs modern/reproduction/forgery; the tells and the known fakes.
+
+## Price tiers (coarse bands)
+
+| Tier | Band | What lands here |
+|---|---|---|
+| $ | | |
+| $$ | | |
+| $$$ | | |
+| $$$$ | | |
+
+Tiers are triage signals, not quotes — PRICE still hunts live comps.
+
+## Inspection shots
+
+The specific macro/lighting a specialist asks for to resolve identity or
+condition — what IDENTIFY should request via `needs_followup_photo`.
+
+## Output hooks (maps onto IDENTIFY fields)
+
+- **Brand** → …
+- **Type** → …
+- **Era** → …
+- **Condition** → …
+- **Distinguishing marks** → include the **value tier** here.
+- **needs_followup_photo** → the inspection shot above.
+
+## Sources
+
+Full reputable-source list with what each is good for.

--- a/specializations/marbles.md
+++ b/specializations/marbles.md
@@ -132,6 +132,17 @@ Sort the pile into **PULL** (look closer) vs **FILLER** (jar lot) in seconds:
 - **Marble King** — patches (two-color "rainbows"), the bread-and-butter of
   later mass marbles; mostly common. *Thinner coverage — verify.*
 
+**Modern foreign mass-makers (the bulk of any pile — usually filler):**
+- **Vacor de Mexico** (a.k.a. Mega Marbles; 1990s–2000s+) — the dominant modern
+  maker. Patches & swirls in transparent or opaque glass; named series incl.
+  **"Planet"/"splatterpatch"** (dark transparent base densely packed with
+  embedded opaque multicolor SPECKLE spots — Jupiter, etc.), galaxy/sun/animal
+  themes. **Tell: a faintly pitted "orange-peel" surface + an oily, extra-shiny
+  sheen.** Machine-made (patch/cut marks, not hand pontils — though the two
+  patch-fold marks are easily MISREAD as pontils). Value ~**$1** single (a
+  "Vacor Planet splatterpatch 5/8 Mint" sold for $1.00); lots are the play.
+- **Modern Chinese** — bag/dollar-store cat's-eyes and patches; filler.
+
 > Coverage note: verified depth is strongest on **Christensen Agate, Peltier,
 > Akro, and Lutz/handmade**. For **M.F. Christensen, Vitro, Master, Marble
 > King**, identify cautiously and use `[BEST-CASE]` + Lens/web confirmation
@@ -180,6 +191,12 @@ Pull and price-hunt these on sight:
   base** is rarer than the common white/yellow ground, and bright splotches shade
   toward "Clown". Confirm cloud-vs-onionskin against the End-of-Day reference
   photos (see Reference library) — the two look alike and price differently.
+  ⚠ **Biggest trap:** a dark-base SPECKLED marble is far more often a **modern
+  Vacor "Planet"/splatterpatch (~$1)** than an antique Cloud ($60–95). Before
+  pricing a speckled marble as an antique Cloud, **run Google Lens** (it cleanly
+  flags Vacor Planets) AND check the surface — Vacor's **orange-peel pitting +
+  oily sheen** and the ~5/8″/.61″ size give it away. Antique Clouds have smoother
+  period glass, genuine play-wear, and rough cane pontils (not patch-fold marks).
 - **Clambroths, Indians, large onionskins/micas** in good grade — solid
   mid-to-high tier.
 
@@ -336,6 +353,8 @@ identification.)
 | Christensen Agate (Guineas, flames) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/christensen-agate-co/ |
 | M.F. Christensen & Son (slags, early machine) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/m-f-christensen-son-co/ |
 | Master Marble / Master Glass | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/master-marble-glass-cos/ |
+| Foreign makers (incl. Vacor de Mexico) — MCSA | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/foreign-manufacturers/ |
+| **Vacor de Mexico** "Planet"/splatterpatch + orange-peel tell (BuyMarbles/Basinet) | https://buymarbles.com/marblealan-vacor.html |
 
 **Grading, triage & value:**
 

--- a/specializations/marbles.md
+++ b/specializations/marbles.md
@@ -2,7 +2,7 @@
 
 ```yaml
 triggers: [marble, marbles, shooter, swirl, sulphide, onionskin, "glass ball toy", "marble lot", "marble jar", "marble collection", agate-marble]
-version: 1
+version: 2
 last_reviewed: 2026-06-16
 sources:
   - Marble Collectors Society of America — marblecollecting.com (taxonomy, grading)
@@ -17,6 +17,13 @@ sources:
 > many styles are still sold in dollar stores. Assume any given marble in a
 > bulk collection is filler until a specific cue says otherwise. The job is to
 > *flag the few percent that are worth pulling*, not to grade everything.
+
+> **Match against real photos, not memory.** Before committing any value-moving
+> type or maker, **WebFetch the relevant page(s) in the Reference Library below
+> and compare the item's photos to the actual reference photographs.** Do not
+> settle a type from recall or from a schematic — the look-alikes (Cloud vs
+> Onionskin vs Joseph's Coat vs machine-made Guinea) are exactly where memory
+> misleads. The MCSA guide is the authority for type; auction sites for value.
 
 ## When this applies
 
@@ -48,8 +55,10 @@ Sort the pile into **PULL** (look closer) vs **FILLER** (jar lot) in seconds:
 - Plain clearies, plain opaque "milkies," common single-color glass.
 
 **PULL signals (worth a closer look):**
-- **Two rough pontil marks** (rough/sheared spots at opposite poles) → likely
-  **German handmade**, c.1850–1920. Handmade = the high-end pool.
+- **Two rough pontil marks** (rough/sheared spots at opposite poles) → **handmade**
+  (cane-cut). Handmade is where the high-end pool lives — but pontils prove *method
+  only*, NOT origin or age: antique German, antique American, and modern/contemporary
+  or reproduction handmades all have pontils. Pull it, then judge origin/era separately.
 - **One pontil + an embedded figure** (animal, person, number) → **sulphide**.
 - **Glittery gold/copper bands or sprinkles** in the glass → possible **Lutz**.
 - **Mica flecks** (silvery metallic specks suspended in colored glass) → mica.
@@ -69,9 +78,12 @@ Sort the pile into **PULL** (look closer) vs **FILLER** (jar lot) in seconds:
 ## Taxonomy — makers / types and how to recognize each
 
 **First split: handmade vs machine-made (read it off the surface).**
-- **Handmade** (German, c.1850–1920): **two rough pontil marks** at opposite
-  poles (cut from a cane). Single-gather types — **sulphides, paperweight-style
-  — show ONE pontil** (formed on a punty). No seams.
+- **Handmade** (cane-cut): **two rough pontil marks** at opposite poles.
+  Single-gather types — **sulphides, paperweight-style — show ONE pontil**
+  (formed on a punty). No seams. Pontils establish the marble is **handmade**;
+  they do NOT by themselves establish German origin or antique age — those are
+  separate inferences (see the method≠origin≠era caution below). Antique German
+  handmades fall ~c.1850–1920, but modern studio/art makers make handmades too.
 - **Transitional / early machine** (turn of the century): a pontil on one end
   but machine character on the other; MCSA lists distinct pontil styles
   (regular, ground, melted, pinpoint, fold, pinch, crease).
@@ -80,6 +92,16 @@ Sort the pile into **PULL** (look closer) vs **FILLER** (jar lot) in seconds:
 - ⚠ Do **not** try to date a handmade marble by how "smooth" the pontil is —
   the once-common pre-1880-smooth / post-1880-rough heuristic is **not
   reliable** (specifically refuted against the specialist sources).
+- ⚠ **Method ≠ origin ≠ era — the cardinal anti-bias rule.** A pontil tells you
+  HOW a marble was made (handmade), not WHERE or WHEN. "Two pontils" is NOT proof
+  of German manufacture or pre-1920 age: modern studio/art marbles and deliberate
+  reproductions are handmade with pontils too. Treat **German origin** and
+  **antique era** as SEPARATE inferences, each earned from glass quality, color
+  idiom, genuine play-wear, size, and any signature/date cane — and held at
+  `[BEST-CASE]` unless the evidence is strong. When it doesn't clearly add up,
+  default to **"handmade — origin/era undetermined"**, never "German antique".
+  (This is a known failure mode: do not let the module's German-handmade emphasis
+  bias an unmarked handmade toward antique German.)
 
 **Handmade categories (the collectible ones):**
 - **Swirls / core swirls** — colored core or bands twisting through clear.
@@ -151,6 +173,13 @@ Pull and price-hunt these on sight:
 - **Sulphides** — clear sphere with embedded figure; **colored or rare-figure
   (human, numbers, painted) sulphides** are the valuable ones; plain animal
   sulphides are more common.
+- **End-of-Day Clouds & Onionskins** — handmade, transparent base with colored
+  flecks. **Cloud** = flecks suspended *unstretched* (spotted); **Onionskin** =
+  flecks *stretched* into a surface skin (converge at poles). Both are a real
+  mid-to-high tier (clouds in ~5/8″ NM–Mint commonly $60–95+); a **dark/colored
+  base** is rarer than the common white/yellow ground, and bright splotches shade
+  toward "Clown". Confirm cloud-vs-onionskin against the End-of-Day reference
+  photos (see Reference library) — the two look alike and price differently.
 - **Clambroths, Indians, large onionskins/micas** in good grade — solid
   mid-to-high tier.
 
@@ -211,8 +240,12 @@ Pull and price-hunt these on sight:
 - **Reproductions / modern art-glass.** Contemporary art-glass makers produce
   beautiful spheres that can be mistaken for antiques; modern handmades often
   have **one ground/polished pontil or a maker's signature/cane date**, very
-  saturated modern colors, and large size. Genuine antique German handmades
-  show **two rough (sheared) pontils** and period color/wear.
+  saturated modern colors, and large size. But **two rough pontils do NOT prove
+  antique** — some modern pieces and deliberate reproductions carry two pontils
+  as well. Separate antique German from modern handmade on glass quality, color
+  idiom, genuine play-wear (vs artificial distressing), size, and design; when
+  they don't clearly add up, stay at **"handmade — era undetermined"** rather
+  than asserting antique.
 - **Faked rarities.** The holy-grail types (Guineas especially) are faked.
   Demand crisp type-specific structure, sensible size, period wear, and ideally
   provenance; when a "Guinea/Superman/Popeye" looks too clean/cheap, assume
@@ -246,6 +279,10 @@ When the photos can't settle identity or condition, request (via
   detect buffing/grinding flats.
 - **Backlit / transmitted-light shot** — for swirls, NLR ribbons, oxblood,
   Lutz glitter, mica, and to see a sulphide figure clearly.
+- ⚠ **Light it from the SIDE, never flat/overhead.** Flat overhead light makes a
+  **transparent base read as opaque/black** and hides the type (verified on a
+  smoky-base Cloud: flat shots looked black; side-lit shots revealed the clear
+  base + suspended flecks). Side/backlight before judging transparency or type.
 - **In-hand with a scale/coin** — size is a value driver; need diameter
   (calipers/ruler ideal; note inches).
 - **Close-up of any printed image/letters** — for a suspected comic/picture
@@ -255,19 +292,63 @@ When the photos can't settle identity or condition, request (via
 
 - **Brand** → the maker when a named type/seam/pattern confirms it (Christensen
   Agate, Akro, Peltier…); `[BEST-CASE]` + bracket for thin-coverage makers
-  (M.F.C., Vitro, Master, Marble King) or unconfirmed rarities; handmade German
-  marbles are typically **Unbranded/maker-unknown** (German handmade) — say so.
+  (M.F.C., Vitro, Master, Marble King) or unconfirmed rarities; **handmade**
+  marbles are **Unbranded/maker-unknown** — call them "handmade" (cane-cut) and
+  only add "German" when origin evidence supports it, not from pontils alone.
 - **Type** → the named type/pattern (e.g. "NLR Superman", "Akro Popeye
   corkscrew", "4-panel onionskin", "sulphide — dog"). This is the highest-
   leverage field for marbles.
-- **Era** → handmade German c.1850–1920; Golden Age machine ~1905–1950s; modern
-  1980s+. `[ASSUMPTION]` when inferred from style only.
+- **Era** → earn it separately from method. Handmade: antique (~1850–1920) vs
+  modern/contemporary studio is often unresolvable from photos → default
+  **"handmade — era undetermined" [BEST-CASE]** unless glass/wear/signature
+  decide it. Machine: Golden Age ~1905–1950s; modern 1980s+. `[ASSUMPTION]` when
+  inferred from style only; never upgrade to "antique German" on pontils alone.
 - **Condition** → MCSA grade + band (e.g. "Near Mint 8.5 — two small subsurface
   moons; no chips") per the rubric above; flag buffed/polished as **no grade**.
 - **Distinguishing marks** → record the **value tier** ($ / $$ / $$$ / $$$$ /
   🏆) here so PRICE/CURATE know which to comp-hunt vs jar; plus size (diameter),
   pontil/seam read, and Lutz/mica/oxblood presence.
 - **needs_followup_photo** → the inspection shot above (usually the pole macro).
+
+## Reference library (fetch real photos before committing)
+
+These are the authoritative pages with **actual reference photographs**. When a
+type/maker is uncertain or value-moving, **WebFetch the matching page and compare
+the item's photos to the real images there** before settling the field — never
+from memory or a schematic. All links verified against MCSA / Block's; if a
+sub-type isn't listed, navigate from the ID-guide index. (These are reference
+*knowledge*; the fresh-investigation rule still applies — judge THIS item on its
+own photos, using the references only to recognize the type, not to import a prior
+identification.)
+
+**Type identification — MCSA "Online Marble ID Guide" (marblecollecting.com):**
+
+| Use it for | URL |
+|---|---|
+| Index — all marble types/makers (start + navigate) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/ |
+| **End of Day — Cloud vs Onionskin** (our key fork) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/end-of-days/ |
+| Handmade overview (swirls, cores, etc.) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/handmade-marbles/ |
+| Lutz (gold/copper glitter types) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/lutzes/ |
+| Other handmades (Indian, Clambroth, Mica, Sulphide, etc.) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/all-other-handmades/ |
+| Earthenware / clay marbles | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/earthenware/ |
+| Akro Agate (corkscrew, Popeye, patch) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/akro-agate-co/ |
+| Peltier (NLR, comics, Peerless patch) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/peltier-glass-co/ |
+| Christensen Agate (Guineas, flames) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/christensen-agate-co/ |
+| M.F. Christensen & Son (slags, early machine) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/m-f-christensen-son-co/ |
+| Master Marble / Master Glass | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/master-marble-glass-cos/ |
+
+**Grading, triage & value:**
+
+| Use it for | URL |
+|---|---|
+| MCSA grading guide (0–10 scale, defect terms) | https://www.marblecollecting.com/marble-reference/marble-grading-guide/ |
+| MCSA "Get a Marble Identified" (the 90%-modern reality check) | https://www.marblecollecting.com/marble-reference/get-a-marble-identified/ |
+| MCSA collector FAQ | https://www.marblecollecting.com/marble-reference/marble-faq/ |
+| Block's condition-grading policy (conservative, no-grade-for-buffed) | https://www.marbleauctions.com/condition-grading |
+| Block's realized auction comps (e.g. Christensen Agate) | https://bid.marbleauctions.com/category/christensen-agate-company-241 |
+
+For an independent visual second opinion on a markless/can't-place marble, also
+see `lib/lens_id.py` (Google Lens) per [`../prompts/identify.md`](../prompts/identify.md).
 
 ## Sources
 
@@ -283,7 +364,7 @@ When the photos can't settle identity or condition, request (via
   *Collecting Antique Marbles*; Robert Block, *Marbles Identification & Price
   Guide*; Everett Grist, *Antique & Collectible Marbles*.
 
-> Open items to deepen in v2 of this module: realized (hammer, not estimate)
+> Open items to deepen in a future revision: realized (hammer, not estimate)
 > price ranges separating the $50/$500/$5,000 tiers; deeper ID for M.F.
 > Christensen, Vitro, Master, Marble King; sharper fake-detection tells; and
 > size-vs-value thresholds beyond the Akro "over 1″" data point.

--- a/specializations/marbles.md
+++ b/specializations/marbles.md
@@ -1,0 +1,290 @@
+# Marbles — specialization module
+
+```yaml
+triggers: [marble, marbles, shooter, swirl, sulphide, onionskin, "glass ball toy", "marble lot", "marble jar", "marble collection", agate-marble]
+version: 1
+last_reviewed: 2026-06-16
+sources:
+  - Marble Collectors Society of America — marblecollecting.com (taxonomy, grading)
+  - Block's Marble Auctions — marbleauctions.com / bid.marbleauctions.com (realized market + grading policy)
+  - Morphy Auctions, LiveAuctioneers (auction comps)
+  - Reference books (corroborated indirectly): Paul Baumann, "Collecting Antique Marbles"; Robert Block, "Marbles Identification & Price Guide"; Everett Grist, "Antique & Collectible Marbles"
+```
+
+> **Reality check first (the single most useful fact for a 1000+ pile).**
+> Per the MCSA, **well over 90% of marbles people submit for ID are modern
+> Mexican or Chinese marbles made since the 1980s with next to no value** —
+> many styles are still sold in dollar stores. Assume any given marble in a
+> bulk collection is filler until a specific cue says otherwise. The job is to
+> *flag the few percent that are worth pulling*, not to grade everything.
+
+## When this applies
+
+Any glass (or rarely clay/stone/steel) toy marble: loose, in jars, in lots, or
+boxed. Includes "shooters" (larger marbles) and any item described as a swirl,
+agate, cat's-eye, sulphide, onionskin, Lutz, or comic marble.
+
+**Carve-outs / look-alikes that are NOT this module:**
+- *Agate* as a loose gemstone, cabochon, or jewelry stone — that's a mineral,
+  not a marble. Only an agate *marble* (a sphere, toy) qualifies.
+- Decorative glass spheres / paperweights / "witch balls" / nest eggs — larger
+  art-glass orbs, not toy marbles (a paperweight has one pontil but is its own
+  category).
+- Steel ball bearings, clay "commies" sold as craft filler, modern craft/vase-
+  filler glass gems (flat-backed) — filler, note and move on.
+
+## Fast triage (the big-lot pass)
+
+Sort the pile into **PULL** (look closer) vs **FILLER** (jar lot) in seconds:
+
+**FILLER signals (the 90%) — leave in the bulk jar:**
+- **Cat's-eye** with a simple injected color "vane/propeller" insert in clear
+  glass — the classic 1950s+ mass-made style; common ones are pennies. (A few
+  vintage/odd-vane cat's-eyes have minor value, but assume common.)
+- Perfectly uniform, glossy, modern-looking color; bag-fresh; identical
+  repeats by the hundred → modern Mexican/Chinese.
+- Obvious chips/grinding on an otherwise common machine-made marble (damage
+  guts common-marble value — see grading).
+- Plain clearies, plain opaque "milkies," common single-color glass.
+
+**PULL signals (worth a closer look):**
+- **Two rough pontil marks** (rough/sheared spots at opposite poles) → likely
+  **German handmade**, c.1850–1920. Handmade = the high-end pool.
+- **One pontil + an embedded figure** (animal, person, number) → **sulphide**.
+- **Glittery gold/copper bands or sprinkles** in the glass → possible **Lutz**.
+- **Mica flecks** (silvery metallic specks suspended in colored glass) → mica.
+- A **printed picture/character or letters** on the surface → **comic/picture
+  marble** (Peltier) — rare, pull immediately.
+- Crisp **named machine-made patterns**: tight pole-to-pole spirals
+  (**corkscrew**), opaque base with thin ribbons (Peltier **NLR**), white
+  filaments + color in clear (**Popeye**).
+- **Oxblood**: a dense, dark brownish-red opaque streak (prized on Akros and
+  others — a value-adder when present). *(Specific oxblood sub-claims vary by
+  source — treat as a "pull and verify," not a settled ID.)*
+- **Size**: anything notably large for its type (≥ ~1 inch) — large examples of
+  named types are disproportionately rare (e.g. *any Akro corkscrew over 1″ is
+  extremely rare*).
+- Anything you simply can't place. **When in doubt, pull it.**
+
+## Taxonomy — makers / types and how to recognize each
+
+**First split: handmade vs machine-made (read it off the surface).**
+- **Handmade** (German, c.1850–1920): **two rough pontil marks** at opposite
+  poles (cut from a cane). Single-gather types — **sulphides, paperweight-style
+  — show ONE pontil** (formed on a punty). No seams.
+- **Transitional / early machine** (turn of the century): a pontil on one end
+  but machine character on the other; MCSA lists distinct pontil styles
+  (regular, ground, melted, pinpoint, fold, pinch, crease).
+- **Machine-made** (American, ~1905–1950s "Golden Age" + later): **seams**
+  (fold/cutoff lines), **no pontils**, high sphericity.
+- ⚠ Do **not** try to date a handmade marble by how "smooth" the pontil is —
+  the once-common pre-1880-smooth / post-1880-rough heuristic is **not
+  reliable** (specifically refuted against the specialist sources).
+
+**Handmade categories (the collectible ones):**
+- **Swirls / core swirls** — colored core or bands twisting through clear.
+- **Onionskins** — flecked/stretched colored "skin" over a clear/opaque core;
+  panels common (e.g. 4-panel). End-of-day family.
+- **End-of-day** — random multicolored flecks/cloud (made from leftover glass).
+- **Lutz** — defined by **Lutz material** (ground copper / goldstone) as
+  glittering bands or sprinkles; NOT a maker (see "money types").
+- **Indians** — dark/black opaque base with colored surface bands.
+- **Clambroths** — opaque base (often white) with many evenly-spaced thin
+  colored lines pole-to-pole.
+- **Micas** — colored glass with suspended silvery mica flakes.
+- **Sulphides** — clear single-gather sphere with an embedded white figure.
+
+**American machine-made makers (Golden Age core four + later majors):**
+- **M.F. Christensen & Son** (1905–1917) — earliest US machine maker;
+  "slags" (single-color transparent + white swirl) and "brick/oxblood."
+  *(Identification of M.F.C. specifically is finicky — verify before claiming.)*
+- **Christensen Agate Co.** (1927–1933) — short-lived, brilliant colors;
+  home of the **Guinea** (see money types). Highly collectible.
+- **Akro Agate** (1911–1951) — corkscrews, patches, **Popeye**, oxblood.
+- **Peltier Glass** (marbles ~1920s–) — **National Line Rainbo** swirls,
+  **comic/picture** marbles, Peerless patches.
+- **Master Marble / Master Glass** — swirls/patches; *thinner reference
+  coverage — verify before a confident maker call.*
+- **Vitro Agate** — cat's-eyes, patches; mostly common, some collectible early
+  lines. *Thinner coverage — verify.*
+- **Marble King** — patches (two-color "rainbows"), the bread-and-butter of
+  later mass marbles; mostly common. *Thinner coverage — verify.*
+
+> Coverage note: verified depth is strongest on **Christensen Agate, Peltier,
+> Akro, and Lutz/handmade**. For **M.F. Christensen, Vitro, Master, Marble
+> King**, identify cautiously and use `[BEST-CASE]` + Lens/web confirmation
+> before stating the maker.
+
+## The money types (named high-value items — the watch-list)
+
+Pull and price-hunt these on sight:
+
+- **Christensen Agate "Guineas"** — *holy-grail tier.* Transparent base
+  (often clear/amber) with stretched, peppered multicolored flecks across the
+  surface. Genuine Guineas reach **four figures** (a mint 19/32″ example
+  carried a $750–$1,500 estimate / $1,400 bid at Block's). Heavily faked —
+  verify hard.
+- **Peltier National Line Rainbo (NLR)** — opaque base with **4–8 thin
+  translucent ribbons** and **two seams**. Named by exact base/ribbon colors:
+  - *Two-color:* Zebra (black/white), Bumblebee (black/yellow), Cub Scout
+    (yellow/blue), Wasp (black/red), Tiger (black/orange), Chocolate Cow
+    (black/brown).
+  - *Tri-color (top):* **Christmas Tree** (white base, red+green), **Superman**
+    (light-blue base, yellow+red), **Liberty** (white base, red+blue).
+  - Named NLRs in mint run tens to several hundred dollars (Superman ~$125–$400+).
+- **Peltier Comic / Picture marbles** — Peerless-patch base with a **fired-on
+  black character transfer** under clear overglaze. Twelve King-Syndicate
+  characters, ascending rarity: Emma, Koko, Bimbo, Smitty, Andy, Herbie,
+  Skeezix, Annie, Sandy, Betty, Moon, Kayo — plus **Tom Mix** (red transfer,
+  extremely rare). Any genuine comic is a serious pull.
+- **Akro "Popeye" corkscrews** — **transparent clear base with opaque WHITE
+  filaments** plus colored spirals (commonly red/yellow or green/yellow). The
+  white filaments are *required* to be a Popeye. **Hybrids** (3+ colors) and
+  **patch Popeyes** are rare and highly prized.
+- **Akro corkscrews (general)** — two+ **non-intersecting** color spirals
+  running pole-to-pole. Rarity rises with color count (**five-color "Specials"
+  extremely rare**) and with **size — any corkscrew over 1″ is extremely rare.**
+- **Lutz marbles** — any handmade with **Lutz material** (glittering ground-
+  copper/goldstone bands or sprinkles). Subtypes: Banded, Onionskin, Ribbon,
+  Indian, Mist/Solid-Core. **More Lutz on the core = more value** (most
+  precisely true of onionskin cores).
+- **Sulphides** — clear sphere with embedded figure; **colored or rare-figure
+  (human, numbers, painted) sulphides** are the valuable ones; plain animal
+  sulphides are more common.
+- **Clambroths, Indians, large onionskins/micas** in good grade — solid
+  mid-to-high tier.
+
+## Value drivers (priority order)
+
+1. **Rarity** — the deep driver everything else proxies for. Handmade and
+   short-run makers (Christensen Agate) are scarce; later mass makers (Marble
+   King, common Vitro/Akro patches) are not.
+2. **Maker + named type/pattern** — a *named* pattern (Guinea, NLR Superman,
+   Popeye, a specific comic) is worth multiples of a generic swirl/patch.
+3. **Color combination** — within a type, specific named/contrasty color sets
+   command premiums (this is literally how NLRs are named and tiered).
+4. **Condition / grade** — see below; interacts hard with #1.
+5. **Size** — larger-than-typical examples of a named type are
+   disproportionately rare and valuable (≥ ~1″ is a strong signal).
+
+> ⚠ Do **not** use "made after 1932 = worthless" as a rule — that specific
+> production-date heuristic was **refuted** against the specialist sources.
+> Date matters only through rarity, not as a hard cutoff.
+
+## Condition grading
+
+**MCSA / standard scale (0–10, four named bands):**
+
+| Grade | Range | Meaning |
+|---|---|---|
+| **Mint** | 9.0–10.0 | Original, unmarked, undamaged surface. *Factory-origin* defects are OK (popped air holes, melt/contact marks, annealing fractures, minor rubbing). |
+| **Near Mint** | 8.0–8.9 | Tiny-to-small post-use defects. |
+| **Good** | 7.0–7.9 | Numerous hit marks. |
+| **Collectible** | below 7.0 | Defects overall, may obscure the core. |
+
+- Grading is **subjective**; dealers vary. Block's grades **conservatively**
+  (treats Mint as 9.0–9.9, a true 10 as unattainable) and uses in-band
+  plus/minus (e.g. Mint(−) ≈ 9.2, Near Mint(+) ≈ 8.8). Plus/minus points are
+  dealer convention, not codified.
+- **Damage vocabulary** (post-use): **moon** (subsurface ring fracture, no
+  glass loss), **bruise** (subsurface discoloration, no loss), **chip** (deep
+  angular break with loss), **flake** (shallow surface loss), **hit mark**.
+- **Condition cuts value far harder on machine-made than handmade.** Per MCSA,
+  *even a small chip reduces a machine-made marble's value by more than half* —
+  because they're common. A **rare handmade** marble (e.g. a Clambroth) holds
+  much of its value even damaged. So: damage on a common marble → filler;
+  damage on a rare handmade → still pull.
+- **Buffed / polished / remelted / reworked → NO grade.** Such marbles get no
+  condition grade because the original surface is altered. **This is a red flag
+  to detect**, not a value-add (see below).
+
+## Authentication & fakes
+
+> This area had thinner verified coverage — treat the items below as working
+> guidance and confirm on high-value calls; don't over-claim authenticity.
+
+- **Buffing/polishing detection (high-value skill).** Buffing removes minor
+  haze and tiny pits to *fake* a higher grade, but **chips and subsurface moons
+  remain** — look for a too-glassy/soft surface, rounded-over former chips,
+  loss of crisp original "as-made" texture, or facets/flats from grinding.
+  A buffed marble should be called out and **not graded** as mint.
+- **Reproductions / modern art-glass.** Contemporary art-glass makers produce
+  beautiful spheres that can be mistaken for antiques; modern handmades often
+  have **one ground/polished pontil or a maker's signature/cane date**, very
+  saturated modern colors, and large size. Genuine antique German handmades
+  show **two rough (sheared) pontils** and period color/wear.
+- **Faked rarities.** The holy-grail types (Guineas especially) are faked.
+  Demand crisp type-specific structure, sensible size, period wear, and ideally
+  provenance; when a "Guinea/Superman/Popeye" looks too clean/cheap, assume
+  reproduction until proven otherwise.
+- **Honesty guard:** an unconfirmed rare type is `[BEST-CASE]` with the exact
+  resolution step, never a stated ID. A wrong "Guinea" call is the most
+  expensive mistake in this category in both directions (over- and under-value).
+
+## Price tiers (coarse bands)
+
+Triage signals, **not quotes** — PRICE still hunts live comps. The $1 floor and
+~$1,000+ ceiling are source-anchored; the middle bands are inferred from the
+type+condition matrix.
+
+| Tier | Band | What lands here |
+|---|---|---|
+| **$ (filler)** | ~$0.05–$2 | Modern Mexican/Chinese, common cat's-eyes, plain clearies/milkies, common patches, any common machine-made with chips. Sell by the **jar/lot**. |
+| **$$** | ~$2–$25 | Identifiable named machine-made in lower grade; common Akro/Peltier/Vitro patches & swirls in NM+; common handmade swirls with damage. |
+| **$$$** | ~$25–$150 | **Mint** named machine-made patterns (corkscrews, common NLRs, good swirls); better handmade (onionskins, micas, Indians) in good grade. |
+| **$$$$** | ~$150–$1,000 | Top named patterns in mint (Popeye hybrids, NLR Superman/Christmas Tree, comics, figural/colored sulphides, heavy-Lutz, clambroths); large mint examples of named types. |
+| **🏆 trophy** | $1,000+ | **Christensen Agate Guineas**, rarest comics (Tom Mix), exceptional sulphides, rare hybrids, exceptional large mint rarities. |
+
+## Inspection shots
+
+When the photos can't settle identity or condition, request (via
+`needs_followup_photo`) the SPECIFIC shot, not "more photos":
+
+- **Pole macro (both ends)** — to read pontils (handmade: two rough; sulphide/
+  paperweight: one) vs seams (machine-made). The decisive method shot.
+- **Raking-light surface macro** — to grade: reveal chips/moons/flakes and
+  detect buffing/grinding flats.
+- **Backlit / transmitted-light shot** — for swirls, NLR ribbons, oxblood,
+  Lutz glitter, mica, and to see a sulphide figure clearly.
+- **In-hand with a scale/coin** — size is a value driver; need diameter
+  (calipers/ruler ideal; note inches).
+- **Close-up of any printed image/letters** — for a suspected comic/picture
+  marble.
+
+## Output hooks (maps onto IDENTIFY fields)
+
+- **Brand** → the maker when a named type/seam/pattern confirms it (Christensen
+  Agate, Akro, Peltier…); `[BEST-CASE]` + bracket for thin-coverage makers
+  (M.F.C., Vitro, Master, Marble King) or unconfirmed rarities; handmade German
+  marbles are typically **Unbranded/maker-unknown** (German handmade) — say so.
+- **Type** → the named type/pattern (e.g. "NLR Superman", "Akro Popeye
+  corkscrew", "4-panel onionskin", "sulphide — dog"). This is the highest-
+  leverage field for marbles.
+- **Era** → handmade German c.1850–1920; Golden Age machine ~1905–1950s; modern
+  1980s+. `[ASSUMPTION]` when inferred from style only.
+- **Condition** → MCSA grade + band (e.g. "Near Mint 8.5 — two small subsurface
+  moons; no chips") per the rubric above; flag buffed/polished as **no grade**.
+- **Distinguishing marks** → record the **value tier** ($ / $$ / $$$ / $$$$ /
+  🏆) here so PRICE/CURATE know which to comp-hunt vs jar; plus size (diameter),
+  pontil/seam read, and Lutz/mica/oxblood presence.
+- **needs_followup_photo** → the inspection shot above (usually the pole macro).
+
+## Sources
+
+- **Marble Collectors Society of America — marblecollecting.com** — the
+  authority for taxonomy, the maker ID guides (Akro, Peltier, Lutz, etc.), the
+  "Get a Marble Identified" reality check, and the grading guide. Start here.
+- **Block's Marble Auctions — marbleauctions.com / bid.marbleauctions.com** —
+  realized market behavior, conservative grading policy (plus/minus, no-grade-
+  for-buffed), and named-type comps (Guineas, NLRs).
+- **Morphy Auctions, LiveAuctioneers** — additional auction comps for high-end
+  types.
+- **Reference books** (corroborated indirectly via the above): Paul Baumann,
+  *Collecting Antique Marbles*; Robert Block, *Marbles Identification & Price
+  Guide*; Everett Grist, *Antique & Collectible Marbles*.
+
+> Open items to deepen in v2 of this module: realized (hammer, not estimate)
+> price ranges separating the $50/$500/$5,000 tiers; deeper ID for M.F.
+> Christensen, Vitro, Master, Marble King; sharper fake-detection tells; and
+> size-vs-value thresholds beyond the Akro "over 1″" data point.
+```


### PR DESCRIPTION
## Summary

Introduces an **extensible, prompt-driven category-specialization system** for IDENTIFY, plus the first module (**marbles**), and the listing-pipeline support needed to run it end-to-end.

A *specialization* is a self-contained expert field guide for one category. When IDENTIFY forms a first-pass category, it checks the registry in `specializations/README.md`; on a trigger match it loads that module and applies its taxonomy, value drivers, condition vocabulary, authentication tests, and a coarse value tier — turning a generalist ID into a specialist one. No code, no build step: adding a specialization is dropping a Markdown file + one registry row.

## What's here (5 commits)

- **`feat(identify)`** — the specialization system: registry + contract in `specializations/README.md`, `_template.md`, and the `marbles.md` module; IDENTIFY loads a module on a category match. Refines, never overrides, the honesty/maker-attribution rules.
- **`feat(marbles)` ×2** — debias method ≠ origin ≠ era (pontils prove *handmade*, not German/antique); refined End-of-Day Cloud vs Onionskin fork; modern Vacor "Planet"/splatterpatch recognition + the Cloud look-alike trap; reference library of MCSA/Block's pages to compare against real photos.
- **`feat(list_edit)`** — AUCTION-format offer support in the publish path.
- **`docs(prompts)`** — telegraphic `condition_description` spec.

## Validation

Exercised end-to-end on real shoots (`marbles/1–4`): IDENTIFY (with the marbles module + Google Lens second opinion) → PRICE (distribution-based comp hunt) → CURATE → INVESTIGATE → DRAFT → REVIEW gate → publish. The module's anti-bias rules held (unmarked swirl lots correctly stayed Unbranded / origin-undetermined rather than over-claiming German antique).

## Status

**Draft** — opened to validate that the specialization structure is sound before adding a couple more category modules to this same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)