### PR TITLE
Collectables KB + marble visual-similarity tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ __pycache__/
 .venv/
 venv/
 
+# Local scratch + generated similarity indexes (large/binary, regenerable)
+.scratch/
+/kb/index/
+
 # Editor / OS
 .vscode/
 .idea/

--- a/RUN.md
+++ b/RUN.md
@@ -188,6 +188,9 @@ only pass `--confirm` on an explicit yes. Use `--offers` to find IDs.
 Cross-cutting depth rules:
 - Condition analysis in IDENTIFY and INVESTIGATE uses
   [prompts/condition-rubric.md](prompts/condition-rubric.md).
+- IDENTIFY loads a category **specialization** (expert field guide) when an
+  item matches one — registry + modules in
+  [specializations/README.md](specializations/README.md) (e.g. marbles).
 - PRICE runs the autonomous exact-match hunt (Stage A WebSearch → Stage B
   Apify eBay-sold → optional Stage C Chrome when confidence is low) before
   any era-peer fallback; see its prompt.

--- a/kb/README.md
+++ b/kb/README.md
@@ -85,7 +85,7 @@ listings — same source-quality bar as the specializations.
 ### General collectables hubs & guides (cross-category identification + overview)
 | Resource | Good for | URL | Ingest |
 |---|---|---|---|
-| COLLECT.Guide | Cross-category ID/reference hub: manufacturer rosters, size-for-ID, grading, glossaries, per-type guides (marbles, etc.) | https://www.collect.guide | ◐ Chrome to ingest (403) |
+| COLLECT.Guide | Cross-category ID/reference hub: manufacturer rosters, size-for-ID, grading, glossaries, per-type guides (marbles, etc.) | https://www.collect.guide | ▢ retry — site down 2026-06-21 (Cloudflare 520 origin error); WebFetch also 403. Ingest via Chrome once origin is back |
 | Collectors Weekly | Broad category overview guides + community knowledge | https://www.collectorsweekly.com/ | ▢ |
 | The Spruce Crafts — Collectibles | Beginner-friendly category primers across many collectables | https://www.thesprucecrafts.com/collectibles-4127771 | ▢ |
 | Invaluable — "Knowledge Center" | Auction-house-backed category guides + realized prices | https://www.invaluable.com/ | ▢ |
@@ -124,6 +124,16 @@ listings — same source-quality bar as the specializations.
 | Antique Trader — fakes coverage | Editorial on fakes, repros, and market trends | https://www.antiquetrader.com/ | ▢ |
 | Entrupy / brand authentication (luxury) | Authentication context for handbags, sneakers, luxury goods | https://www.entrupy.com/ | ▢ |
 
+### Community peer-ID forums (second opinion — crowd, not authority)
+| Resource | Good for | URL | Ingest |
+|---|---|---|---|
+| Marble Connection — "Marble I.D.'s" | Marble photo-ID forum (~17k threads). Indexed for **visual similarity search** — given a reference marble, find the most-similar posted marbles. See [`../lib/marble_index.py`](../lib/marble_index.py) | https://marbleconnection.com/forum/22-marble-ids/ | ● (CLIP index + refresh tool) |
+
+> Forums are **peer opinion** (sometimes wrong), so they're a *second-opinion /
+> look-alike* layer, not an authority like MCSA or an auction house. The visual
+> index narrows the corpus to candidates; final ID still follows the
+> [marbles specialization](../specializations/marbles.md) discipline.
+
 ### Category specialist references (cross-link to specializations)
 | Resource | Good for | URL | Ingest |
 |---|---|---|---|
@@ -132,6 +142,41 @@ listings — same source-quality bar as the specializations.
 
 _When a resource is specific to one category that already has a specialization
 module, keep its deep links in that module; list it here only as a pointer._
+
+---
+
+## Tools (KB-adjacent scripts)
+
+Reusable scripts a run can call to turn a source into an answer. Code is
+tracked; generated indexes live under `kb/index/` (gitignored, regenerable).
+
+### `lib/marble_index.py` — marble visual-similarity search
+
+Index the marble photos posted to the Marble Connection "Marble I.D.'s" forum,
+then find the threads whose marbles look most like a reference photo.
+
+```
+# build / extend the index (newest threads first; resumable)
+python lib/marble_index.py index --max-pages 10 [--start-page 1]
+
+# periodic sync — append only threads created since the last run
+python lib/marble_index.py refresh [--max-new-pages 10]
+
+# find the top-K most-similar threads for one or more reference photos
+python lib/marble_index.py query path/or/url [more-angles...] --top 5 [--json out.json]
+
+python lib/marble_index.py status      # index size + last sync
+```
+
+- **Embedding backend** (`MARBLE_EMBED` env): `phash` (default — colour+structure
+  features, no torch) or `clip` (CLIP ViT-B/32, needs torch + the MS VC++
+  Redistributable). An index is tied to the backend that built it; to upgrade
+  phash→clip, install VC++ then rebuild with `MARBLE_EMBED=clip`.
+- **Honesty contract:** similarity retrieval is a *candidate finder*, not an ID.
+  Treat the top-K as "look here", then settle maker/era per the
+  [marbles specialization](../specializations/marbles.md) (method ≠ origin ≠ era).
+- **Periodic refresh:** `refresh` is safe to run on a schedule (idempotent,
+  dedups by thread-id + image-URL) to keep the index current as new IDs are posted.
 
 ---
 

--- a/kb/README.md
+++ b/kb/README.md
@@ -1,0 +1,163 @@
+# Knowledge Base — cross-category collectables reference
+
+A local, **prompt-readable** reference library of collectables knowledge that
+any phase of a run can consult on demand. Where a
+[specialization](../specializations/README.md) is a deep field guide for **one
+category** (marbles, jewelry…), the KB holds the **cross-cutting** knowledge
+that applies across many categories — hallmark systems, condition-grading
+conventions, reproduction/fake red flags, where to find real comps, dating
+clues, shipping/handling for fragile classes — plus the curated **resource
+registry** the modules and prompts link out to.
+
+Like the rest of v3 this is prompt-driven: an article is just a Markdown file
+the pipeline reads when it's relevant. No code, no build step.
+
+- **KB article** → reusable reference knowledge (a digest of one or more
+  resources), category-agnostic or spanning categories.
+- **Specialization** → one category's expert playbook (taxonomy, money types,
+  price tiers). Lives in [`../specializations/`](../specializations/).
+
+When the two overlap, the specialization wins for its category (it's more
+specific); the KB is the fallback/shared layer and the place general knowledge
+lives so it isn't copy-pasted into every module.
+
+---
+
+## How a run uses the KB (the contract)
+
+1. **Consult on a cue, not always.** IDENTIFY / INVESTIGATE / PRICE check the
+   article index below when an item raises a cross-category question a
+   specialization doesn't already answer — e.g. "what does this silver
+   hallmark mean?", "is this a reproduction?", "what's the right comp source
+   for this?". Load the matching article; don't pre-load the whole KB.
+2. **Refine, never override honesty.** KB articles obey the same rules as
+   everything else: they *inform* a call, they do not license inventing.
+   Maker-attribution discipline ([`../prompts/identify.md`](../prompts/identify.md)),
+   the `[BEST-CASE]`/`[ASSUMPTION]` markers, and the fresh-investigation rule
+   in [`../prompts/_shared.md`](../prompts/_shared.md) all still apply. Judge
+   THIS item on its own evidence; use the article to recognize and interpret,
+   not to import a prior conclusion.
+3. **Dated and sourced.** Every article cites its source class and records
+   `last_reviewed`, so stale market/marks claims can be refreshed. Live PRICE
+   still hunts real comps — KB price signals are context, never quotes.
+4. **Verify against real references on value-moving calls.** When an article
+   points at a primary source (a hallmark date-letter chart, a real-vs-repro
+   photo set), WebFetch it and compare before committing a value-tier call —
+   same discipline as the specialization modules.
+5. **New-source policy — surface, don't self-add.** Any time a run encounters a
+   web source that isn't already in the registry below, **consider it for the
+   KB and ASK the user before adding it.** Bring the URL, what it's good for,
+   and why it might earn a place; let the user approve before it goes in the
+   registry or gets ingested. Don't silently expand the KB mid-run. (Always
+   record the **reference URL** with any fact taken from a source, so it can be
+   cited correctly.)
+
+> **Access note.** Some quality sources block automated fetching (HTTP 403 to
+> WebFetch) — e.g. **925-1000.com**, **collect.guide**. For these, ingest via
+> the **Claude-in-Chrome** extension (drive a real browser) or read them
+> manually; never let a 403 silently drop a source. Mark such rows "Chrome to
+> ingest" in the registry.
+
+---
+
+## Article index (what's ingested)
+
+| Article | Covers | Status |
+|---|---|---|
+| [silver-hallmarks.md](articles/silver-hallmarks.md) | Sterling vs coin vs plate vs not-silver; reading US maker marks & British hallmark sets (standard/town/date-letter/maker); continental fineness; `925` forgery & EPNS red flags | v1 |
+| [ebay-sold-comps.md](articles/ebay-sold-comps.md) | Finding real sold-price comps: sold≠asking, the Apify/Chrome ladder, query craft, delivered basis, distribution tiers, comp pitfalls | v1 |
+
+_Add a row per article as it's ingested. Keep this in sync with `articles/`._
+
+---
+
+## Resource registry (the links section)
+
+The curated, reputable sources the KB ingests from and that prompts may link
+out to live. Grouped by **what they're good for**. Prefer specialist
+societies, established auction houses, and standard references over random
+listings — same source-quality bar as the specializations.
+
+> Ingestion status legend: **▢ not started · ◐ partial · ● ingested** (digested
+> into an `articles/` file). The goal is to turn each high-value resource into a
+> reusable article so a run doesn't have to re-fetch and re-read the raw page.
+
+### General collectables hubs & guides (cross-category identification + overview)
+| Resource | Good for | URL | Ingest |
+|---|---|---|---|
+| COLLECT.Guide | Cross-category ID/reference hub: manufacturer rosters, size-for-ID, grading, glossaries, per-type guides (marbles, etc.) | https://www.collect.guide | ◐ Chrome to ingest (403) |
+| Collectors Weekly | Broad category overview guides + community knowledge | https://www.collectorsweekly.com/ | ▢ |
+| The Spruce Crafts — Collectibles | Beginner-friendly category primers across many collectables | https://www.thesprucecrafts.com/collectibles-4127771 | ▢ |
+| Invaluable — "Knowledge Center" | Auction-house-backed category guides + realized prices | https://www.invaluable.com/ | ▢ |
+
+### Niche catalogs & databases (authoritative per-category references)
+| Resource | Good for | URL | Ingest |
+|---|---|---|---|
+| Discogs | Music releases (vinyl/CD) — definitive catalog + sold marketplace data | https://www.discogs.com/ | ▢ |
+| Numista | World coins & banknotes catalog with mintage/values | https://en.numista.com/ | ▢ |
+| Colnect | Broad collectibles catalog (stamps, coins, banknotes, postcards, more) | https://colnect.com/ | ▢ |
+| PSA / PCGS / Beckett | Third-party grading + population/price data (cards & coins) | https://www.psacard.com/ · https://www.pcgs.com/ | ▢ |
+| BrickLink | LEGO sets & parts catalog + market prices | https://www.bricklink.com/ | ▢ |
+
+### Comps & realized prices (what things actually sell for)
+| Resource | Good for | URL | Ingest |
+|---|---|---|---|
+| eBay — Sold/Completed listings | The primary comp source; real sold prices across every category | https://www.ebay.com/sch/ (filter: Sold items) | ● [→](articles/ebay-sold-comps.md) |
+| WorthPoint | Deep historical sold-price database (subscription); marks dictionary | https://www.worthpoint.com/ | ▢ |
+| LiveAuctioneers | Aggregated auction-house realized prices, many categories | https://www.liveauctioneers.com/ | ▢ |
+| Heritage Auctions (HA.com) | High-end realized prices + reference archive (coins, comics, art, watches) | https://www.ha.com/ | ▢ |
+| Morphy Auctions | Realized prices for toys, advertising, glass, marbles, militaria | https://www.morphyauctions.com/ | ▢ |
+| Replacements, Ltd. | China / crystal / silver / flatware **pattern** identification + going prices | https://www.replacements.com/ | ▢ |
+
+### Identification, marks & makers
+| Resource | Good for | URL | Ingest |
+|---|---|---|---|
+| Kovels | The standard antiques/collectibles marks + price guide; pottery/silver marks | https://www.kovels.com/ | ▢ |
+| 925-1000.com | Encyclopedia of silver & sterling **hallmarks** (intl. date letters, makers) | https://www.925-1000.com/ | ● [→](articles/silver-hallmarks.md) |
+| Marks4Antiques / online marks DBs | Pottery, porcelain & silver mark lookup | https://www.marks4antiques.com/ | ▢ |
+| Gemological Institute of America (GIA) | Gemstone ID, grading standards, treatment disclosure | https://www.gia.edu/ | ▢ |
+
+### Authentication & reproductions (don't get fooled)
+| Resource | Good for | URL | Ingest |
+|---|---|---|---|
+| Real Or Repro | Side-by-side genuine-vs-reproduction tells across many categories | https://www.realorrepro.com/ | ▢ |
+| Antique Trader — fakes coverage | Editorial on fakes, repros, and market trends | https://www.antiquetrader.com/ | ▢ |
+| Entrupy / brand authentication (luxury) | Authentication context for handbags, sneakers, luxury goods | https://www.entrupy.com/ | ▢ |
+
+### Category specialist references (cross-link to specializations)
+| Resource | Good for | URL | Ingest |
+|---|---|---|---|
+| Marble Collectors Society of America | Marbles — see [`../specializations/marbles.md`](../specializations/marbles.md) | https://www.marblecollecting.com/ | ● (in module) |
+| (add specialist societies as categories are added) | | | |
+
+_When a resource is specific to one category that already has a specialization
+module, keep its deep links in that module; list it here only as a pointer._
+
+---
+
+## Article file schema
+
+Every article follows [`_template.md`](_template.md) so they stay
+interchangeable and prompt-friendly. Required: front matter (`topic`,
+`applies_to`, `version`, `last_reviewed`, `sources`), a short **When to consult
+this**, the digested **knowledge** itself (tables/checklists a run can act on),
+**Red flags / gotchas**, **How it maps onto our fields** (IDENTIFY/INVESTIGATE/
+PRICE hooks), and **Sources**.
+
+Keep articles **action-oriented**: a run should be able to *do* something with
+each section (interpret a mark, grade a defect, pick a comp source), not just
+read prose.
+
+---
+
+## Adding / ingesting an article
+
+1. Pick a resource from the registry (start with the highest-leverage:
+   comps + marks + repro).
+2. Copy `_template.md` to `articles/<topic>.md`.
+3. WebFetch the resource and **digest** it into the article's knowledge
+   sections — durable, reusable facts (how a hallmark system works, the repro
+   tells for a class), not a copy of the page. Cite the source and set
+   today's `last_reviewed`.
+4. Flip the resource's Ingest marker to ● and add the article to the index.
+5. That's it — prompts pick it up via the index on the next relevant run.

--- a/kb/README.md
+++ b/kb/README.md
@@ -210,6 +210,59 @@ python lib/ebay_visual.py status
   (`--label`) so the library grows into a tagged, queryable set of priced
   examples for the categories you sell.
 
+### `lib/ebay_browse.py` — other sellers' ACTIVE listings (Browse API)
+
+Direct eBay **Browse API** reader (app-context OAuth, no Chrome/Apify). Pulls any
+seller's currently-active listings, or a general keyword search.
+```
+python lib/ebay_browse.py seller <username> [--q ...] [--category 220] [--max 200]
+python lib/ebay_browse.py search "<keywords>" [--seller ...] [--max 100]
+```
+- **Active listings only = ASKING prices.** Other sellers' **sold** history is
+  NOT available via API (Marketplace Insights is gated/404 for this keyset) —
+  realized comps still come from Apify. See [[ebay_api_seller_access]] in memory.
+- Seller filter needs a `q`/`category_ids` (Browse rejects it alone); seller
+  mode defaults to Toys & Hobbies (220).
+
+### `lib/seller_intel.py` — comps × live API (who sells, who competes)
+
+Bridges the two sources: Apify sold comps carry `sellerName`, so mine them for
+*who sells a type*, then pull that seller's live activity via Browse.
+```
+python lib/seller_intel.py rank      --from <comps.json...> [--by comps|realized]
+python lib/seller_intel.py profile   <username> --from <comps.json...>
+python lib/seller_intel.py landscape --from <comps.json...> [--check 30]
+```
+- **rank** — top sellers by sold-comp count or realized $, with median sale,
+  feedback, and their top types (attributed via the top-100 taxonomy).
+- **profile** — one seller's realized footprint + LIVE active listings + feedback.
+- **landscape** — category competitive map: MOST FOR SALE (active inventory),
+  HIGHEST-PRICED (top asking), TOP REALIZED — to see how successful sellers
+  operate (volume players vs premium specialists).
+- Reads the standard `apify_ebay.py` saved-run JSON (`raw_items`) directly —
+  `sellerName` flows through with no extra step.
+
+---
+
+## Recipe — studying a new category (reusable beyond marbles)
+
+The marble work above is a template. To bring a new category (jewelry, Pyrex,
+Fenton…) up to the same depth:
+
+1. **Taxonomy** — author `kb/taxonomies/<category>-types.md` (the named
+   collectable types + value tiers + match keywords), mirroring
+   [`taxonomies/marble-types-top100.md`](taxonomies/marble-types-top100.md).
+2. **Pull comps** — `python lib/apify_ebay.py "<type queries…>" --save-dir <dir>`
+   (one run, many keywords). The saved JSON carries `sellerName` + images.
+3. **Priced visual library** — `ebay_visual.py add --from <saved.json>` →
+   query by photo for similar **sold** listings + prices.
+4. **Seller intelligence** — `seller_intel.py rank|landscape --from <saved.json>`
+   → who sells the category, who competes, how they price.
+5. **(Optional) forum/visual ID index** — if a peer-ID forum exists, mirror
+   `lib/marble_index.py` for the look-alike side.
+
+Same tooling, new taxonomy — that's the whole pattern.
+
 ---
 
 ## Article file schema

--- a/kb/README.md
+++ b/kb/README.md
@@ -178,6 +178,37 @@ python lib/marble_index.py status      # index size + last sync
 - **Periodic refresh:** `refresh` is safe to run on a schedule (idempotent,
   dedups by thread-id + image-URL) to keep the index current as new IDs are posted.
 
+### `lib/ebay_visual.py` — eBay SOLD visual comp finder
+
+Same featurizer as `marble_index` (imported, not duplicated), but the corpus is
+**eBay sold listings with realized prices** — so a reference photo returns
+visually-similar *sold* listings **and what they went for**. A priced
+look-alike finder that complements the forum index (which has no prices).
+
+Data flow — the Apify scraper is an **MCP tool the assistant runs**, not Python:
+```
+# 1) assistant runs automation-lab/ebay-sold-scraper for some pattern queries
+#    (the same actor PRICE uses), then pulls the dataset to a JSON file, e.g.
+#    via the Apify API using apify.api_token from config.yaml.
+# 2) ingest those listings (download image, embed, dedup by itemId):
+python lib/ebay_visual.py add --from results.json [more.json] --label "pattern-name"
+
+# 3) find the top-K similar SOLD listings + price signal (min/median/max):
+python lib/ebay_visual.py query path/or/url [more-angles...] --top 6 [--json out.json]
+
+python lib/ebay_visual.py status
+```
+
+- **Index:** `kb/index/ebay-sold/` (gitignored). meta rows carry `price`, `url`,
+  `soldDate`, `condition` → results are priced comps.
+- **Honesty contract:** similarity finds *priced candidates*, not a valuation.
+  The top-K are comps to **vet** — condition, size, and authenticity still
+  decide validity (see [`../prompts/price.md`](../prompts/price.md)). Backend is
+  `phash` today (CLIP upgrade is the same VC++ path as marble_index).
+- **Build it by pattern:** ingest one named collectable pattern at a time
+  (`--label`) so the library grows into a tagged, queryable set of priced
+  examples for the categories you sell.
+
 ---
 
 ## Article file schema

--- a/kb/README.md
+++ b/kb/README.md
@@ -66,6 +66,7 @@ lives so it isn't copy-pasted into every module.
 |---|---|---|
 | [silver-hallmarks.md](articles/silver-hallmarks.md) | Sterling vs coin vs plate vs not-silver; reading US maker marks & British hallmark sets (standard/town/date-letter/maker); continental fineness; `925` forgery & EPNS red flags | v1 |
 | [ebay-sold-comps.md](articles/ebay-sold-comps.md) | Finding real sold-price comps: sold≠asking, the Apify/Chrome ladder, query craft, delivered basis, distribution tiers, comp pitfalls | v1 |
+| [taxonomies/marble-types-top100.md](taxonomies/marble-types-top100.md) | The 100 most-collectable marble types, grouped by family with value tiers; doubles as the keyword matcher for the eBay-sold visual library | v1 |
 
 _Add a row per article as it's ingested. Keep this in sync with `articles/`._
 

--- a/kb/_template.md
+++ b/kb/_template.md
@@ -1,0 +1,47 @@
+# <Topic> — KB article
+
+<!--
+Copy this to articles/<topic>.md and fill every section. Then flip the
+resource's Ingest marker to ● in README.md and add a row to the article index.
+Keep it evidence-based, dated, and ACTION-ORIENTED (a run should be able to DO
+something with each section). Delete these comments.
+-->
+
+```yaml
+topic: <short topic name>
+applies_to: [<category or "cross-category">, <material>, <keyword>]  # when a run should consult this
+version: 1
+last_reviewed: <YYYY-MM-DD>
+sources:
+  - <reputable source — society / auction house / standard reference / primary chart>
+```
+
+## When to consult this
+
+The precise cue(s) that should make a run open this article (a mark seen, a
+material, a "is this real?" question). Keep it tight so it fires on the right
+items, not everything.
+
+## Knowledge (the digest)
+
+The durable, reusable facts — digested, not copied. Prefer tables, checklists,
+and decision rules a run can act on directly. This is the body of the article;
+break into subsections as needed (e.g. "How the system works", "Reading a
+mark", "Dating clues").
+
+## Red flags / gotchas
+
+The traps: look-alikes, common misreadings, where memory misleads, the
+expensive-to-get-wrong calls. What to double-check before committing.
+
+## How it maps onto our fields
+
+- **IDENTIFY / INVESTIGATE** → which fields this informs (Brand, Era, Material,
+  Condition, Distinguishing marks) and at what confidence marker.
+- **PRICE** → comp-source or value-signal hooks (never a quote).
+- **needs_followup_photo** → the specific shot that resolves the question, if any.
+
+## Sources
+
+Full reputable-source list with what each is good for, and the primary
+reference URLs to WebFetch on value-moving calls.

--- a/kb/articles/ebay-sold-comps.md
+++ b/kb/articles/ebay-sold-comps.md
@@ -1,0 +1,110 @@
+# eBay sold/completed comps — KB article
+
+```yaml
+topic: finding real sold-price comps on eBay
+applies_to: [cross-category, pricing, comps, valuation]
+version: 1
+last_reviewed: 2026-06-21
+sources:
+  - eBay advanced search — Sold/Completed items filter (the primary comp source)
+  - Internal: prompts/price.md (PRICE phase), lib/price_stats.py, lib/ (Apify scraper)
+  - feedback_apify_optin / feedback_price_delivered_basis (policy memory)
+```
+
+## When to consult this
+
+Any time a run needs **what an item actually sold for** — PRICE phase, a CURATE
+buy decision, or sanity-checking a draft price. This article is the *method* for
+turning eBay sold data into a defensible price; the deep policy (tiers, stats,
+ceiling vetting) lives in [`../../prompts/price.md`](../../prompts/price.md) and
+[`../../lib/price_stats.py`](../../lib/price_stats.py). Use this for the
+search-craft and the pitfalls.
+
+## Knowledge (the digest)
+
+### Sold ≠ asking. Always.
+**Active listings show hope; sold listings show the market.** Never price off
+active/asking listings — filter to **Sold items** (and read completed/unsold as
+a ceiling signal). The whole comp hunt is about *realized* prices.
+
+### The comp-hunt ladder (our stack)
+1. **Stage A — WebSearch / manual eBay sold search** for the exact item to scope
+   the market and the right query words.
+2. **Stage B — Apify** (default, un-gated): the
+   [`automation-lab/ebay-sold-scraper`](../../lib/) pulls structured sold
+   results (US proxy, correct currency). This is the workhorse — runs
+   automatically in PRICE.
+3. **Stage C — Chrome** (optional, only when confidence is low): drive a live
+   eBay sold search in-browser for the exact comp or to read details Apify
+   misses. Also the fallback for sources that block scraping.
+
+### How to search eBay sold well (query craft)
+- **Start specific, then broaden** (the query ladder): brand + line/pattern +
+  model/size + key attribute → drop terms until you have enough comps.
+- **Match the value-moving attributes:** maker, exact pattern/model, size,
+  material, colorway, era. A "close enough" comp on the wrong variant misprices.
+- **Use eBay search operators:** quotes for phrases (`"national line rainbo"`),
+  `-` to exclude (`-repro -reproduction -lot`), `(a,b)` for synonyms.
+- **Filter:** Sold items; correct **Condition**; and exclude **lots/bulk** when
+  pricing a single (and vice-versa — see `unit_type`).
+- **Thin market?** Broaden the query while like-condition comps < 3, then fall
+  back to the closest comparable (per price.md's thin-market rule).
+
+### Compare on the DELIVERED basis
+Per [delivered-basis policy](../../prompts/price.md): compare comps on
+**sold price + shipping** (delivered), not item-only — especially against
+free-shipping listings where shipping is baked into the price. Parse the
+scraper's `shippingCost` into a `total_price` and run the stats on the delivered
+field. Then show **net-to-us** after fees/shipping.
+
+### Reading the distribution (not one number)
+Don't average a handful by eye. Per price-strategy-v2:
+- **Conservative** ≈ 25th percentile · **Recommended** ≈ median of the
+  like-condition cohort · **Push-high** ≈ vetted ceiling (else 90th pct).
+- **Exact-match short-circuit:** a true exact comp anchors Recommended on the
+  median of exact matches.
+- **Outliers:** a survivor above ~2.5× median is a **ceiling candidate to vet**
+  (confirm comparability), not an auto-drop.
+
+## Red flags / gotchas
+
+- **Currency leak:** non-US proxies return foreign-currency or foreign-market
+  prices that look wrong — the scraper was migrated to a US proxy specifically
+  to fix this. If prices look off by a FX-shaped factor, suspect the proxy/market.
+- **Lots vs singles:** a "$60" sold comp that's actually a **lot of 12** is a $5
+  item. Read the title/photos for quantity; honor `unit_type`.
+- **Condition mismatch:** a Mint comp doesn't price a chipped item — keep the
+  like-condition cohort strict; only pool Used grades when the cohort is thin.
+- **Charm-price artifacts / bad parses:** a charm-price validator exists for a
+  reason — sanity-check suspicious round/low values against the raw listing.
+- **Best Offer "sold" prices** on eBay show the **list** price, not the accepted
+  offer — the real sale was often lower. Treat BO solds as a soft ceiling.
+- **Reproductions in the comp set:** repro/fake examples sell cheap and poison
+  the median — exclude them (`-repro`) and cross-check authenticity.
+- **Stale/seasonal:** a single old comp isn't the market; prefer recent solds
+  and enough of them.
+
+## How it maps onto our fields
+
+- **PRICE → Conservative / Recommended / Push-high tiers** from the
+  distribution, on the delivered basis, with net-to-us shown. The working price
+  auto-adopts Recommended (provisional) per the headless gate.
+- **PRICE → "how hard we looked"** report: which stages ran, query ladder used,
+  n comps, exact-match or peer fallback.
+- **CURATE → buy/skip:** compare expected sold (net-to-us) against acquisition
+  cost + effort.
+- **needs_followup:** if comps hinge on an unread attribute (size, pattern,
+  mark), flag the inspection that would pin the right comp.
+
+## Sources
+
+- **eBay advanced search, Sold/Completed filter** — the primary realized-price
+  source. (Active listings = asking, never price off them.)
+- **[`../../prompts/price.md`](../../prompts/price.md)** — the full PRICE policy:
+  query ladder, tiers, ceiling vetting, exact-match short-circuit, thin-market.
+- **[`../../lib/price_stats.py`](../../lib/price_stats.py)** — the deterministic
+  filtering + percentile/tier statistics.
+- **Apify `automation-lab/ebay-sold-scraper`** — Stage B structured sold pull
+  (US proxy). Marketplace Insights API is closed; Apify is the default path.
+- Policy memory: `feedback_apify_optin`, `feedback_price_delivered_basis`,
+  `project_price_strategy_v2`.

--- a/kb/articles/silver-hallmarks.md
+++ b/kb/articles/silver-hallmarks.md
@@ -1,0 +1,166 @@
+# Silver hallmarks & purity marks — KB article
+
+```yaml
+topic: silver hallmarks and purity marks
+applies_to: [cross-category, silver, sterling, "925", flatware, hollowware, jewelry, holloware, plate]
+version: 1
+last_reviewed: 2026-06-21
+sources:
+  - 925-1000.com — Online Encyclopedia of Silver Marks, Hallmarks & Makers' Marks (the canonical lookup)
+  - The Silver Society — thesilversociety.org (identification guidance)
+  - Goldsmiths' Company Assay Office, London (British hallmarking authority)
+```
+
+## When to consult this
+
+Any item that may be silver and carries marks: flatware, hollowware, trays,
+tea sets, jewelry, frames, vanity items, trophies. Cue words/marks: **925,
+STERLING, STER, .925, 800/835/900, COIN, EPNS, A1, "quadruple plate",** a
+**lion**, a **leopard's head**, an **anchor**, a **crown**, or any small struck
+maker's symbol. Consult before settling Material, Era, Brand, or value tier —
+silver vs silverplate is a large value fork and one of the most common
+misreads. Cross-check with the [silver push-high pricing rule](../../prompts/price.md)
+(silver under-prices and sells fast — rarity-check and hunt the exact comp).
+
+## Knowledge (the digest)
+
+### 1. The big fork — solid silver vs plate vs not-silver
+
+This is the value-decisive split. Get it right first.
+
+| Class | What it is | How it's marked | Value posture |
+|---|---|---|---|
+| **Sterling** | 92.5% silver alloy | `STERLING`, `STER`, `925`, `.925`, or British hallmark set (lion passant etc.) | Real silver — has melt value + collectible value |
+| **Coin silver** (US, ~pre-1870) | ~90% silver (from melted coin), 0.892–0.900 | `COIN`, `PURE COIN`, `STANDARD`, `DOLLAR`, `C`, `900`, or just a maker's name | Real silver, often older/desirable |
+| **Continental** | European standards | `800`, `835`, `830`, `900`, `silver` + national marks | Real silver (note: 800 < sterling purity) |
+| **Britannia** (British) | 95.84% silver | figure of Britannia + lion's head erased; `958` | Real silver, higher purity |
+| **Silverplate (EPNS)** | base metal w/ thin silver layer | `EPNS`, `EP`, `A1`, `EPBM`, `silver on copper`, `triple/quadruple plate`, `nickel silver`, maker name **without** sterling/925 | **NOT solid silver** — minimal melt value; value is brand/decorative only |
+| **Not silver at all** | white base alloys | `German silver`, `nickel silver`, `alpaca/alpacca`, `EPNS` (the "silver" is plating only), `silver-tone`, `925` on obvious junk | No silver content despite "silver" in the name |
+
+**Decision rule:** A solid-silver piece will carry **either** a recognized
+national hallmark set **or** an unambiguous fineness/standard word (`STERLING`/
+`925`/`800`/`COIN`). The words **PLATE, EP, EPNS, A1, nickel/German silver,
+alpaca** mean **plated or no silver** — full stop, regardless of how "silvery"
+it looks. When a piece shows only a maker name and a non-committal word, treat
+it as **plate until a fineness mark or hallmark proves solid**.
+
+### 2. American silver — read the maker, not an assay office
+
+US makers did **not** use a government assay system (no town mark, no date
+letter). On American silver you typically get:
+- **A fineness word/number:** `STERLING` or `925` became standard from the
+  ~1860s onward; **`COIN`/`900`** signals earlier (pre-~1870) coin silver.
+- **A maker's mark:** name, initials, or a symbol. Major houses have their own
+  systems — **Gorham** (lion–anchor–G + a date-letter symbol system),
+  **Tiffany & Co.** (name + pattern/order numbers), **Reed & Barton**,
+  **Towle**, **International**, **Wallace**, **Unger Bros.**, **Kirk**.
+- **No date letter** in general — date American pieces by maker system,
+  pattern, style, and any model number, **not** a hallmark date letter.
+
+⚠ A lone `STERLING` with a symbol you can't place → look up the **maker's
+mark** on 925-1000.com's American makers index before naming a brand.
+
+### 3. British hallmarks — a true date-encoded system (4–5 marks)
+
+Genuine British silver carries a **set** of separately struck marks. Reading
+all of them gives standard, town, year, and maker:
+
+1. **Standard / fineness mark** — the **lion passant** (walking lion) = sterling
+   (England). Scotland historically used a thistle; Ireland a crowned harp.
+   Britannia figure = 95.8% Britannia standard.
+2. **Town / assay-office mark** — *where* it was assayed:
+   - **Leopard's head** = London
+   - **Anchor** = Birmingham
+   - **Rose** (crown, pre-1975) = Sheffield
+   - **Castle** = Edinburgh
+   - **Harp crowned** = Dublin
+   - (Chester, Glasgow, Exeter, Newcastle, York = closed offices → older)
+3. **Date letter** — a single letter in a specific **font + shield shape** that
+   changes annually on a ~20–26-year cycle, **unique per office**. This is how
+   you date British silver to the **exact year** — but only via the office's
+   chart (font and shield matter as much as the letter).
+4. **Maker's / sponsor's mark** — the registered initials of the maker.
+5. **Duty mark** (sovereign's head, ~1784–1890) — present only in that window;
+   its presence/absence is itself a dating clue.
+
+**To date British silver:** identify the town mark → open that office's
+date-letter chart → match the **letter + font + shield outline**. Never date
+from the letter alone.
+
+### 4. Continental / world marks
+
+European silver uses **fineness numbers** (`800`, `835`, `830`, `900`, `925`)
+often with national/control marks and maker punches. `800` is the common German/
+Italian standard (lower purity than sterling — note for melt math). National
+systems (French Minerva head, German crescent-moon-and-crown `800`, Russian
+zolotnik `84`, etc.) each have their own lookup. Use 925-1000.com's world-marks
+index to place an unfamiliar national mark.
+
+### 5. Dating clues beyond the marks
+- **`STERLING`/`925` spelled out** → generally American/modern (Britain uses the
+  symbol set, not the word, on hallmarked pieces).
+- **`COIN`/`900`/no fineness + early style** → pre-1870 American.
+- **Duty mark (monarch's head)** on British → 1784–1890.
+- **Optional millesimal `925` added to British marks** → common after 1999.
+- **Pseudo-hallmarks** (American makers mimicking British-style symbol rows
+  without a real assay office, e.g. some 19th-c. firms) → American, not British;
+  don't read them as an English date letter.
+
+## Red flags / gotchas
+
+- **"Looks like silver" ≠ silver.** EPNS, German/nickel silver, and alpaca are
+  the most common false positives. The plating words override the shine.
+- **`925` forgeries.** Modern fakes (especially imported jewelry) stamp `925`
+  on non-silver. Treat a lone `925` on a suspicious item as a claim to verify
+  (magnet test — silver is **non-magnetic**; acid test; weight/feel), not proof.
+- **`A1`, `triple plate`, `quadruple plate`** are **plate-quality** boasts, not
+  silver standards — Rogers Bros. "1847" etc. are silverplate lines.
+- **Pseudo-hallmarks** on American pieces imitate British symbol rows — don't
+  mine them for a (non-existent) English date letter or town.
+- **Worn/partial marks:** a rubbed lion or smudged letter can flip the ID.
+  Don't over-claim a town/year from a half-struck mark — request a macro.
+- **Plated flatware sets** are routinely sold "as silver" — confirm the fork
+  vs plate split before any silver value tier.
+- **Melt-math trap:** `800` is only 80% silver — don't compute melt at sterling
+  purity for continental pieces.
+
+## How it maps onto our fields
+
+- **IDENTIFY / INVESTIGATE → Material:** "Sterling silver (925)" only when a
+  fineness mark or full hallmark confirms; otherwise "Silverplate (EPNS)" or
+  "white metal, unmarked — silver unconfirmed `[BEST-CASE]`". The plate/solid
+  fork is value-tier-moving, so bracket it if unresolved.
+- **→ Brand:** the maker from the maker's-mark lookup (Gorham, Tiffany, etc.);
+  `[BEST-CASE]` until the punch is matched on 925-1000.com.
+- **→ Era:** British → exact year from the date-letter chart (cite office +
+  letter); American → maker-system/style estimate `[ASSUMPTION]`.
+- **→ Distinguishing marks:** record the literal marks seen (e.g. "lion passant
+  + anchor + date letter 'h' + maker 'WH'") and the resulting standard/town/year.
+- **PRICE:** if solid silver, apply the [silver push-high rule](../../prompts/price.md)
+  — rarity-check, hunt the exact maker/pattern comp, list at the ceiling + Best
+  Offer; never just melt. If plate, value is brand/decorative — comp the line,
+  not silver weight.
+- **needs_followup_photo:** a **raking-light macro of the full mark row**
+  (and the underside) — the single shot that settles standard, town, year, and
+  maker. For a `925`-on-suspect item, a **magnet test** photo/result.
+
+## Sources
+
+- **[925-1000.com](https://www.925-1000.com/index.html)** — the canonical
+  Online Encyclopedia of Silver Marks. Primary lookups to WebFetch on a
+  value-moving call:
+  - American makers' marks index (place a US maker's punch)
+  - **[British / English-Irish-Scottish hallmarks](https://www.925-1000.com/british_marks.html)**
+    — assay-office marks + **date-letter charts** (the dating tool)
+  - **[World / foreign hallmarks](https://www.925-1000.com/foreign_marks.html)**
+    — continental & national systems
+  - Silverplate trade marks & pseudo-hallmarks indexes
+- **[The Silver Society](https://www.thesilversociety.org/research/identify-your-silver/)**
+  — identification guidance and scholarship.
+- **Goldsmiths' Company Assay Office (London)** — the British hallmarking
+  authority; definitive for the meaning of the UK mark set.
+
+> Note: 925-1000.com blocks automated fetching (HTTP 403 to scrapers) — when a
+> run needs its date-letter charts, open the page in **Chrome** (Stage C) rather
+> than WebFetch. This article's digest is the offline fallback for the common
+> cases; the charts themselves are the authority for an exact British year.

--- a/kb/taxonomies/marble-types-top100.md
+++ b/kb/taxonomies/marble-types-top100.md
@@ -1,0 +1,202 @@
+# Top 100 collectable marble types — taxonomy
+
+```yaml
+topic: marble type taxonomy (top 100 collectable kinds)
+applies_to: [marbles]
+version: 1
+last_reviewed: 2026-06-22
+sources:
+  - Marble Collectors Society of America — marblecollecting.com (type taxonomy)
+  - Block's Marble Auctions — marbleauctions.com (named types + realized market)
+  - specializations/marbles.md (in-repo expert module)
+```
+
+A working catalog of the 100 most-collectable marble kinds, grouped by family.
+It serves two jobs:
+
+1. **Reference** — a quick map of the named types worth pulling, with a coarse
+   value **tier** and the tells, complementing
+   [`../../specializations/marbles.md`](../../specializations/marbles.md).
+2. **The matcher for the eBay-sold visual library** — the **Keywords** column
+   drives [`../../lib/ebay_visual.py`](../../lib/ebay_visual.py) attribution:
+   each scraped sold listing is tagged to a type by title keyword. Matching is
+   **longest-keyword-first**, so a specific phrase (`onionskin lutz`, `tiger
+   eye`) wins over a generic one (`onionskin`, `tiger`) regardless of row order
+   — the family grouping below is for reading, not match priority.
+
+> Numbers 1–100 are catalog indices for reference, **not** a strict value rank
+> — collectability is shown by **Tier**. Keep this in sync with the library's
+> curation script. Honesty contract still applies: a keyword tag is a *bucket*,
+> not an authenticated ID — the live judgement is the specialization's
+> (method ≠ origin ≠ era), and a "Guinea"-titled listing may be a fake.
+
+**Tier legend:** `$` filler/common · `$$` modest · `$$$` strong · `$$$$` top ·
+`🏆` trophy. Tiers are triage signals; PRICE still hunts live comps.
+
+> Keywords are `;`-separated; kept tight to avoid false matches (generic words
+> like "swirl", "patch", "slag", "agate" are never used alone).
+
+---
+
+## A. Handmade swirls (German/American, ~1850–1920)
+
+| # | Type | Tier | Keywords | Notes |
+|---|---|---|---|---|
+| 1 | Solid Core Swirl | $$$ | solid core | Opaque colored core, cane bands over it |
+| 2 | Divided Core Swirl | $$$ | divided core | Core split into separate strands |
+| 3 | Latticinio Core Swirl | $$ | latticinio | Net-like white/yellow lattice core; common handmade |
+| 4 | Ribbon Core Swirl | $$$ | ribbon core | One/two flat ribbon cores |
+| 5 | Coreless Swirl | $$ | coreless | Bands but no central core |
+| 6 | Banded Swirl | $$$ | banded swirl | Color bands on a clear/colored base |
+| 7 | Caramel Swirl | $$ | caramel swirl | Brown/amber naked swirl |
+| 8 | Peppermint Swirl | $$$ | peppermint | Opaque white w/ red+blue bands (US, Navarre era) |
+| 9 | Beachball | $$$$ | beachball; beach ball | 3-color paneled peppermint variant; sought |
+| 10 | Gooseberry | $$$ | gooseberry | Transparent base w/ tight white-yellow lines |
+
+## B. Handmade end-of-day / onionskin
+
+| # | Type | Tier | Keywords | Notes |
+|---|---|---|---|---|
+| 11 | Onionskin (single) | $$$ | onionskin; onion skin | Stretched flecked skin, converges at poles |
+| 12 | Paneled Onionskin | $$$ | paneled onionskin; panel onionskin | Distinct color panels |
+| 13 | Segmented Onionskin | $$$ | segmented onionskin | Segmented skin |
+| 14 | Onionskin Mist | $$$ | onionskin mist | Hazy/misted skin |
+| 15 | End of Day Cloud | $$$ | end of day | Flecks suspended unstretched (spotted) |
+| 16 | Joseph's Coat | $$$ | joseph's coat; josephs coat; joseph coat | Tightly packed multicolor bands, no core |
+| 17 | Submarine / Cornhusk | $$$ | submarine; cornhusk | Subsurface paneled/skin variants |
+
+## C. Handmade Lutz (gold/copper aventurine)
+
+| # | Type | Tier | Keywords | Notes |
+|---|---|---|---|---|
+| 18 | Banded Lutz | $$$$ | banded lutz | Lutz bands on colored/clear base |
+| 19 | Onionskin Lutz | $$$$ | onionskin lutz | Lutz over an onionskin core — top tier |
+| 20 | Ribbon Lutz | $$$$ | ribbon lutz | Lutz on ribbon |
+| 21 | Indian Lutz | 🏆 | indian lutz | Lutz on black Indian base — rare |
+| 22 | Mist Lutz | $$$$ | mist lutz; lutz mist | Lutz on misted base |
+| 23 | Lutz (generic/colored) | $$$$ | lutz | Any handmade w/ true Lutz material |
+
+## D. Handmade opaque & specialty
+
+| # | Type | Tier | Keywords | Notes |
+|---|---|---|---|---|
+| 24 | Indian | $$$ | indian | Black opaque base w/ colored surface bands |
+| 25 | Mica | $$$ | mica | Suspended silvery mica flakes |
+| 26 | Clambroth | $$$$ | clambroth | Opaque base, evenly-spaced thin lines |
+| 27 | Banded Opaque | $$$ | banded opaque | Opaque base w/ bands |
+| 28 | Banded Transparent | $$ | banded transparent | Transparent base w/ bands |
+| 29 | Custard | $$ | custard | Opaque custard-yellow base |
+| 30 | Maglite | $$ | maglite | Magnesia/“milk” base swirl |
+| 31 | Sulphide (single figure) | $$$ | sulphide; sulfide | Clear sphere, embedded white figure |
+| 32 | Sulphide (colored/painted) | $$$$ | colored sulphide; painted sulphide | Colored base/painted figure — rarer |
+| 33 | Sulphide (numbered/figural pair) | $$$$ | numbered sulphide; sulphide number | Numbers/multiple figures |
+
+## E. Transitional (early machine, single pontil ~1900–1915)
+
+| # | Type | Tier | Keywords | Notes |
+|---|---|---|---|---|
+| 34 | Leighton | $$$ | leighton | Classic single-pontil transitional |
+| 35 | Navarre | $$$ | navarre | Navarre/Iowa City transitional |
+| 36 | Crease Pontil | $$ | crease pontil | Crease-style pontil |
+| 37 | Ground Pontil | $$ | ground pontil | Ground/faceted pontil |
+| 38 | Melted Pontil | $$ | melted pontil | Melted/blended pontil |
+| 39 | Pinch / Fold Pontil | $$ | pinch pontil; fold pontil | Pinch or fold pontil |
+| 40 | Slag Transitional | $$ | transitional slag; transitional | Early slag w/ pontil |
+
+## F. M.F. Christensen & Son (1905–1917)
+
+| # | Type | Tier | Keywords | Notes |
+|---|---|---|---|---|
+| 41 | M.F.C. Slag | $$$ | m.f. christensen; mf christensen; m f christensen; mfc slag | Earliest US machine slag; "9 & 9" |
+| 42 | M.F.C. Brick | $$$ | mfc brick; christensen brick | Oxblood-streaked “brick” |
+| 43 | M.F.C. Oxblood Slag | $$$$ | mfc oxblood | Oxblood in slag — prized |
+| 44 | M.F.C. Opaque/Pearl | $$$ | mfc opaque; mfc pearl | Opaque/pearl bodies |
+
+## G. Christensen Agate Co. (1927–1933)
+
+| # | Type | Tier | Keywords | Notes |
+|---|---|---|---|---|
+| 45 | Guinea | 🏆 | guinea | Transparent base, peppered flecks — holy grail |
+| 46 | Flame | $$$$ | flame | Stretched flame design |
+| 47 | Cyclone / Cobra | $$$$ | cyclone; cobra | Tight twisted multicolor — rare |
+| 48 | Christensen Swirl | $$$$ | christensen swirl | Brilliant-color slag/swirl |
+| 49 | Christensen Slag | $$$ | christensen slag | High-color slag |
+| 50 | Striped Opaque | $$$$ | striped opaque | Opaque base, stripes |
+| 51 | Striped Transparent | $$$$ | striped transparent | Transparent base, stripes |
+| 52 | Bloodie | $$$ | bloodie | Oxblood-on-yellow |
+| 53 | American Agate | $$$ | american agate | Orange/red w/ white |
+| 54 | Electric (color) | $$$$ | electric | Electric/UV-bright colorways |
+
+## H. Akro Agate (1911–1951)
+
+| # | Type | Tier | Keywords | Notes |
+|---|---|---|---|---|
+| 55 | Popeye Corkscrew | $$$$ | popeye | Clear base + white filaments + 2 colors |
+| 56 | Corkscrew Special (4+ color) | $$$$ | corkscrew special; special corkscrew; five color corkscrew | Multi-color specials — rare |
+| 57 | Snake Corkscrew | $$$ | snake corkscrew | Snake variant |
+| 58 | Corkscrew (2-color) | $$ | corkscrew | Standard non-intersecting spirals |
+| 59 | Patch-and-Ribbon | $$ | patch and ribbon; patch ribbon | Patch w/ ribbon |
+| 60 | Akro Patch | $$ | akro patch | Two-color patch |
+| 61 | Carnelian (oxblood) | $$$ | carnelian | Oxblood on orange |
+| 62 | Limeade (oxblood) | $$$ | limeade | Oxblood on green |
+| 63 | Lemonade (oxblood) | $$$ | lemonade | Oxblood on yellow-green |
+| 64 | Egg Yolk (oxblood) | $$$ | egg yolk; eggyolk | Oxblood on yellow |
+| 65 | Silver Oxblood | $$$$ | silver oxblood | Oxblood on grey/silver — scarce |
+| 66 | Oxblood (generic) | $$$ | oxblood | Dense dark brownish-red streak |
+| 67 | Sparkler | $$$ | sparkler | Many colors from clear base |
+| 68 | Moss Agate | $$ | moss agate | Transparent base w/ opaque swirl |
+| 69 | Slag (Akro) | $$ | akro slag | Single transparent color + white |
+| 70 | Prize Name | $$$ | prize name | Named premium line |
+| 71 | Hero / Ace | $$ | hero ace; ace agate | Lower lines |
+| 72 | Ringer | $$ | ringer | Boxed-set line |
+| 73 | Tri-Color Agate | $$$ | tri-color agate; tricolor agate | Three-color corkscrew/patch |
+
+## I. Peltier Glass Co.
+
+| # | Type | Tier | Keywords | Notes |
+|---|---|---|---|---|
+| 74 | NLR Superman | $$$$ | superman | Lt-blue base, yellow+red ribbons |
+| 75 | NLR Christmas Tree | $$$$ | christmas tree | White base, red+green |
+| 76 | NLR Liberty | $$$$ | rainbo liberty; nlr liberty | White base, red+blue |
+| 77 | NLR Zebra | $$$ | zebra | Black/white |
+| 78 | NLR Bumblebee | $$ | bumblebee | Black/yellow |
+| 79 | NLR Wasp | $$$ | wasp | Black/red |
+| 80 | NLR Tiger | $$$ | nlr tiger; tiger rainbo | Black/orange |
+| 81 | NLR Cub Scout | $$$ | cub scout | Blue/yellow |
+| 82 | NLR Rebel | $$$ | rebel | Named tri/odd |
+| 83 | National Line Rainbo (generic) | $$$ | national line rainbo; nlr | Opaque base, thin ribbons, 2 seams |
+| 84 | Comic / Picture | 🏆 | comic; picture marble; tom mix; koko; skeezix; kayo; bimbo; smitty | Fired-on character transfer |
+| 85 | Peerless Patch | $$ | peerless | Patch base (also comic substrate) |
+| 86 | Peltier Rainbo | $$ | peltier rainbo | Later two-color line |
+| 87 | Peltier Sunset / Multicolor Swirl | $$$ | peltier sunset; multicolor swirl | Multicolor swirl |
+| 88 | Peltier Slag | $$ | peltier slag | Slag line |
+
+## J. Master, Vitro, Marble King & WV swirl houses
+
+| # | Type | Tier | Keywords | Notes |
+|---|---|---|---|---|
+| 89 | Master Sunburst | $$ | sunburst; master marble; master glass | Translucent multicolor sunburst |
+| 90 | Master Tiger Eye / Cloudy | $$ | master tiger; cloudy | Cloudy/translucent swirl |
+| 91 | Vitro Conqueror | $$ | conqueror | Patch-on-white, milky swirl |
+| 92 | Vitro Tiger Eye | $$ | tiger eye | Cat's-eye-adjacent |
+| 93 | Vitro All-Red (Blackie/Whitie) | $$ | all-red; all red; blackie; whitie | Red ribbon lines |
+| 94 | Vitro Parrot | $$$ | parrot | Multicolor — sought Vitro |
+| 95 | Marble King Rainbow (Spiderman etc.) | $$ | marble king; spiderman; watermelon | Two-color patch/rainbow lines |
+| 96 | Alley Agate Swirl | $$ | alley agate; alley swirl | WV multicolor swirl |
+| 97 | Champion / Ravenswood Swirl | $$ | champion agate; ravenswood | WV furnace swirl |
+| 98 | Heaton / Cairo Swirl | $ | heaton; cairo novelty | WV swirl, common |
+| 99 | Cat's Eye (vintage/named) | $ | cat's eye; cats eye; cat eye | Injected vane; mostly common |
+| 100 | Vacor "Planet" / splatterpatch | $ | vacor; splatterpatch; mega marble | Modern Mexican — filler reference |
+
+---
+
+## How the visual library uses this
+
+`lib/ebay_visual.py` ingests eBay **sold** listings (from the Apify
+ebay-sold-scraper PRICE uses) and tags each to one of these 100 types via the
+Keywords above (longest-match-first). A reference photo then returns the most
+visually-similar **sold** listings + their realized prices — a priced comp
+finder, bucketed by collectable type. The forum index
+([`marble_index.py`](../../lib/marble_index.py)) gives the ID/look-alike side;
+this gives the price side. Build/extend the library by scraping the types not
+yet covered and re-running the curation — no type needs re-scraping once held.

--- a/lib/apify_ebay.py
+++ b/lib/apify_ebay.py
@@ -397,6 +397,7 @@ class CompRecord:
     item_id: Optional[str] = None
     listing_type: Optional[str] = None    # "Buy It Now" / "Auction"
     bids_count: Optional[int] = None      # for Tier-C single-bid exclusion
+    thumbnail: Optional[str] = None       # listing image (for the visual library)
     keyword_tag: Optional[str] = None     # which input keyword this matched
     bo_accepted: bool = False             # not exposed by this Actor
     raw: dict = field(default_factory=dict, repr=False)
@@ -531,6 +532,7 @@ def _map_to_comp_record(item: dict, keyword_tag: Optional[str]) -> Optional[Comp
         item_id=str(item.get("itemId")) if item.get("itemId") is not None else None,
         listing_type=item.get("listingType"),
         bids_count=_parse_int(item.get("bidsCount")),
+        thumbnail=item.get("thumbnail"),
         keyword_tag=keyword_tag,
         bo_accepted=False,
         raw=item,
@@ -549,7 +551,8 @@ def _comp_to_dict(c: "CompRecord") -> dict:
         "total_price": c.total_price, "seller_username": c.seller_username,
         "seller_feedback_score": c.seller_feedback_score,
         "seller_feedback_pct": c.seller_feedback_pct,
-        "item_id": c.item_id, "keyword_tag": c.keyword_tag, "url": c.url,
+        "item_id": c.item_id, "thumbnail": c.thumbnail,
+        "keyword_tag": c.keyword_tag, "url": c.url,
     }
 
 
@@ -890,6 +893,7 @@ def _cli() -> None:
                     "shipping_cost": c.shipping_cost,
                     "shipping_type": c.shipping_type,
                     "total_price": c.total_price,
+                    "thumbnail": c.thumbnail,
                     "keyword_tag": c.keyword_tag,
                 }
                 for c in comps

--- a/lib/config.example.yaml
+++ b/lib/config.example.yaml
@@ -74,6 +74,10 @@ ebay:
                                          # sized) marked fulfillment_mode LOCAL_PICKUP.
                                          # Create via `--create-pickup-policy`.
     payment_policy_id: null
+    payment_policy_id_auction: null      # optional: a payment policy with immediate
+                                         # payment OFF; required for AUCTION offers
+                                         # (eBay forbids immediate-pay on auctions).
+                                         # Falls back to payment_policy_id if unset.
     return_policy_id: null
 
   production:
@@ -91,6 +95,10 @@ ebay:
                                          # sized) marked fulfillment_mode LOCAL_PICKUP.
                                          # Create via `--create-pickup-policy`.
     payment_policy_id: null
+    payment_policy_id_auction: null      # optional: a payment policy with immediate
+                                         # payment OFF; required for AUCTION offers
+                                         # (eBay forbids immediate-pay on auctions).
+                                         # Falls back to payment_policy_id if unset.
     return_policy_id: null
 
 # ---------------------------------------------------------------------------

--- a/lib/ebay_browse.py
+++ b/lib/ebay_browse.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""eBay **Browse API** reader — other sellers' ACTIVE listings, direct via API.
+
+Uses the app-context OAuth token from ebay_client.py (app_id + cert_id, no user
+consent) to call the Buy > Browse API. Lets you pull any seller's currently
+**active** listings — title, asking price, condition, image, URL — without
+Chrome or Apify.
+
+  IMPORTANT — what this can and cannot do (verified 2026-06-22, production):
+  • ACTIVE listings by seller  -> YES (this module; Browse item_summary/search
+    with filter=sellers:{username}).
+  • SOLD/completed by seller    -> NO via official API. The only API with sold
+    data is Marketplace Insights (buy/marketplace_insights/v1/item_sales/search),
+    a Limited-Release API not granted to this keyset (returns HTTP 404). That is
+    why realized-price comps come from Apify (lib/apify_ebay.py / ebay_visual.py),
+    which is keyword-based and has no seller filter. A specific seller's SOLD
+    history is not reachable by API — only their ACTIVE listings are.
+
+So treat prices here as **asking**, not realized. Useful for watching what a
+known-good seller currently offers (and how they price/title/condition-grade),
+not as sold comps.
+
+CLI:
+    python ebay_browse.py seller <username> [--q marble] [--category 233]
+                                            [--max 200] [--json out.json]
+    python ebay_browse.py search "<keywords>" [--category 233] [--max 100] [--json out.json]
+
+Browse search requires at least a `q` OR `category_ids`; a seller filter alone is
+not enough, so `seller` defaults to the Marbles category (233) when no q/category
+is given. Output records are normalised and include `listingStatus: "active"`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import ebay_client as ec  # noqa: E402
+
+BROWSE_SEARCH = "/buy/browse/v1/item_summary/search"
+PAGE_LIMIT = 200            # Browse API max page size
+# Browse rejects a seller filter alone (HTTP 400 — needs q OR category_ids). For
+# "a seller's whole store" we default to the Toys & Hobbies PARENT category,
+# which captures marble/toy subcategories (verified: dusar-8's marbles surface
+# under 220, not the narrower 233). Pass --category for sellers outside toys.
+DEFAULT_SELLER_CATEGORY = "220"   # Toys & Hobbies (EBAY_US top-level)
+
+
+def _normalize(it: dict) -> dict:
+    pr = it.get("price") or {}
+    img = (it.get("image") or {}).get("imageUrl")
+    if not img:
+        thumbs = it.get("thumbnailImages") or []
+        img = thumbs[0].get("imageUrl") if thumbs else None
+    val = pr.get("value")
+    try:
+        val = float(val) if val is not None else None
+    except (TypeError, ValueError):
+        pass
+    return {
+        "itemId": it.get("itemId"),
+        "title": it.get("title"),
+        "askingPrice": val,
+        "priceStr": f"{pr.get('value')} {pr.get('currency')}".strip() if pr else None,
+        "currency": pr.get("currency"),
+        "condition": it.get("condition"),
+        "conditionId": it.get("conditionId"),
+        "thumbnail": img,                      # named to match ebay_visual ingest
+        "url": (it.get("itemWebUrl") or "").split("?")[0] or None,
+        "seller": (it.get("seller") or {}).get("username"),
+        "buyingOptions": it.get("buyingOptions"),
+        "listingStatus": "active",             # NB: asking price, not sold
+    }
+
+
+def search(q: str | None = None, *, seller: str | None = None,
+           category_ids: str | None = None, max_items: int = 200,
+           marketplace: str = "EBAY_US", creds=None) -> list[dict]:
+    """Page Browse item_summary/search and return normalised active listings.
+
+    Provide at least one of `q` or `category_ids` (eBay requires it). `seller`
+    adds filter=sellers:{seller}.
+    """
+    if not q and not category_ids:
+        raise ValueError("Browse search needs a `q` or `category_ids`.")
+    out: list[dict] = []
+    offset = 0
+    while len(out) < max_items:
+        query = {"limit": min(PAGE_LIMIT, max_items - len(out)), "offset": offset}
+        if q:
+            query["q"] = q
+        if category_ids:
+            query["category_ids"] = category_ids
+        if seller:
+            query["filter"] = f"sellers:{{{seller}}}"
+        data = ec.api_get(BROWSE_SEARCH, query=query, marketplace=marketplace, creds=creds)
+        batch = data.get("itemSummaries") or []
+        out.extend(_normalize(it) for it in batch)
+        total = data.get("total") or 0
+        offset += len(batch)
+        if not batch or offset >= total:
+            break
+    return out[:max_items]
+
+
+def seller_items(seller: str, *, q: str | None = None,
+                 category_ids: str | None = None, max_items: int = 200,
+                 creds=None) -> list[dict]:
+    """A seller's ACTIVE listings. Defaults to the Toys & Hobbies category if no q/cat."""
+    if not q and not category_ids:
+        category_ids = DEFAULT_SELLER_CATEGORY
+    return search(q=q, seller=seller, category_ids=category_ids,
+                  max_items=max_items, creds=creds)
+
+
+def _print(records: list[dict], header: str) -> None:
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+    print(f"\n{header} — {len(records)} active listing(s):\n")
+    for r in records:
+        price = f"${r['askingPrice']:.2f}" if isinstance(r.get("askingPrice"), float) else (r.get("priceStr") or "?")
+        opt = ",".join(r.get("buyingOptions") or [])
+        print(f"  {price:>9}  [{r.get('condition')}/{opt}]  {(r.get('title') or '')[:58]}")
+        print(f"     {r.get('url')}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("seller", help="a seller's ACTIVE listings (asking prices)")
+    p.add_argument("username")
+    p.add_argument("--q", default=None, help="optional keyword filter")
+    p.add_argument("--category", default=None, help="category_ids (default 233 Marbles)")
+    p.add_argument("--max", type=int, default=200)
+    p.add_argument("--json", default=None)
+
+    p = sub.add_parser("search", help="general Browse keyword search (active listings)")
+    p.add_argument("query")
+    p.add_argument("--seller", default=None)
+    p.add_argument("--category", default=None)
+    p.add_argument("--max", type=int, default=100)
+    p.add_argument("--json", default=None)
+
+    args = ap.parse_args()
+    try:
+        if args.cmd == "seller":
+            recs = seller_items(args.username, q=args.q, category_ids=args.category, max_items=args.max)
+            _print(recs, f"Seller {args.username} (active)")
+        else:
+            recs = search(q=args.query, seller=args.seller, category_ids=args.category, max_items=args.max)
+            _print(recs, f"Search {args.query!r}")
+        if args.json:
+            Path(args.json).write_text(json.dumps(recs, indent=2), encoding="utf-8")
+            print(f"\nWrote {len(recs)} records -> {args.json}")
+    except (ec.EbayAuthError, ec.EbayAPIError, ValueError) as e:
+        print(f"[X] {type(e).__name__}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ebay_browse.py
+++ b/lib/ebay_browse.py
@@ -59,6 +59,7 @@ def _normalize(it: dict) -> dict:
         val = float(val) if val is not None else None
     except (TypeError, ValueError):
         pass
+    seller = it.get("seller") or {}
     return {
         "itemId": it.get("itemId"),
         "title": it.get("title"),
@@ -69,7 +70,9 @@ def _normalize(it: dict) -> dict:
         "conditionId": it.get("conditionId"),
         "thumbnail": img,                      # named to match ebay_visual ingest
         "url": (it.get("itemWebUrl") or "").split("?")[0] or None,
-        "seller": (it.get("seller") or {}).get("username"),
+        "seller": seller.get("username"),
+        "sellerFeedbackPct": seller.get("feedbackPercentage"),
+        "sellerFeedbackScore": seller.get("feedbackScore"),
         "buyingOptions": it.get("buyingOptions"),
         "listingStatus": "active",             # NB: asking price, not sold
     }

--- a/lib/ebay_browse.py
+++ b/lib/ebay_browse.py
@@ -118,6 +118,25 @@ def seller_items(seller: str, *, q: str | None = None,
                   max_items=max_items, creds=creds)
 
 
+def seller_active(seller: str, *, q: str | None = None,
+                  category_ids: str | None = None, sample: int = 200,
+                  creds=None) -> tuple[int, list[dict]]:
+    """One Browse call: a seller's EXACT active-listing `total` in a category +
+    a normalised price sample (up to `sample`). Cheap enough to fan across many
+    sellers to map a category's competitive landscape."""
+    if not q and not category_ids:
+        category_ids = DEFAULT_SELLER_CATEGORY
+    query = {"limit": min(PAGE_LIMIT, sample), "filter": f"sellers:{{{seller}}}"}
+    if q:
+        query["q"] = q
+    if category_ids:
+        query["category_ids"] = category_ids
+    data = ec.api_get(BROWSE_SEARCH, query=query, marketplace="EBAY_US", creds=creds)
+    total = int(data.get("total") or 0)
+    recs = [_normalize(it) for it in (data.get("itemSummaries") or [])]
+    return total, recs
+
+
 def _print(records: list[dict], header: str) -> None:
     try:
         sys.stdout.reconfigure(encoding="utf-8")

--- a/lib/ebay_visual.py
+++ b/lib/ebay_visual.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Visual library of eBay SOLD listings — a priced visual comp finder.
+
+Given a reference photo, return the most visually-similar *sold* eBay listings
+together with their realized prices. Complements lib/marble_index.py (forum
+photos, no prices) with priced comps, and **reuses its pHash featurizer** so the
+two libraries behave identically (same embedding method, separate indexes).
+
+Why a separate ingester: eBay sold data comes from the Apify actor
+`automation-lab/ebay-sold-scraper`, which is an **MCP tool the assistant runs**,
+not something Python can call. So the flow is:
+
+  1) assistant runs the scraper for some pattern queries (the same actor PRICE
+     uses), and saves the dataset items to a JSON file, e.g.:
+         [{ "itemId","title","soldPrice","soldPriceString","thumbnail",
+            "url","soldDate","condition" }, ...]
+  2) `python lib/ebay_visual.py add --from results1.json results2.json`
+         -> download each listing's image, embed, append (dedup by itemId)
+  3) `python lib/ebay_visual.py query <image-or-url> --top N`
+         -> top-K visually-similar SOLD listings, each with price + link
+  4) `python lib/ebay_visual.py status`
+
+Index: kb/index/ebay-sold/ (gitignored, regenerable).
+  meta.jsonl  one row per listing image {i,img,itemId,url,title,price,...}
+  emb.npy     float32 [N,D] L2-normalised features, row-aligned to meta
+  state.json  dedup sets + last_sync_utc + backend
+
+Honesty contract (same as marble_index): similarity finds *candidates*, it does
+NOT identify maker/era or guarantee a comp is truly comparable. Treat the
+top-K as priced look-alikes to vet — condition, size, and authenticity still
+decide whether a sold listing is a valid comp (see prompts/price.md).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Reuse marble_index's tooling WITHOUT editing it (import is read-only/safe even
+# while a marble crawl is running in another process).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from marble_index import _feat_phash, _download_pil, _nap, IMG_DELAY  # noqa: E402
+
+INDEX_DIR = Path(__file__).resolve().parent.parent / "kb" / "index" / "ebay-sold"
+EMBED_BATCH = 16
+
+
+def _hires(url: str) -> str:
+    """Bump an eBay thumbnail (…/s-l140.webp) to a larger but still-light size."""
+    return re.sub(r"s-l\d+\.", "s-l500.", url) if url else url
+
+
+# --- storage (same layout as marble_index, own dir) --------------------------
+def _state_path():
+    return INDEX_DIR / "state.json"
+
+
+def load_state():
+    p = _state_path()
+    if p.exists():
+        return json.loads(p.read_text())
+    return {"indexed_item_ids": [], "indexed_img_urls": [],
+            "count": 0, "last_sync_utc": None, "backend": "phash",
+            "queries": []}
+
+
+def save_state(state):
+    INDEX_DIR.mkdir(parents=True, exist_ok=True)
+    _state_path().write_text(json.dumps(state, indent=2))
+
+
+def append_index(rows, embeddings):
+    import numpy as np
+    INDEX_DIR.mkdir(parents=True, exist_ok=True)
+    emb_p, meta_p = INDEX_DIR / "emb.npy", INDEX_DIR / "meta.jsonl"
+    if emb_p.exists():
+        embeddings = np.vstack([np.load(emb_p), embeddings]).astype("float32")
+    np.save(emb_p, embeddings.astype("float32"))
+    with meta_p.open("a", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+
+def load_index():
+    import numpy as np
+    emb_p, meta_p = INDEX_DIR / "emb.npy", INDEX_DIR / "meta.jsonl"
+    if not emb_p.exists() or not meta_p.exists():
+        raise SystemExit("Index is empty — run `add` first.")
+    emb = np.load(emb_p)
+    meta = [json.loads(l) for l in meta_p.read_text(encoding="utf-8").splitlines() if l.strip()]
+    return emb, meta
+
+
+def _load_items(paths):
+    """Read Apify dataset items from one or more JSON files (list or {items})."""
+    items = []
+    for f in paths:
+        data = json.loads(Path(f).read_text(encoding="utf-8"))
+        items.extend(data if isinstance(data, list) else data.get("items", []))
+    return items
+
+
+# --- commands ----------------------------------------------------------------
+def cmd_add(args):
+    import numpy as np
+    state = load_state()
+    seen_items = set(state["indexed_item_ids"])
+    seen_imgs = set(state["indexed_img_urls"])
+    items = _load_items(args.from_)
+    print(f"loaded {len(items)} listing rows from {len(args.from_)} file(s)", flush=True)
+
+    pil_batch, batch_meta, added, skipped = [], [], 0, 0
+
+    def flush():
+        nonlocal added
+        if not pil_batch:
+            return
+        emb = np.vstack([_feat_phash(p) for p in pil_batch]).astype("float32")
+        base = state["count"]
+        rows = [dict(m, i=base + k) for k, m in enumerate(batch_meta)]
+        append_index(rows, emb)
+        state["count"] += len(rows)
+        added += len(rows)
+        pil_batch.clear()
+        batch_meta.clear()
+
+    for it in items:
+        iid = str(it.get("itemId") or it.get("url") or "")
+        if not iid or iid in seen_items:
+            continue
+        seen_items.add(iid)
+        url = _hires(it.get("thumbnail") or it.get("image") or "")
+        if not url or url in seen_imgs:
+            skipped += 1
+            continue
+        try:
+            pil_batch.append(_download_pil(url))
+        except Exception as e:
+            print(f"  ! img skip {iid}: {e}", flush=True)
+            skipped += 1
+            continue
+        seen_imgs.add(url)
+        batch_meta.append({
+            "img": url, "itemId": iid, "url": it.get("url"),
+            "title": it.get("title"),
+            "price": it.get("soldPrice"),
+            "priceStr": it.get("soldPriceString"),
+            "soldDate": it.get("soldDate"),
+            "condition": it.get("condition"),
+            "query": it.get("query") or args.label,
+        })
+        _nap(IMG_DELAY)
+        if len(pil_batch) >= EMBED_BATCH:
+            flush()
+    flush()
+
+    state["indexed_item_ids"] = sorted(seen_items)
+    state["indexed_img_urls"] = sorted(seen_imgs)
+    if args.label and args.label not in state["queries"]:
+        state["queries"].append(args.label)
+    state["last_sync_utc"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    save_state(state)
+    print(f"\n+{added} listings ({skipped} skipped). Index holds {state['count']} "
+          f"sold listings.", flush=True)
+
+
+def cmd_query(args):
+    import numpy as np
+    emb, meta = load_index()
+    pil = []
+    for ref in args.images:
+        p = Path(ref)
+        try:
+            if p.exists():
+                from PIL import Image
+                pil.append(Image.open(p).convert("RGB"))
+            else:
+                pil.append(_download_pil(ref))
+        except Exception as e:
+            print(f"! could not load reference {ref}: {e}", file=sys.stderr)
+    if not pil:
+        raise SystemExit("No usable reference image.")
+    q = np.vstack([_feat_phash(p) for p in pil]).astype("float32")
+    score = (emb @ q.T).max(axis=1)
+    # best image per listing
+    best = {}
+    for i, m in enumerate(meta):
+        iid = m["itemId"]
+        if iid not in best or score[i] > best[iid][0]:
+            best[iid] = (float(score[i]), m)
+    ranked = sorted(best.values(), key=lambda x: x[0], reverse=True)[: args.top]
+    prices = [m["price"] for _, m in ranked if isinstance(m.get("price"), (int, float))]
+    print(f"\nTop {len(ranked)} visually-similar SOLD listings "
+          f"(of {len(best)} listings / {len(meta)} images):\n")
+    for rank, (sc, m) in enumerate(ranked, 1):
+        pr = m.get("priceStr") or (f"${m['price']}" if m.get("price") is not None else "?")
+        print(f"{rank:>2}. {sc:.3f}  {pr:>9}  {(m.get('title') or '')[:60]}")
+        print(f"     {m.get('url')}  [{m.get('condition')}, sold {m.get('soldDate')}]")
+    if prices:
+        prices.sort()
+        med = prices[len(prices) // 2]
+        print(f"\nprice signal among top matches: n={len(prices)}  "
+              f"min ${min(prices):.2f}  median ${med:.2f}  max ${max(prices):.2f}")
+        print("(candidates to VET — confirm condition/size/authenticity per price.md)")
+    if args.json:
+        out = [{"rank": r, "score": round(sc, 4), **m} for r, (sc, m) in enumerate(ranked, 1)]
+        Path(args.json).write_text(json.dumps(out, indent=2))
+        print(f"\nWrote {args.json}")
+
+
+def cmd_status(args):
+    state = load_state()
+    print(json.dumps({
+        "listings": state["count"],
+        "distinct_item_ids": len(state["indexed_item_ids"]),
+        "queries_ingested": state["queries"],
+        "backend": state["backend"],
+        "last_sync_utc": state["last_sync_utc"],
+        "index_dir": str(INDEX_DIR),
+    }, indent=2))
+
+
+def main():
+    # eBay titles carry emoji/unicode; the Windows console is cp1252 by default.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("add", help="ingest Apify ebay-sold dataset JSON file(s)")
+    p.add_argument("--from", dest="from_", nargs="+", required=True,
+                   help="JSON file(s) of Apify ebay-sold items")
+    p.add_argument("--label", default=None,
+                   help="optional pattern label to tag these listings with")
+    p.set_defaults(func=cmd_add)
+
+    p = sub.add_parser("query", help="top-K similar SOLD listings for reference image(s)")
+    p.add_argument("images", nargs="+", help="local path(s) or URL(s)")
+    p.add_argument("--top", type=int, default=5)
+    p.add_argument("--json", help="also write ranked results to this JSON file")
+    p.set_defaults(func=cmd_query)
+
+    p = sub.add_parser("status", help="index size + ingested queries")
+    p.set_defaults(func=cmd_status)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ebay_visual.py
+++ b/lib/ebay_visual.py
@@ -95,11 +95,20 @@ def load_index():
 
 
 def _load_items(paths):
-    """Read Apify dataset items from one or more JSON files (list or {items})."""
+    """Read Apify sold-listing items from one or more JSON files.
+
+    Accepts a bare list, an Apify MCP dump ({items}), or — preferred — the
+    standard saved-run JSON from lib/apify_ebay.py ({raw_items}). raw_items are
+    full raw records (sellerName, thumbnail, soldPrice…), so a comp pull feeds
+    the visual library directly with no field loss.
+    """
     items = []
     for f in paths:
         data = json.loads(Path(f).read_text(encoding="utf-8"))
-        items.extend(data if isinstance(data, list) else data.get("items", []))
+        if isinstance(data, list):
+            items.extend(data)
+        else:
+            items.extend(data.get("raw_items") or data.get("items") or [])
     return items
 
 

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -568,14 +568,14 @@ def _build_inventory_item(draft: Draft, image_urls: list[str]) -> dict:
 def _build_offer(draft: Draft, sku: str, category_id: str,
                  location_key: str, policies: dict) -> dict:
     price = _to_decimal_str(draft.get("price"))
+    fmt = str(draft.get("format") or "FIXED_PRICE").upper()
     offer: dict = {
         "sku": sku,
         "marketplaceId": DEFAULT_MARKETPLACE,
-        "format": "FIXED_PRICE",
+        "format": fmt,
         "availableQuantity": int(draft.get("quantity") or 1),
         "categoryId": str(category_id),
         "listingDescription": _body_to_html(draft.body),
-        "pricingSummary": {"price": {"value": price, "currency": CURRENCY}},
         "merchantLocationKey": location_key,
         "listingPolicies": {
             "fulfillmentPolicyId": policies["fulfillment"],
@@ -583,15 +583,30 @@ def _build_offer(draft: Draft, sku: str, category_id: str,
             "returnPolicyId": policies["return"],
         },
     }
-    if draft.get("best_offer.enabled"):
-        terms: dict = {"bestOfferEnabled": True}
-        decline = _to_decimal_str(draft.get("best_offer.auto_decline_amount"))
-        accept = _to_decimal_str(draft.get("best_offer.auto_accept_amount"))
-        if decline:
-            terms["autoDeclinePrice"] = {"value": decline, "currency": CURRENCY}
-        if accept:
-            terms["autoAcceptPrice"] = {"value": accept, "currency": CURRENCY}
-        offer["listingPolicies"]["bestOfferTerms"] = terms
+    if fmt == "AUCTION":
+        # Auctions: the start bid goes in auctionStartPrice (NOT price); a
+        # listingDuration is REQUIRED (DAYS_1..DAYS_10); availableQuantity is
+        # rejected (always 1 implicitly); Best Offer is not permitted. eBay also
+        # forbids immediate-payment on auctions, so use the auction-specific
+        # payment policy (no immediate pay) when configured.
+        offer.pop("availableQuantity", None)
+        offer["pricingSummary"] = {
+            "auctionStartPrice": {"value": price, "currency": CURRENCY}
+        }
+        offer["listingDuration"] = str(draft.get("listing_duration") or "DAYS_7").upper()
+        if policies.get("payment_auction"):
+            offer["listingPolicies"]["paymentPolicyId"] = policies["payment_auction"]
+    else:
+        offer["pricingSummary"] = {"price": {"value": price, "currency": CURRENCY}}
+        if draft.get("best_offer.enabled"):
+            terms: dict = {"bestOfferEnabled": True}
+            decline = _to_decimal_str(draft.get("best_offer.auto_decline_amount"))
+            accept = _to_decimal_str(draft.get("best_offer.auto_accept_amount"))
+            if decline:
+                terms["autoDeclinePrice"] = {"value": decline, "currency": CURRENCY}
+            if accept:
+                terms["autoAcceptPrice"] = {"value": accept, "currency": CURRENCY}
+            offer["listingPolicies"]["bestOfferTerms"] = terms
     return offer
 
 
@@ -617,9 +632,13 @@ def _resolve_policies_and_location(creds: EbayCredentials) -> tuple[dict, str]:
     # Optional: a Local-pickup-only policy used for ship-risky items (fragile /
     # oversized). Not required — only items the user marks LOCAL_PICKUP need it.
     policies["fulfillment_local_pickup"] = _ebay_extra("fulfillment_policy_id_local_pickup")
+    # Optional: a payment policy WITHOUT immediate-payment, required for AUCTION
+    # offers (eBay forbids immediate-pay on auctions — error 25003). Only auction
+    # listings need it; falls back to the default payment policy otherwise.
+    policies["payment_auction"] = _ebay_extra("payment_policy_id_auction")
     location = _ebay_extra("merchant_location_key")
     for k, v in policies.items():
-        if k in ("fulfillment_media", "fulfillment_local_pickup"):
+        if k in ("fulfillment_media", "fulfillment_local_pickup", "payment_auction"):
             continue  # optional
         if not v:
             missing.append(f"ebay.{k}_policy_id")
@@ -1225,7 +1244,8 @@ def publish_offer(draft_path: Path, creds: Optional[EbayCredentials] = None,
 
     off = api_send("GET", f"/sell/inventory/v1/offer/{offer_id}", creds=creds)
     status = str(off.get("status") or "UNKNOWN")
-    price = str(((off.get("pricingSummary") or {}).get("price") or {}).get("value") or "?")
+    _ps = off.get("pricingSummary") or {}
+    price = str((_ps.get("price") or _ps.get("auctionStartPrice") or {}).get("value") or "?")
     sku = str(off.get("sku") or draft.get("meta.ebay_inventory_sku") or "")
     title = str(draft.get("title") or "")
     if not title and sku:

--- a/lib/marble_index.py
+++ b/lib/marble_index.py
@@ -30,12 +30,14 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import os
 import random
 import re
 import sys
 import time
 import urllib.request
 import urllib.error
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -46,8 +48,15 @@ INDEX_DIR = Path(__file__).resolve().parent.parent / "kb" / "index" / "marblecon
 # Randomized polite pauses — (min, max) seconds, drawn uniformly per request so
 # the traffic pattern isn't a fixed metronome. Tune to go gentler on the server.
 PAGE_DELAY = (1.0, 2.5)   # between forum page / topic fetches
-IMG_DELAY = (0.25, 0.8)   # between image downloads
+IMG_DELAY = (0.25, 0.8)   # between image downloads (sequential mode only)
 EMBED_BATCH = 16
+
+# Speed knob: MARBLE_IMG_WORKERS>1 downloads a topic's images CONCURRENTLY (they
+# hit S3/image hosts, which are built to be fast) and switches to a short
+# between-topic delay. Default 1 = the gentle sequential behaviour (unchanged).
+IMG_WORKERS = max(1, int(os.environ.get("MARBLE_IMG_WORKERS", "1")))
+FAST = IMG_WORKERS > 1
+FAST_PAGE_DELAY = (0.1, 0.4)   # between forum topic-page fetches in fast mode
 MODEL_NAME = "clip-ViT-B-32"
 # image hosts that carry user-posted marble photos (not avatars / emoji / theme)
 IMG_HOST_OK = ("s3mcinvision", "/uploads/monthly_")
@@ -273,6 +282,30 @@ def _download_pil(url):
     return Image.open(io.BytesIO(raw)).convert("RGB")
 
 
+def _download_pils(urls):
+    """Download urls -> [(url, PIL)] for successes. Parallel when IMG_WORKERS>1
+    (image hosts tolerate it); else sequential with the polite IMG_DELAY nap."""
+    out = []
+    if not urls:
+        return out
+    if IMG_WORKERS <= 1:
+        for u in urls:
+            try:
+                out.append((u, _download_pil(u)))
+            except Exception:
+                pass
+            _nap(IMG_DELAY)
+        return out
+    with ThreadPoolExecutor(max_workers=IMG_WORKERS) as ex:
+        futs = {ex.submit(_download_pil, u): u for u in urls}
+        for f in as_completed(futs):
+            try:
+                out.append((futs[f], f.result()))
+            except Exception:
+                pass
+    return out
+
+
 # --- crawl core --------------------------------------------------------------
 def crawl_topics(topics, state, *, verbose=True):
     """Crawl a list of (tid, turl, title), embed OP images, append to index."""
@@ -305,28 +338,22 @@ def crawl_topics(topics, state, *, verbose=True):
         except Exception as e:
             if verbose:
                 print(f"  ! topic {tid} fetch/parse failed: {e}", flush=True)
-            _nap(PAGE_DELAY)
+            _nap(FAST_PAGE_DELAY if FAST else PAGE_DELAY)
             continue
         kept = 0
-        for u in imgs:
-            if u in indexed_imgs:
-                continue
-            try:
-                pil_batch.append(_download_pil(u))
-                batch_meta.append({"img": u, "tid": tid, "turl": turl, "title": title})
-                indexed_imgs.add(u)
-                kept += 1
-                _nap(IMG_DELAY)
-            except Exception as e:
-                if verbose:
-                    print(f"  ! image skip ({tid}): {e}", flush=True)
+        new_urls = [u for u in imgs if u not in indexed_imgs]
+        for u, pil in _download_pils(new_urls):
+            pil_batch.append(pil)
+            batch_meta.append({"img": u, "tid": tid, "turl": turl, "title": title})
+            indexed_imgs.add(u)
+            kept += 1
             if len(pil_batch) >= EMBED_BATCH:
                 flush()
         indexed_tids.add(tid)
         state["max_topic_id"] = max(state["max_topic_id"], tid)
         if verbose:
             print(f"  + topic {tid}: {kept} img  \"{title[:48]}\"", flush=True)
-        _nap(PAGE_DELAY)
+        _nap(FAST_PAGE_DELAY if FAST else PAGE_DELAY)
 
     flush()
     state["indexed_topic_ids"] = sorted(indexed_tids)
@@ -354,7 +381,7 @@ def cmd_index(args):
         print(f"[page {page}] {len(topics)} topics", flush=True)
         total += crawl_topics(topics, state)
         state["pages_indexed"] = max(state["pages_indexed"], page)
-        _nap(PAGE_DELAY)
+        _nap(FAST_PAGE_DELAY if FAST else PAGE_DELAY)
     print(f"\nDone. +{total} images this run. Index now holds {state['count']} images "
           f"across {len(state['indexed_topic_ids'])} threads.", flush=True)
 
@@ -379,7 +406,7 @@ def cmd_refresh(args):
             break
         total += crawl_topics(fresh, state)
         known |= {t[0] for t in fresh}
-        _nap(PAGE_DELAY)
+        _nap(FAST_PAGE_DELAY if FAST else PAGE_DELAY)
     print(f"\nRefresh done. +{total} images ({before} -> {state['count']}).", flush=True)
 
 

--- a/lib/marble_index.py
+++ b/lib/marble_index.py
@@ -467,6 +467,13 @@ def cmd_status(args):
 
 
 def main():
+    # Forum titles can carry emoji; the Windows console / redirected log defaults
+    # to cp1252 and a bare print() of such a title raises UnicodeEncodeError
+    # (which would kill a long crawl). Force utf-8 so progress prints never crash.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = ap.add_subparsers(dest="cmd", required=True)

--- a/lib/marble_index.py
+++ b/lib/marble_index.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import random
 import re
 import sys
 import time
@@ -42,8 +43,10 @@ from pathlib import Path
 FORUM_BASE = "https://marbleconnection.com/forum/22-marble-ids/"
 UA = "Mozilla/5.0 (compatible; ebaybiz-KB/1.0; personal collectables research)"
 INDEX_DIR = Path(__file__).resolve().parent.parent / "kb" / "index" / "marbleconnection"
-PAGE_DELAY = 0.7      # seconds between forum page / topic fetches (be polite)
-IMG_DELAY = 0.2       # seconds between image downloads
+# Randomized polite pauses — (min, max) seconds, drawn uniformly per request so
+# the traffic pattern isn't a fixed metronome. Tune to go gentler on the server.
+PAGE_DELAY = (1.0, 2.5)   # between forum page / topic fetches
+IMG_DELAY = (0.25, 0.8)   # between image downloads
 EMBED_BATCH = 16
 MODEL_NAME = "clip-ViT-B-32"
 # image hosts that carry user-posted marble photos (not avatars / emoji / theme)
@@ -52,6 +55,12 @@ IMG_SKIP = ("emoji", "avatar", "profile", "default_photo", "theme", ".svg",
             "rising", "set_resources", "/reactions/", "react_")
 
 TOPIC_RE = re.compile(r"/topic/(\d+)-")
+
+
+# --- pacing ------------------------------------------------------------------
+def _nap(rng):
+    """Sleep a random duration in the (min, max) seconds tuple — polite jitter."""
+    time.sleep(random.uniform(rng[0], rng[1]))
 
 
 # --- tiny http ---------------------------------------------------------------
@@ -296,7 +305,7 @@ def crawl_topics(topics, state, *, verbose=True):
         except Exception as e:
             if verbose:
                 print(f"  ! topic {tid} fetch/parse failed: {e}", flush=True)
-            time.sleep(PAGE_DELAY)
+            _nap(PAGE_DELAY)
             continue
         kept = 0
         for u in imgs:
@@ -307,7 +316,7 @@ def crawl_topics(topics, state, *, verbose=True):
                 batch_meta.append({"img": u, "tid": tid, "turl": turl, "title": title})
                 indexed_imgs.add(u)
                 kept += 1
-                time.sleep(IMG_DELAY)
+                _nap(IMG_DELAY)
             except Exception as e:
                 if verbose:
                     print(f"  ! image skip ({tid}): {e}", flush=True)
@@ -317,7 +326,7 @@ def crawl_topics(topics, state, *, verbose=True):
         state["max_topic_id"] = max(state["max_topic_id"], tid)
         if verbose:
             print(f"  + topic {tid}: {kept} img  \"{title[:48]}\"", flush=True)
-        time.sleep(PAGE_DELAY)
+        _nap(PAGE_DELAY)
 
     flush()
     state["indexed_topic_ids"] = sorted(indexed_tids)
@@ -345,7 +354,7 @@ def cmd_index(args):
         print(f"[page {page}] {len(topics)} topics", flush=True)
         total += crawl_topics(topics, state)
         state["pages_indexed"] = max(state["pages_indexed"], page)
-        time.sleep(PAGE_DELAY)
+        _nap(PAGE_DELAY)
     print(f"\nDone. +{total} images this run. Index now holds {state['count']} images "
           f"across {len(state['indexed_topic_ids'])} threads.", flush=True)
 
@@ -370,7 +379,7 @@ def cmd_refresh(args):
             break
         total += crawl_topics(fresh, state)
         known |= {t[0] for t in fresh}
-        time.sleep(PAGE_DELAY)
+        _nap(PAGE_DELAY)
     print(f"\nRefresh done. +{total} images ({before} -> {state['count']}).", flush=True)
 
 

--- a/lib/marble_index.py
+++ b/lib/marble_index.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Visual-similarity index over the Marble Connection "Marble I.D.'s" forum.
+
+Build a local CLIP-embedding index of the marble photos people post for ID, so
+you can hand it a reference marble and get back the most visually-similar
+threads ("the top few listings"). Pairs with specializations/marbles.md.
+
+Pipeline:
+  index    crawl forum listing pages (newest-first by thread creation), pull the
+           original-poster's marble photos from each thread, embed them with
+           CLIP, and append to the local index.
+  refresh  re-crawl only NEW threads created since the last run and append them
+           (the periodic sync tool). Dedups by thread id + image url.
+  query    embed one or more reference images and return the top-K most similar
+           threads, grouped by thread, each with its link + best-match score.
+  status   print index size + last sync.
+
+Index lives under kb/index/marbleconnection/ (gitignored — regenerable):
+  meta.jsonl   one row per embedded image  {i, img, tid, turl, title}
+  emb.npy      float32 [N, D] L2-normalised embeddings, row-aligned to meta
+  state.json   crawl cursor + dedup sets + last_sync_utc
+
+Model: CLIP ViT-B/32 via sentence-transformers (downloaded once, ~350 MB).
+Honesty note: CLIP retrieval narrows the corpus to candidates by visual
+similarity; it does NOT identify maker/era. Treat the top-K as "look here",
+then judge each per the marbles specialization (method vs maker vs era).
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import sys
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+
+# --- config -----------------------------------------------------------------
+FORUM_BASE = "https://marbleconnection.com/forum/22-marble-ids/"
+UA = "Mozilla/5.0 (compatible; ebaybiz-KB/1.0; personal collectables research)"
+INDEX_DIR = Path(__file__).resolve().parent.parent / "kb" / "index" / "marbleconnection"
+PAGE_DELAY = 0.7      # seconds between forum page / topic fetches (be polite)
+IMG_DELAY = 0.2       # seconds between image downloads
+EMBED_BATCH = 16
+MODEL_NAME = "clip-ViT-B-32"
+# image hosts that carry user-posted marble photos (not avatars / emoji / theme)
+IMG_HOST_OK = ("s3mcinvision", "/uploads/monthly_")
+IMG_SKIP = ("emoji", "avatar", "profile", "default_photo", "theme", ".svg",
+            "rising", "set_resources", "/reactions/", "react_")
+
+TOPIC_RE = re.compile(r"/topic/(\d+)-")
+
+
+# --- tiny http ---------------------------------------------------------------
+def _get(url: str, *, binary: bool = False, tries: int = 3, timeout: int = 30):
+    last = None
+    for attempt in range(tries):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": UA})
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                data = r.read()
+            return data if binary else data.decode("utf-8", "replace")
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+            last = e
+            time.sleep(1.0 * (attempt + 1))
+    raise RuntimeError(f"GET failed after {tries} tries: {url} ({last})")
+
+
+# --- parsing (lxml + XPath) --------------------------------------------------
+def _listing_url(page: int, sort_by_creation: bool) -> str:
+    url = FORUM_BASE if page <= 1 else f"{FORUM_BASE}page/{page}/"
+    if sort_by_creation:
+        sep = "&" if "?" in url else "?"
+        url += f"{sep}sortby=start_date&sortdirection=desc"
+    return url
+
+
+def parse_listing(htmltext: str, base: str):
+    """Return [(topic_id:int, topic_url:str, title:str)] for one listing page."""
+    from lxml import html as lhtml
+    doc = lhtml.fromstring(htmltext)
+    doc.make_links_absolute(base)
+    seen, out = set(), []
+    for a in doc.xpath('//a[contains(@href,"/topic/")]'):
+        href = a.get("href") or ""
+        m = TOPIC_RE.search(href)
+        if not m:
+            continue
+        tid = int(m.group(1))
+        if tid in seen:
+            continue
+        title = (a.text_content() or "").strip()
+        # skip the bare date/"last reply" anchors; keep the real title anchor
+        if len(title) < 5 or title[:1].isdigit() and "/" in title:
+            continue
+        seen.add(tid)
+        out.append((tid, href.split("?")[0], title))
+    return out
+
+
+def parse_topic_images(htmltext: str, base: str):
+    """Return the original poster's marble image URLs (full-size preferred)."""
+    from lxml import html as lhtml
+    doc = lhtml.fromstring(htmltext)
+    doc.make_links_absolute(base)
+
+    # the first post's content block (Invision Power Board)
+    blocks = doc.xpath('(//div[contains(@class,"cPost_contentWrap")])[1]')
+    scope = blocks[0] if blocks else doc
+
+    urls = []
+    # prefer <a> links to the full-size image, then <img> src as fallback
+    for node in scope.xpath('.//a[@href]'):
+        h = node.get("href") or ""
+        if _img_ok(h):
+            urls.append(h)
+    for node in scope.xpath('.//img[@src]'):
+        s = node.get("src") or node.get("data-src") or ""
+        if _img_ok(s):
+            urls.append(s)
+    # dedup, drop obvious thumbnail dupes when a full-size sibling exists
+    out, seen = [], set()
+    for u in urls:
+        key = u.split("?")[0]
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return out
+
+
+def _img_ok(u: str) -> bool:
+    if not u:
+        return False
+    lo = u.lower()
+    if not lo.startswith("http"):
+        return False
+    if any(b in lo for b in IMG_SKIP):
+        return False
+    if not any(h in lo for h in IMG_HOST_OK):
+        return False
+    return lo.endswith((".jpg", ".jpeg", ".png"))
+
+
+# --- storage -----------------------------------------------------------------
+def _state_path():
+    return INDEX_DIR / "state.json"
+
+
+def load_state():
+    p = _state_path()
+    if p.exists():
+        return json.loads(p.read_text())
+    return {"indexed_topic_ids": [], "indexed_img_urls": [],
+            "max_topic_id": 0, "count": 0, "last_sync_utc": None,
+            "pages_indexed": 0, "backend": None}
+
+
+def save_state(state):
+    INDEX_DIR.mkdir(parents=True, exist_ok=True)
+    _state_path().write_text(json.dumps(state, indent=2))
+
+
+def append_index(rows, embeddings):
+    """rows: list of dict meta; embeddings: np.ndarray [n, D] (normalised)."""
+    import numpy as np
+    INDEX_DIR.mkdir(parents=True, exist_ok=True)
+    emb_p = INDEX_DIR / "emb.npy"
+    meta_p = INDEX_DIR / "meta.jsonl"
+    if emb_p.exists():
+        old = np.load(emb_p)
+        embeddings = np.vstack([old, embeddings]).astype("float32")
+    np.save(emb_p, embeddings.astype("float32"))
+    with meta_p.open("a", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+
+def load_index():
+    import numpy as np
+    emb_p = INDEX_DIR / "emb.npy"
+    meta_p = INDEX_DIR / "meta.jsonl"
+    if not emb_p.exists() or not meta_p.exists():
+        raise SystemExit("Index is empty — run `index` first.")
+    emb = np.load(emb_p)
+    meta = [json.loads(l) for l in meta_p.read_text(encoding="utf-8").splitlines() if l.strip()]
+    return emb, meta
+
+
+# --- embedding backend -------------------------------------------------------
+# "phash" = no-torch perceptual+colour featurizer (works today).
+# "clip"  = CLIP ViT-B/32 via sentence-transformers (needs torch + the MS VC++
+#           Redistributable). Switch with the MARBLE_EMBED env var or the flag.
+# An index is tied to the backend that built it (query must match) — recorded in
+# state.json. To move phash -> clip later: rebuild the index with clip.
+import os
+EMBED_BACKEND = os.environ.get("MARBLE_EMBED", "phash").lower()
+_MODEL = None
+
+
+def get_model():
+    global _MODEL
+    if _MODEL is None:
+        from sentence_transformers import SentenceTransformer
+        print(f"[model] loading {MODEL_NAME} (first run downloads it)…", flush=True)
+        _MODEL = SentenceTransformer(MODEL_NAME)
+    return _MODEL
+
+
+def _embed_clip(pil_images):
+    model = get_model()
+    emb = model.encode(pil_images, batch_size=EMBED_BATCH, convert_to_numpy=True,
+                       normalize_embeddings=True, show_progress_bar=False)
+    return emb.astype("float32")
+
+
+def _feat_phash(pil):
+    """One image -> normalised feature vector (colour-weighted + structure).
+
+    No ML model. Captures what drives marble look-alikes: a saturation-weighted
+    hue/sat colour histogram (so the marble's glass colour dominates the neutral
+    towel/hand background) + a dHash structural signature + a brightness profile.
+    Weaker than CLIP, but solid for near-duplicates and same colour/pattern.
+    """
+    import numpy as np
+    HB, SB = 12, 4                                   # hue, saturation bins
+    hsv = np.asarray(pil.convert("HSV").resize((64, 64))).astype("float32")
+    h, s, v = hsv[..., 0] / 255.0, hsv[..., 1] / 255.0, hsv[..., 2] / 255.0
+    hi = np.clip((h * HB).astype(int), 0, HB - 1)
+    si = np.clip((s * SB).astype(int), 0, SB - 1)
+    hist = np.zeros((HB, SB), dtype="float32")
+    np.add.at(hist, (hi, si), s)                     # weight by saturation
+    hist = hist.flatten()
+    if hist.sum() > 0:
+        hist /= hist.sum()
+    g = np.asarray(pil.convert("L").resize((9, 8))).astype("float32")
+    dh = (g[:, 1:] > g[:, :-1]).astype("float32").flatten()   # 64-bit dHash
+    vh, _ = np.histogram(v, bins=8, range=(0, 1))
+    vh = vh.astype("float32")
+    if vh.sum() > 0:
+        vh /= vh.sum()
+    feat = np.concatenate([hist * 3.0, dh * 1.0, vh * 1.0])   # colour weighted up
+    n = float(np.linalg.norm(feat))
+    return (feat / n).astype("float32") if n > 0 else feat.astype("float32")
+
+
+def _embed_phash(pil_images):
+    import numpy as np
+    return np.vstack([_feat_phash(p) for p in pil_images]).astype("float32")
+
+
+def embed_images(pil_images):
+    if EMBED_BACKEND == "clip":
+        return _embed_clip(pil_images)
+    return _embed_phash(pil_images)
+
+
+def _download_pil(url):
+    from PIL import Image
+    raw = _get(url, binary=True)
+    return Image.open(io.BytesIO(raw)).convert("RGB")
+
+
+# --- crawl core --------------------------------------------------------------
+def crawl_topics(topics, state, *, verbose=True):
+    """Crawl a list of (tid, turl, title), embed OP images, append to index."""
+    indexed_tids = set(state["indexed_topic_ids"])
+    indexed_imgs = set(state["indexed_img_urls"])
+    new_rows, pil_batch, batch_meta = [], [], []
+    added_imgs = 0
+
+    def flush():
+        nonlocal pil_batch, batch_meta, added_imgs
+        if not pil_batch:
+            return
+        emb = embed_images(pil_batch)
+        base_i = state["count"]
+        rows = []
+        for k, m in enumerate(batch_meta):
+            m = dict(m, i=base_i + k)
+            rows.append(m)
+        append_index(rows, emb)
+        state["count"] += len(rows)
+        added_imgs += len(rows)
+        pil_batch, batch_meta = [], []
+
+    for tid, turl, title in topics:
+        if tid in indexed_tids:
+            continue
+        try:
+            page = _get(turl)
+            imgs = parse_topic_images(page, turl)
+        except Exception as e:
+            if verbose:
+                print(f"  ! topic {tid} fetch/parse failed: {e}", flush=True)
+            time.sleep(PAGE_DELAY)
+            continue
+        kept = 0
+        for u in imgs:
+            if u in indexed_imgs:
+                continue
+            try:
+                pil_batch.append(_download_pil(u))
+                batch_meta.append({"img": u, "tid": tid, "turl": turl, "title": title})
+                indexed_imgs.add(u)
+                kept += 1
+                time.sleep(IMG_DELAY)
+            except Exception as e:
+                if verbose:
+                    print(f"  ! image skip ({tid}): {e}", flush=True)
+            if len(pil_batch) >= EMBED_BATCH:
+                flush()
+        indexed_tids.add(tid)
+        state["max_topic_id"] = max(state["max_topic_id"], tid)
+        if verbose:
+            print(f"  + topic {tid}: {kept} img  \"{title[:48]}\"", flush=True)
+        time.sleep(PAGE_DELAY)
+
+    flush()
+    state["indexed_topic_ids"] = sorted(indexed_tids)
+    state["indexed_img_urls"] = sorted(indexed_imgs)
+    state["backend"] = EMBED_BACKEND
+    state["last_sync_utc"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    save_state(state)
+    return added_imgs
+
+
+# --- commands ----------------------------------------------------------------
+def cmd_index(args):
+    state = load_state()
+    total = 0
+    for page in range(args.start_page, args.start_page + args.max_pages):
+        url = _listing_url(page, sort_by_creation=True)
+        try:
+            topics = parse_listing(_get(url), url)
+        except Exception as e:
+            print(f"[page {page}] listing failed: {e}", flush=True)
+            break
+        if not topics:
+            print(f"[page {page}] no topics — stopping.", flush=True)
+            break
+        print(f"[page {page}] {len(topics)} topics", flush=True)
+        total += crawl_topics(topics, state)
+        state["pages_indexed"] = max(state["pages_indexed"], page)
+        time.sleep(PAGE_DELAY)
+    print(f"\nDone. +{total} images this run. Index now holds {state['count']} images "
+          f"across {len(state['indexed_topic_ids'])} threads.", flush=True)
+
+
+def cmd_refresh(args):
+    """Sync only NEW threads created since last run (periodic update)."""
+    state = load_state()
+    before = state["count"]
+    known = set(state["indexed_topic_ids"])
+    total = 0
+    for page in range(1, args.max_new_pages + 1):
+        url = _listing_url(page, sort_by_creation=True)
+        try:
+            topics = parse_listing(_get(url), url)
+        except Exception as e:
+            print(f"[refresh p{page}] listing failed: {e}", flush=True)
+            break
+        fresh = [t for t in topics if t[0] not in known]
+        print(f"[refresh p{page}] {len(fresh)} new / {len(topics)} topics", flush=True)
+        if not fresh:
+            print("Reached already-indexed threads — sync complete.", flush=True)
+            break
+        total += crawl_topics(fresh, state)
+        known |= {t[0] for t in fresh}
+        time.sleep(PAGE_DELAY)
+    print(f"\nRefresh done. +{total} images ({before} -> {state['count']}).", flush=True)
+
+
+def cmd_query(args):
+    import numpy as np
+    state = load_state()
+    if state.get("backend") and state["backend"] != EMBED_BACKEND:
+        raise SystemExit(
+            f"Index was built with backend '{state['backend']}' but query is using "
+            f"'{EMBED_BACKEND}'. Set MARBLE_EMBED={state['backend']} or rebuild the index.")
+    emb, meta = load_index()
+    pil = []
+    for ref in args.images:
+        p = Path(ref)
+        try:
+            if p.exists():
+                from PIL import Image
+                pil.append(Image.open(p).convert("RGB"))
+            else:
+                pil.append(_download_pil(ref))
+        except Exception as e:
+            print(f"! could not load reference {ref}: {e}", file=sys.stderr)
+    if not pil:
+        raise SystemExit("No usable reference image.")
+    q = embed_images(pil)                      # [r, D] normalised
+    sims = emb @ q.T                            # [N, r] cosine
+    score = sims.max(axis=1)                    # best across reference angles
+    # best image per thread
+    best = {}
+    for i, m in enumerate(meta):
+        tid = m["tid"]
+        if tid not in best or score[i] > best[tid][0]:
+            best[tid] = (float(score[i]), m)
+    ranked = sorted(best.values(), key=lambda x: x[0], reverse=True)[: args.top]
+    print(f"\nTop {len(ranked)} visually-similar threads "
+          f"(of {len(best)} threads / {len(meta)} images):\n")
+    for rank, (sc, m) in enumerate(ranked, 1):
+        print(f"{rank:>2}. {sc:.3f}  {m['title']}")
+        print(f"     {m['turl']}")
+        print(f"     match img: {m['img']}")
+    if args.json:
+        out = [{"rank": r, "score": round(sc, 4), **m}
+               for r, (sc, m) in enumerate(ranked, 1)]
+        Path(args.json).write_text(json.dumps(out, indent=2))
+        print(f"\nWrote {args.json}")
+
+
+def cmd_status(args):
+    state = load_state()
+    print(json.dumps({
+        "images": state["count"],
+        "threads": len(state["indexed_topic_ids"]),
+        "max_topic_id": state["max_topic_id"],
+        "pages_indexed": state["pages_indexed"],
+        "last_sync_utc": state["last_sync_utc"],
+        "index_dir": str(INDEX_DIR),
+    }, indent=2))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("index", help="crawl + embed forum threads (newest-first)")
+    p.add_argument("--max-pages", type=int, default=10)
+    p.add_argument("--start-page", type=int, default=1,
+                   help="start deeper to index older history (dedups by thread id)")
+    p.set_defaults(func=cmd_index)
+
+    p = sub.add_parser("refresh", help="sync only new threads since last run")
+    p.add_argument("--max-new-pages", type=int, default=10)
+    p.set_defaults(func=cmd_refresh)
+
+    p = sub.add_parser("query", help="find top-K similar threads for reference image(s)")
+    p.add_argument("images", nargs="+", help="local path(s) or URL(s) of the marble")
+    p.add_argument("--top", type=int, default=5)
+    p.add_argument("--json", help="also write ranked results to this JSON file")
+    p.set_defaults(func=cmd_query)
+
+    p = sub.add_parser("status", help="index size + last sync")
+    p.set_defaults(func=cmd_status)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/seller_intel.py
+++ b/lib/seller_intel.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Seller intelligence — join eBay SOLD comps to the live Browse API.
+
+The bridge between our two data sources:
+  • Apify sold-comp data carries `sellerName` (+ feedback) for each realized sale
+    — so we can mine the comps to find WHO actually sells a collectable type.
+  • The eBay Browse API (lib/ebay_browse.py) then pulls that same seller's LIVE
+    ACTIVE listings + current feedback.
+
+Together: "these are the sellers moving Akro/Peltier marbles, here's their
+realized-sale footprint, and here's what they're offering right now."
+
+  rank    --from <sold.json...> [--by comps|realized] [--top 20] [--min-comps 2]
+          Rank sellers by how much they sell in the comp data: # of sold comps,
+          total + median realized $, point-in-time feedback, and the top
+          marble types they sell (attributed via the top-100 taxonomy).
+
+  profile <username> --from <sold.json...> [--max-active 50] [--q ...] [--category ...]
+          One seller: their SOLD-comp footprint (from the data) PLUS their LIVE
+          active listings and current feedback (Browse API). The full picture.
+
+Sold-comp JSON must include `sellerName` (re-fetch Apify datasets with that
+field). Honesty: sold prices are realized; active prices are ASKING. Type tags
+are keyword buckets, not authenticated IDs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import ebay_browse  # noqa: E402
+
+TAXONOMY = Path(__file__).resolve().parent.parent / "kb" / "taxonomies" / "marble-types-top100.md"
+
+
+# --- taxonomy matcher (shared with the visual library curation) --------------
+def load_taxonomy():
+    """Parse (keyword -> type) pairs from the top-100 taxonomy, longest first."""
+    pairs = []
+    if not TAXONOMY.exists():
+        return pairs
+    for ln in TAXONOMY.read_text(encoding="utf-8").splitlines():
+        if not ln.lstrip().startswith("|"):
+            continue
+        cols = [c.strip() for c in ln.strip().strip("|").split("|")]
+        if len(cols) < 4 or not cols[0].isdigit():
+            continue
+        typ, kws = cols[1], cols[3]
+        for kw in kws.split(";"):
+            kw = kw.strip().lower()
+            if kw:
+                pairs.append((kw, typ))
+    pairs.sort(key=lambda x: len(x[0]), reverse=True)
+    return pairs
+
+
+def type_for(title, pairs):
+    t = (title or "").lower()
+    for kw, lab in pairs:
+        if kw in t:
+            return lab
+    return None
+
+
+# --- data --------------------------------------------------------------------
+def load_comps(paths):
+    items = []
+    for f in paths:
+        data = json.loads(Path(f).read_text(encoding="utf-8"))
+        items.extend(data if isinstance(data, list) else data.get("items", []))
+    return items
+
+
+def _fnum(s):
+    """Parse a feedback-count string like '5.8K' or '106' to an int."""
+    if s is None:
+        return None
+    s = str(s).strip().replace(",", "")
+    try:
+        if s.lower().endswith("k"):
+            return int(float(s[:-1]) * 1000)
+        if s.lower().endswith("m"):
+            return int(float(s[:-1]) * 1_000_000)
+        return int(float(s))
+    except ValueError:
+        return None
+
+
+def aggregate(items, pairs):
+    sellers = defaultdict(lambda: {"prices": [], "types": Counter(), "fb_pct": None,
+                                   "fb_count": None, "titles": []})
+    for it in items:
+        name = it.get("sellerName")
+        if not name:
+            continue
+        s = sellers[name]
+        pr = it.get("soldPrice")
+        if isinstance(pr, (int, float)):
+            s["prices"].append(float(pr))
+        lab = type_for(it.get("title"), pairs)
+        if lab:
+            s["types"][lab] += 1
+        if it.get("sellerFeedbackPercent") and s["fb_pct"] is None:
+            s["fb_pct"] = it["sellerFeedbackPercent"]
+        fc = _fnum(it.get("sellerFeedbackCount"))
+        if fc is not None and (s["fb_count"] is None or fc > s["fb_count"]):
+            s["fb_count"] = fc
+        if len(s["titles"]) < 3:
+            s["titles"].append((it.get("title") or "")[:50])
+    return sellers
+
+
+def _stats(prices):
+    if not prices:
+        return (0, 0.0, 0.0, 0.0)
+    return (len(prices), sum(prices), statistics.median(prices), max(prices))
+
+
+# --- commands ----------------------------------------------------------------
+def cmd_rank(args):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+    pairs = load_taxonomy()
+    sellers = aggregate(load_comps(args.from_), pairs)
+    rows = []
+    for name, s in sellers.items():
+        n, total, med, mx = _stats(s["prices"])
+        n_comps = max(n, sum(s["types"].values()), len(s["titles"]))
+        if n_comps < args.min_comps:
+            continue
+        rows.append((name, n_comps, total, med, mx, s))
+    key = (lambda r: r[2]) if args.by == "realized" else (lambda r: r[1])
+    rows.sort(key=key, reverse=True)
+    print(f"\nTop {min(args.top, len(rows))} marble sellers by "
+          f"{'total realized $' if args.by=='realized' else 'sold-comp count'} "
+          f"(of {len(sellers)} sellers in {sum(len(s['prices']) for s in sellers.values())} comps):\n")
+    print(f"  {'seller':<22} {'comps':>5} {'realized$':>10} {'median$':>8} {'fb%':>6} {'fb#':>7}  top types")
+    for name, n_comps, total, med, mx, s in rows[: args.top]:
+        tt = ", ".join(f"{t}({c})" for t, c in s["types"].most_common(3))
+        fb = s["fb_pct"] or "?"
+        fc = s["fb_count"] if s["fb_count"] is not None else "?"
+        print(f"  {name:<22} {n_comps:>5} {total:>10.0f} {med:>8.0f} {fb:>6} {str(fc):>7}  {tt}")
+
+
+def cmd_profile(args):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+    pairs = load_taxonomy()
+    name = args.username
+    sellers = aggregate(load_comps(args.from_), pairs)
+    s = sellers.get(name)
+
+    print(f"\n=== Seller profile: {name} ===\n")
+    print("— SOLD-comp footprint (realized, from comp data) —")
+    if not s:
+        print(f"  (no sold comps for {name} in the provided data)")
+    else:
+        n, total, med, mx = _stats(s["prices"])
+        print(f"  sold comps: {max(n, sum(s['types'].values()))}   "
+              f"realized total: ${total:.0f}   median: ${med:.0f}   high: ${mx:.0f}")
+        print(f"  feedback (point-in-time): {s['fb_pct'] or '?'}  ({s['fb_count'] if s['fb_count'] is not None else '?'} ratings)")
+        print(f"  sells: {', '.join(f'{t} x{c}' for t,c in s['types'].most_common(6)) or '(untagged)'}")
+
+    print("\n— LIVE active listings (asking, Browse API) —")
+    try:
+        active = ebay_browse.seller_items(name, q=args.q, category_ids=args.category,
+                                          max_items=args.max_active)
+    except Exception as e:
+        print(f"  ! Browse API error: {e}")
+        active = []
+    if active:
+        fb = next((a.get("sellerFeedbackPct") for a in active if a.get("sellerFeedbackPct")), None)
+        fs = next((a.get("sellerFeedbackScore") for a in active if a.get("sellerFeedbackScore")), None)
+        print(f"  live feedback: {fb or '?'}%  ({fs if fs is not None else '?'} score)   "
+              f"active listings: {len(active)}")
+        prices = [a["askingPrice"] for a in active if isinstance(a.get("askingPrice"), float)]
+        if prices:
+            print(f"  asking range: ${min(prices):.0f}–${max(prices):.0f}  (median ${statistics.median(prices):.0f})")
+        print()
+        for a in active[: args.show]:
+            price = f"${a['askingPrice']:.0f}" if isinstance(a.get("askingPrice"), float) else "?"
+            print(f"    {price:>7}  {(a.get('title') or '')[:58]}")
+            print(f"            {a.get('url')}")
+    else:
+        print("  (no active listings found — they may have sold out, or list outside the default category)")
+    if args.json:
+        Path(args.json).write_text(json.dumps(
+            {"seller": name, "active": active}, indent=2), encoding="utf-8")
+        print(f"\nWrote {args.json}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("rank", help="rank sellers found in the sold comps")
+    p.add_argument("--from", dest="from_", nargs="+", required=True)
+    p.add_argument("--by", choices=["comps", "realized"], default="comps")
+    p.add_argument("--top", type=int, default=20)
+    p.add_argument("--min-comps", type=int, default=2)
+    p.set_defaults(func=cmd_rank)
+
+    p = sub.add_parser("profile", help="one seller: comps footprint + live active listings")
+    p.add_argument("username")
+    p.add_argument("--from", dest="from_", nargs="+", required=True)
+    p.add_argument("--max-active", type=int, default=50)
+    p.add_argument("--show", type=int, default=10)
+    p.add_argument("--q", default=None)
+    p.add_argument("--category", default=None)
+    p.add_argument("--json", default=None)
+    p.set_defaults(func=cmd_profile)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/seller_intel.py
+++ b/lib/seller_intel.py
@@ -198,6 +198,67 @@ def cmd_profile(args):
         print(f"\nWrote {args.json}")
 
 
+def cmd_landscape(args):
+    """Competitive landscape for a category: join realized comps (who sells, how
+    much) to LIVE active inventory (who has the most for sale, who asks highest).
+    """
+    import time
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+    pairs = load_taxonomy()
+    sellers = aggregate(load_comps(args.from_), pairs)
+
+    # the competitor set = sellers most active in the comp data
+    ranked = sorted(sellers.items(),
+                    key=lambda kv: max(len(kv[1]["prices"]), sum(kv[1]["types"].values())),
+                    reverse=True)[: args.check]
+    print(f"\nProbing live active inventory for the top {len(ranked)} comp sellers "
+          f"(category {args.category or ebay_browse.DEFAULT_SELLER_CATEGORY}, Browse API)…\n")
+
+    rows = []
+    for name, s in ranked:
+        n, total, med, mx = _stats(s["prices"])
+        try:
+            active_total, recs = ebay_browse.seller_active(
+                name, q=args.q, category_ids=args.category, sample=200)
+        except Exception as e:
+            active_total, recs = -1, []
+            print(f"  ! {name}: Browse error ({type(e).__name__})")
+        asks = [r["askingPrice"] for r in recs if isinstance(r.get("askingPrice"), float)]
+        rows.append({
+            "seller": name, "comps": max(n, sum(s["types"].values())),
+            "realized": total, "med_sold": med, "high_sold": mx,
+            "active": active_total,
+            "ask_med": statistics.median(asks) if asks else 0.0,
+            "ask_max": max(asks) if asks else 0.0,
+            "fb": s["fb_pct"] or "?",
+            "top": ", ".join(t for t, _ in s["types"].most_common(2)),
+        })
+        time.sleep(args.delay)
+
+    def show(title, key, fmt):
+        print(f"\n=== {title} ===")
+        print(f"  {'seller':<20} {'active':>6} {'sold':>5} {'realized$':>9} "
+              f"{'medSold':>7} {'askMed':>7} {'askMax':>7} {'fb':>6}  top types")
+        for r in sorted(rows, key=key, reverse=True)[: args.top]:
+            at = r["active"] if r["active"] >= 0 else "err"
+            print(f"  {r['seller']:<20} {str(at):>6} {r['comps']:>5} {r['realized']:>9.0f} "
+                  f"{r['med_sold']:>7.0f} {r['ask_med']:>7.0f} {r['ask_max']:>7.0f} "
+                  f"{str(r['fb']):>6}  {r['top']}")
+
+    show("MOST FOR SALE NOW (active inventory leaders)", lambda r: r["active"], None)
+    show("HIGHEST-PRICED (premium — by top active asking)", lambda r: r["ask_max"], None)
+    show("TOP REALIZED (volume x price, from sold comps)", lambda r: r["realized"], None)
+    print("\nReading it: high active + low median = volume players; few active + high "
+          "ask/realized = premium specialists. 'active' is exact (Browse total); "
+          "sold figures are from the comp sample, asking from a 200-item sample.")
+    if args.json:
+        Path(args.json).write_text(json.dumps(rows, indent=2), encoding="utf-8")
+        print(f"\nWrote {args.json}")
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -219,6 +280,16 @@ def main():
     p.add_argument("--category", default=None)
     p.add_argument("--json", default=None)
     p.set_defaults(func=cmd_profile)
+
+    p = sub.add_parser("landscape", help="category competitive map: active inventory + price leaders")
+    p.add_argument("--from", dest="from_", nargs="+", required=True)
+    p.add_argument("--category", default=None, help="category_ids (default 220 Toys)")
+    p.add_argument("--q", default=None, help="optional keyword to scope the category")
+    p.add_argument("--check", type=int, default=30, help="how many top comp-sellers to probe live")
+    p.add_argument("--top", type=int, default=12, help="rows per ranking")
+    p.add_argument("--delay", type=float, default=0.2, help="seconds between Browse calls")
+    p.add_argument("--json", default=None)
+    p.set_defaults(func=cmd_landscape)
 
     args = ap.parse_args()
     args.func(args)

--- a/lib/seller_intel.py
+++ b/lib/seller_intel.py
@@ -69,10 +69,15 @@ def type_for(title, pairs):
 
 # --- data --------------------------------------------------------------------
 def load_comps(paths):
+    """Read sold comps from a bare list, an Apify dump ({items}), or the standard
+    saved-run JSON from lib/apify_ebay.py ({raw_items} — carries sellerName)."""
     items = []
     for f in paths:
         data = json.loads(Path(f).read_text(encoding="utf-8"))
-        items.extend(data if isinstance(data, list) else data.get("items", []))
+        if isinstance(data, list):
+            items.extend(data)
+        else:
+            items.extend(data.get("raw_items") or data.get("items") or [])
     return items
 
 

--- a/prompts/condition-rubric.md
+++ b/prompts/condition-rubric.md
@@ -87,3 +87,26 @@ its decisions.
   one-line condition summary feed "Listing-safe claims"; un-assessables
   go in "NOT defensible". DRAFT writes every flagged defect into the
   listing's Condition section — defects always survive any trim.
+
+### `condition_description` field — write it telegraphic
+
+The eBay `condition_description` is a **factual defect disclosure, not
+sales copy**. Absolute minimum information that protects against an INAD
+return. Sentence fragments are correct; full warm sentences are not.
+
+Order, each part only if it applies:
+1. **Defects** — every flagged defect, as `<location>: <defect>`
+   fragments. Severity word only when it changes buyer expectation
+   (`hairline crack`, `light shelf wear`). This part never gets trimmed.
+2. **Grade-relevant clears** — one terse `No <defects> noted.` covering
+   the defects a buyer would reasonably fear for this material/grade
+   (e.g. `No chips, cracks, or repairs.`). Skip clears that don't bear on
+   the grade.
+3. **Can't-assess** — untested function, undersides/interior unseen,
+   smoke-free not verifiable from photos. One fragment.
+
+**Never** include: narrative ("removed from box only to photograph"),
+marketing adjectives, decorative description of the item itself (that's
+the title/specifics), or what's-included (that's the body's What's
+Included). If a clause doesn't disclose a defect, a grade-relevant clear,
+or a limit of inspection, it does not belong in this field.

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -54,6 +54,13 @@ repeat a claim INVESTIGATE confirmed.
 **item_specifics:** from INVESTIGATE's "Item specifics" section ONLY. If
 INVESTIGATE listed it, copy; else `""` — do NOT fall back to IDENTIFY.
 Standard fields ≤65, `upc` ≤20. Extra specifics → `item_specifics.extra`.
+**Category-REQUIRED aspects must still be emitted** even if INVESTIGATE didn't
+itemize them and even when unbranded — eBay rejects the publish otherwise (errorId
+25002 "item specific <X> is missing"). A loaded specialization names its category's
+required aspects in its Output hooks (e.g. jewelry rings require `Metal` +
+`Metal Purity` + `Ring Size`); emit those into `item_specifics.extra` from
+INVESTIGATE/IDENTIFY. When unsure which a category requires, prefer including the
+obvious ones over a failed publish.
 
 **pricing:** `format` FIXED_PRICE (AUCTION only if price.txt says) ·
 `price` = working price as string, ≤13 · `cost_of_goods` null ·

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -45,8 +45,11 @@ repeat a claim INVESTIGATE confirmed.
 - `category_id` blank (eBay suggests at LIST) · `category_path` from
   INVESTIGATE/IDENTIFY category (human-readable only).
 - `condition` — map INVESTIGATE's grade (already from condition-rubric)
-  to `CONDITION_ENUM`. · `condition_description` from INVESTIGATE's
-  observable condition lines; ≤1000; **every flagged defect survives**.
+  to `CONDITION_ENUM`. · `condition_description` — telegraphic factual
+  disclosure per condition-rubric's "write it telegraphic" spec: defect
+  fragments → one grade-relevant `No … noted.` → can't-assess. No
+  narrative, marketing, decorative description, or what's-included.
+  ≤1000 but aim far shorter; **every flagged defect survives**.
 
 **item_specifics:** from INVESTIGATE's "Item specifics" section ONLY. If
 INVESTIGATE listed it, copy; else `""` — do NOT fall back to IDENTIFY.
@@ -131,9 +134,10 @@ Compose from INVESTIGATE's claim set only:
 - **Hook** (1–2 sentences) from INVESTIGATE Summary, buyer-facing.
 - **What's Included** — bullets from observable components; unit-type
   vocabulary.
-- **Condition** — one warm framing sentence + bullets enumerating EVERY
-  defect INVESTIGATE flagged (no minimizing); context sentence for
-  vintage wear.
+- **Condition** — factual, minimal. Bullets enumerating EVERY defect
+  INVESTIGATE flagged (no minimizing), each as `<location>: <defect>`.
+  At most one short context line for expected vintage wear; no warm
+  framing sentence, no marketing. Defects always survive any trim.
 - **About this item** — 1–2 sentence collector hook from INVESTIGATE's
   listing-approach.
 
@@ -154,8 +158,9 @@ Satisfy by **rephrasing, never mid-word truncation:**
   words. Always keep brand (or "Vintage"/"Unbranded") + the noun.
 - item_specifics: shortest correct canonical form (`Store Catalog`, not a
   prose sentence).
-- condition_description: trim redundancy first, then least-critical
-  observations; defects always stay; end at a sentence boundary.
+- condition_description: already telegraphic, so rarely near the cap. If
+  over, drop grade-relevant clears first, then can't-assess; defects
+  always stay; end at a fragment boundary.
 - numeric fields: the cap is on the string form. If a real value won't
   fit, the input is wrong (round/re-measure/flag) — never drop digits.
 - `lookup_only` (`country_of_origin`, `department`): substitute closest

--- a/prompts/identify.md
+++ b/prompts/identify.md
@@ -54,6 +54,33 @@ Marker discipline (per _shared confidence rule):
   mid-to-late"). No bracket.
 - `Unknown` — no real basis. Not a license to invent the priciest identity.
 
+## Category specializations (load expert knowledge on a match)
+
+Some categories have a dedicated **specialization module** — a self-contained
+expert field guide under [`../specializations/`](../specializations/). After you
+form an item's first-pass Category, check the registry table in
+[`../specializations/README.md`](../specializations/README.md): match the item's
+category / material / keywords against each module's **Triggers**. On a hit, the
+item is *in specialization* — **read that module file and apply it** before
+settling this item's fields.
+
+A loaded module gives you, for that item: the maker/type taxonomy and visual
+tells, the named high-value types to watch for, the category's own condition
+vocabulary, the authentication/fake tests, and a coarse **value tier**. Use it
+to:
+
+- settle Brand / Type / Era / Condition with specialist precision;
+- record the module's **value tier** in Distinguishing marks (so PRICE/CURATE
+  know which items deserve the exact-comp hunt vs which are filler);
+- set `needs_followup_photo` to the SPECIFIC inspection shot the module names
+  (e.g. a pontil/seam macro) when the confident call needs an inspection the
+  photos don't show.
+
+A specialization **refines, never overrides** the honesty rules and the
+maker-attribution discipline below: still no inventing, still `[BEST-CASE]` +
+scenario bracket for value-swing inferences, still the maker-mark gate. If no
+module's triggers match, proceed with the general pass as normal.
+
 ## Maker / brand attribution (work it HARD — high leverage)
 
 Brand is the single highest-leverage field: a confirmed maker changes the

--- a/specializations/README.md
+++ b/specializations/README.md
@@ -1,0 +1,93 @@
+# Specializations — category-expert knowledge modules
+
+A **specialization** is a self-contained expert field guide for one category
+of item (marbles, fountain pens, pocket knives…). When IDENTIFY meets an item
+whose category matches a module's triggers, it **loads that module and applies
+its rules** — turning a generalist identification into a specialist one:
+better attribution, the named high-value types flagged, the right condition
+vocabulary, the inspection shots a specialist would ask for, and a coarse
+value tier so PRICE and CURATE start from an informed anchor.
+
+This is prompt-driven, like the rest of v3 — a module is just a Markdown file
+the pipeline reads on demand. No code, no build step. Adding the next
+specialization is: drop a new file in here, add one row to the registry below.
+
+---
+
+## Registry (the index IDENTIFY checks)
+
+IDENTIFY reads THIS table to decide whether a specialization applies. Match an
+item's category/material against the **Triggers** column; on a hit, load that
+module before settling the item's fields. Keep this table in sync with the
+files in this directory — it is the single source of truth for what's active.
+
+| Module | Triggers (category / material / keyword match) | Status |
+|---|---|---|
+| [marbles.md](marbles.md) | marble, marbles, shooter, swirl, sulphide, agate (as a marble), "glass ball" toy, marble lot/jar/collection | active |
+
+_Add a row per new module. Triggers should be specific enough not to fire on
+unrelated items (e.g. "agate" alone is also a gemstone — qualify it)._
+
+---
+
+## How IDENTIFY uses a module (the contract)
+
+1. **Detect.** After forming a first-pass Category for an item, scan this
+   registry's Triggers. On a match, the item is *in specialization* — load the
+   module file.
+2. **Apply.** Use the module's taxonomy, value drivers, condition vocabulary,
+   and authentication tests to settle Brand / Type / Era / Condition and the
+   distinguishing-marks field. The module **refines**, never overrides, the
+   honesty rules in [`../prompts/_shared.md`](../prompts/_shared.md) and the
+   maker-attribution discipline in
+   [`../prompts/identify.md`](../prompts/identify.md): still no inventing, still
+   `[BEST-CASE]` + scenario brackets for value-swing inferences.
+3. **Flag value.** Emit the module's **value tier** for the item (its coarse
+   triage band) in Distinguishing marks, so PRICE/CURATE know which items
+   deserve the exact-comp hunt and which are filler.
+4. **Request the right shots.** If the confident call needs an inspection the
+   photos don't show, set `needs_followup_photo` to the SPECIFIC shot the
+   module names (e.g. for marbles, a pontil/seam macro), not a generic "more
+   photos".
+
+A specialization adds expertise; it does not change the gate contract. The
+maker-mark stop-and-ask, the SOFT-gate defaults, and the publish firewall all
+still apply exactly as in [`../RUN.md`](../RUN.md).
+
+---
+
+## Module file schema
+
+Every module follows [`_template.md`](_template.md) so they stay
+interchangeable. Required sections:
+
+- **Front matter** — `triggers`, `version`, `last_reviewed`, source list.
+- **When this applies** — the precise trigger conditions + carve-outs.
+- **Fast triage** — the 30-second-per-item pass for sorting a big lot into
+  "look closer" vs "filler". This is the workhorse for a 1000+ item pile.
+- **Taxonomy** — makers/types and how to recognize each.
+- **The money types** — the named high-value items and their tells.
+- **Value drivers** — what moves price, in priority order.
+- **Condition grading** — the category's own vocabulary + how defects cut value.
+- **Authentication & fakes** — antique vs modern/repro; common forgeries.
+- **Price tiers** — coarse bands ($ / $$ / $$$ / $$$$) with what lands in each.
+- **Inspection shots** — the macro/lighting the specialist asks for.
+- **Output hooks** — how the module's findings map onto IDENTIFY's fields.
+- **Sources** — the reputable references behind the module.
+
+Keep modules **evidence-based and dated**: cite the source class (specialist
+society, auction house, standard reference book) and record `last_reviewed` so
+stale market claims can be refreshed. Prices are tiers and signals, not
+quotes — the live PRICE phase still hunts real comps.
+
+---
+
+## Adding a new specialization
+
+1. Copy `_template.md` to `<category>.md`.
+2. Research it from reputable, specialist sources (society/club references,
+   established auction houses, standard reference books — not random listings).
+   The `deep-research` skill is a good way to gather and fact-check the body.
+3. Fill every section; set `version: 1` and today's `last_reviewed`.
+4. Add a row to the registry table above with specific triggers.
+5. That's it — IDENTIFY will pick it up on the next run that hits the triggers.

--- a/specializations/README.md
+++ b/specializations/README.md
@@ -24,6 +24,7 @@ files in this directory — it is the single source of truth for what's active.
 | Module | Triggers (category / material / keyword match) | Status |
 |---|---|---|
 | [marbles.md](marbles.md) | marble, marbles, shooter, swirl, sulphide, agate (as a marble), "glass ball" toy, marble lot/jar/collection | active |
+| [jewelry.md](jewelry.md) | ring, necklace, pendant, locket, bracelet, bangle, brooch/pin, earrings, cufflinks, chain, charm, parure; precious-metal marks (10k/14k/18k, 375/585/750, sterling/925, plat/950, "gold filled"/GF/vermeil); costume jewelry, rhinestone, signed maker (Tiffany/Cartier/Trifari/etc.); a gemstone **set in / sold as jewelry** (diamond, sapphire, jade, agate-as-gemstone, etc.) | active (v1, partial — see module header) |
 
 _Add a row per new module. Triggers should be specific enough not to fire on
 unrelated items (e.g. "agate" alone is also a gemstone — qualify it)._

--- a/specializations/_template.md
+++ b/specializations/_template.md
@@ -1,0 +1,77 @@
+# <Category> — specialization module
+
+<!--
+Copy this file to <category>.md and fill every section. Then add a row to
+README.md's registry. Keep it evidence-based and dated. Delete these comments.
+-->
+
+```yaml
+triggers: [<keyword>, <keyword>, <category>, <material>]   # what activates this module in IDENTIFY
+version: 1
+last_reviewed: <YYYY-MM-DD>
+sources:
+  - <specialist society / club reference>
+  - <established auction house>
+  - <standard reference book — author, title>
+```
+
+## When this applies
+
+Precise trigger conditions and carve-outs. When does an item count as in-scope,
+and when does a look-alike NOT (e.g. material overlaps with another category)?
+
+## Fast triage (the big-lot pass)
+
+The 30-seconds-per-item sort: the few cues that move an item from "filler" to
+"look closer". Optimized for triaging a large collection fast. End with the
+rule: when in doubt, pull it for a closer look.
+
+## Taxonomy — makers / types and how to recognize each
+
+The maker/type landscape with the concrete visual tells for each.
+
+## The money types (named high-value items)
+
+The specific named types/patterns that command real money, each with its
+identifying features and why it's valuable. This is the watch-list.
+
+## Value drivers (priority order)
+
+What moves price, ranked. How the drivers interact.
+
+## Condition grading
+
+The category's own grading vocabulary and how each defect class cuts value.
+
+## Authentication & fakes
+
+Antique/genuine vs modern/reproduction/forgery; the tells and the known fakes.
+
+## Price tiers (coarse bands)
+
+| Tier | Band | What lands here |
+|---|---|---|
+| $ | | |
+| $$ | | |
+| $$$ | | |
+| $$$$ | | |
+
+Tiers are triage signals, not quotes — PRICE still hunts live comps.
+
+## Inspection shots
+
+The specific macro/lighting a specialist asks for to resolve identity or
+condition — what IDENTIFY should request via `needs_followup_photo`.
+
+## Output hooks (maps onto IDENTIFY fields)
+
+- **Brand** → …
+- **Type** → …
+- **Era** → …
+- **Condition** → …
+- **Distinguishing marks** → include the **value tier** here.
+- **needs_followup_photo** → the inspection shot above.
+
+## Sources
+
+Full reputable-source list with what each is good for.

--- a/specializations/jewelry.md
+++ b/specializations/jewelry.md
@@ -1,0 +1,507 @@
+# Jewelry — specialization module
+
+```yaml
+triggers: [jewelry, jewellery, ring, necklace, pendant, locket, bracelet, bangle, brooch, "brooch pin", earrings, cufflinks, "tie clip", chain, charm, parure, hallmark, karat, "10k", "14k", "18k", "carat gold", sterling, "925", "gold filled", "gold-filled", vermeil, "costume jewelry", rhinestone, "signed jewelry", "diamond ring", "gemstone ring", "set gemstone"]
+version: 1
+last_reviewed: 2026-06-18
+coverage: v1 (built from four deep-research passes). SOURCE-VERIFIED: metals/marks (FTC);
+  British + German + Russian + Mexican hallmark decode; diamond + corundum + assembled-stone +
+  jade + ivory + glass-paste + pearl tells; and the maker roster Tiffany / Cartier (mark only,
+  not serial) / Mikimoto / Boucher / Juliana / Trifari / Coro-Vendome-Duette / Eisenberg /
+  Schreiner / Miriam Haskell / Hobé. STILL [DEEPEN] (routed to reference library, held [BEST-CASE]):
+  French + Italian + Asian hallmark decode; the remaining fine makers (VCA, Bulgari, Georg Jensen,
+  Boucheron, Webb, Yurman, Hardy, Buccellati, Harry Winston); turquoise/amber/coral/tortoiseshell/
+  emerald organics; the Cartier serial-number format (claims were refuted — do not state).
+sources:
+  - US FTC, 16 CFR Part 23 "Guides for the Jewelry, Precious Metals, and Pewter Industries" (2018 rev) — primary law for metal/karat/plating terms
+  - GIA — gia.edu (gem imitation/simulant definitions; jade FTIR primary; diamond 4Cs; the 7 Pearl Value Factors)
+  - International Gem Society / Gem Society + Gem-A — gemsociety.org, gem-a.com (synthetics, assembled stones, jade, glass paste)
+  - Lang Antiques / Antique Jewelry University — langantiques.com/university (gold terminology, maker-mark database, gem references, period timeline)
+  - The Goldsmiths' Company Assay Office London + The Silver Society — UK hallmark structure & date letters
+  - CITES — Identification Guide for Ivory and Ivory Substitutes (Schreger lines; legal status)
+  - The Online Encyclopedia of Silver Marks (925-1000.com) + silvercollection.it — silver/maker/foreign assay marks (German, Russian, Mexican decode)
+  - costumejewelrycollectors.com (CJCI) + morninggloryjewelry.com — costume maker marks & dating rosters
+  - Mikimoto America brand FAQ + GIA — pearl authentication & grading
+  - Spratling Silver (spratlingsilver.com), Jewelers Mutual, AC Silver — corroborating references
+```
+
+> **Reality check first (the single most useful fact for an estate box of jewelry).** Most
+> of a typical estate jewelry lot is **unmarked or base-metal COSTUME** with little melt or
+> maker value. The money sits in the few pieces that carry (a) a **precious-metal mark**
+> (10k/14k/18k, sterling/925, plat), (b) a **signed maker** (fine OR collectible costume), or
+> (c) a **genuine gemstone**. The job is to *find and read every mark first*, pull those few,
+> and not over-grade the rest. Fine jewelry has a **hard melt/scrap floor** that costume does
+> not — that floor is the safety net under every precious-metal pull.
+
+> **Match marks and stones against the reference library, not memory.** Before committing a
+> maker, a hallmark's origin/date, or a "genuine gemstone" claim that moves value, **WebFetch
+> the matching reference page (below) and compare the actual mark/stone photo.** Maker punches,
+> assay marks, and gem look-alikes are exactly where memory misleads (a counterfeit "925"/
+> "TIFFANY & CO." stamp, a doublet that looks solid face-up, a Verneuil synthetic that looks
+> natural). The honesty rules in [`../prompts/_shared.md`](../prompts/_shared.md) and the
+> **maker-mark gate** in [`../prompts/identify.md`](../prompts/identify.md) apply in full — a
+> stamp *indicates* but does not *prove*; many decisive tests need a bench jeweler or gem lab.
+
+## When this applies
+
+Any wearable jewelry — ring, necklace/pendant/locket, bracelet/bangle, brooch/pin, earrings,
+cufflinks, chain, charm, parure — whether **fine** (precious metal / gemstone / signed designer)
+or **costume** (base metal, rhinestone, Bakelite, enamel, signed costume makers). Includes loose
+gemstones set in jewelry and unset stones offered with a piece.
+
+**Maker-mark GATE (this is a gate category).** Jewelry, precious metals, and set glass/gemstones
+are all on the [`identify.md`](../prompts/identify.md) maker-mark stop-and-ask list. When a mark
+(karat stamp, hallmark, signature) is plausibly present but not decisively readable from the
+photos, **STOP and ask the user to read the inside/underside/clasp marking** before spending on
+research or settling Brand/metal — their close-read of the stamp beats any guess. Headless: degrade
+to `needs_followup_photo` + a `NEEDS_REVIEW.md` line and proceed.
+
+**Carve-outs / NOT this module:**
+- **Watches / wristwatches / pocket watches** — deep separate category; a future `watches.md`
+  module. (A gem-set watch's *stones/metal* can still use this module's metal & stone tells.)
+- **Holloware / flatware / tableware silver** — it's silver, and this module's silver-hallmark
+  decode applies, but those are tableware, not jewelry. (PRICE's silver push-high + melt-floor
+  rules still govern pricing — see [`../prompts/price.md`](../prompts/price.md).)
+- **Loose mineral specimens / lapidary rough** that are not gem-quality or set — minerals, not jewelry.
+- **"Agate marble" / glass-ball toy** → the [marbles](marbles.md) module, not this one (a loose
+  agate *gemstone* or an agate *cabochon set in jewelry* IS this module).
+
+## Fast triage (the estate-box pass)
+
+Sort the lot into **PULL** (look closer / read the mark) vs **FILLER** (bulk costume) fast. The
+decisive first action is always **find and read every mark** (base, inner band, clasp, pin stem,
+back of a brooch, earring post).
+
+**PULL signals (worth the close look):**
+- **Any precious-metal mark** — gold karat (`10K 14K 18K 22K 24K`, or `+P`/`KP`), fineness number
+  (`375 417 585 750 916 999`), `STERLING`/`925`/`800`/`835`/`900`, platinum (`PLAT 950 PT950 900`).
+- **Any signed maker** — fine (TIFFANY, CARTIER, etc.) OR collectible costume (Trifari crown,
+  EISENBERG, Boucher MB-cap, HASKELL, unsigned-but-Juliana construction).
+- **Genuine-looking gemstones** — real diamonds, ruby/sapphire/emerald, natural pearls, jadeite,
+  fine opal. (Verify; see Stones below — most "gems" in costume are glass.)
+- **Old construction** — C-clasp / trombone clasp brooch, cut-down/closed-back/foil-backed settings,
+  screw-back earrings, hand-fabrication → likely pre-WWII (see Period dating).
+- **Bakelite** and other early plastics (hot-water/Simichrome tests — in-hand only).
+- **Matched parure/demi-parure** (necklace + bracelet + earrings + brooch en suite).
+- Anything heavy-for-its-size in a precious-metal color. **When in doubt, pull it.**
+
+**FILLER signals (the bulk):**
+- Unmarked base metal, no signed maker, missing/replaced stones, heavy plating loss, broken
+  findings, modern mass-market costume; bag-fresh identical repeats.
+- A `925`/karat stamp on a piece that is magnetic or shows base-metal wear-through → **suspect a
+  faked stamp** (a stamp indicates, does not prove — flag for acid/density test).
+
+---
+
+## Metals & their marks (SOURCE-VERIFIED — FTC 16 CFR Part 23)
+
+The mark tells you the metal *claim*; only an in-hand acid/XRF/density test *proves* it. A
+**photo seller cannot confirm fineness** — read the stamp, then flag verification.
+
+**Gold — karat ↔ fineness (parts-per-24 ↔ parts-per-1000):**
+
+| Karat | Stamp | Gold % | Fineness mark |
+|---|---|---|---|
+| 9K | 9K / 375 | 37.5% | 375 |
+| 10K | 10K / 417 | 41.7% | 417 |
+| 14K | 14K / 585 | 58.3% | 585 |
+| 18K | 18K / 750 | 75.0% | 750 |
+| 22K | 22K / 916 | 91.7% | 916 |
+| 24K | 24K / 999 | 99.9% | 999 |
+
+- US/Canada stamp **karat** (number + `K`/`KT`); Europe/Japan/Mideast stamp **millesimal fineness**
+  (the 3-digit number). Either is "solid gold" of that purity.
+- **`P` / `KP` = plumb** — the alloy tests to *exactly* the marked fineness (tight tolerance), e.g.
+  `14KP` = exactly 58.3%. Convention from the 1976 US Stamping Act amendment (effective 1981).
+- **Not solid gold — the regulated layered tiers (mark says so):**
+  - **Gold-filled (`GF`)** — karat-gold layer **≥ 1/20 (5%) of total weight**, gold ≥10K. Stamp
+    encodes fraction+karat: `1/20 12kt GF`, `1/20 14K GF`, heavier `1/10 12K GF`. (FTC 23.3)
+  - **Vermeil** — **sterling-silver base** + gold ≥10K, **≥2.5 micron** thick. (FTC 23.4) The
+    silver base is what separates vermeil from gold-filled.
+  - **Rolled gold plate (`RGP`)** — applied gold ≥10K, layer *below* the 1/20 GF threshold (down to
+    the 1/40 floor); states karat when marked.
+  - **Gold electroplate (`GP`/`GE`/`GEP`)** — ≥0.175 micron of ≥10K. **Heavy gold electroplate
+    (`HGE`)** — ≥2.5 micron. ⚠ HGE marks are **unregulated in practice** and often mean only thin
+    base-metal plating — treat HGE as costume, not gold.
+  - `1/20`, `RGP`, `GF`, `GP`, `HGE`, `gold tone` → **NOT solid gold**; melt-floor logic does not apply.
+- ⛔ Do **not** repeat these refuted myths: GF is "5–10× thicker than plating" (false heuristic);
+  "HGE has no legal definition" (FTC does define it); "10K is the US legal minimum and below-10K is
+  misbranded" (overstatement) — all three were specifically refuted against FTC primary text.
+
+**Silver:**
+- **Sterling = 92.5% silver** → marked `STERLING`, `925`, or `.925`. Coin = `900`; continental
+  `800`/`835`/`900`; fine `999`. The stamp **indicates**, does not **prove** — a faked `925` on
+  plated brass/nickel is common; verify with magnet (silver is non-magnetic) + acid/density in hand.
+- **NOT silver, despite the word:** `EPNS` / `EP` / "quadruple plate" / "silver on copper" =
+  silver-PLATE over base; **"nickel silver" / "German silver" / "alpaca"** = a copper-nickel-zinc
+  BASE alloy with **no silver content at all**. (PRICE still treats the *word* "silver" as a
+  push-high trigger regardless — see its silver rule — but for ID these are base metal.)
+
+**Platinum / palladium:** `PLAT`, `PT`, `950`, `PT950`, `900`, `IRIDPLAT`, `PLAT900`. Dense, white,
+non-tarnishing. **White gold vs platinum vs silver** is not photo-decidable beyond the stamp —
+white gold is marked with a karat; platinum with `PLAT/950`; flag for weight/test.
+
+**Base metals:** brass, "pot metal" (low-melt zinc alloy, common in vintage costume), nickel/German
+silver, stainless, pewter. No melt floor; value is maker/design only.
+
+**Photo-only limits (state honestly):** you can read the *stamp* from a macro; you **cannot** confirm
+metal content, detect a faked stamp, or weigh for melt from a photo. Acid test, XRF, and scale are
+**in-hand** steps → request them via `needs_followup_photo` / the maker-mark gate.
+
+## Hallmarks & makers' marks by country
+
+**United States** — no national assay office. A US piece carries a **fineness/karat mark + a
+registered maker's trademark** (and often `STERLING`). The **word `STERLING`** skews older/US;
+the **numeral `925`** skews later or import — a soft era/origin cue, not proof.
+
+**British (assay-office) — the decodable system (VERIFIED):** a UK hallmark is **4–5 component
+marks**. Modern (post-**1999**) the **three compulsory** marks are: **sponsor's (maker's) mark** +
+**millesimal fineness number** (e.g. 925, 750) + **assay-office mark**. The traditional **fineness
+symbol** and the **date letter** are now *optional* (London still applies the lion as standard).
+- **Lion passant** = English **sterling** standard (used by all English offices after **1720**);
+  higher **Britannia** standard shows a seated Britannia figure instead.
+- **Assay-office/town marks:** London = leopard's head · **Birmingham = anchor** · Sheffield = crown
+  (rose post-1975) · Chester = sword between three wheatsheaves · Edinburgh = three-towered castle.
+- **Date letter** = a letter whose **font AND enclosing-shield shape together** give the year (each
+  cycle spans defined years) → decode **only** with a date-letter chart for that office (reference lib).
+
+**German (VERIFIED).** The unified national mark is a **crescent moon + imperial crown**
+(*Halbmond und Reichskrone*), set by the law of 16 July 1884 (effective 1888), minimum national
+fineness **800/1000**. Crescent+crown ⇒ German origin + ≥800 silver; the accompanying number
+(`800`/`835`/`900`/`925`) gives exact fineness.
+
+**Russian (VERIFIED) — the kokoshnik (woman's-head) assay mark + zolotnik fineness.** Official from
+the 1896 reform (in use ~1899). **Head direction is a photo-checkable dating cue:** head facing
+**LEFT** = **1899-1908**; a more detailed head facing **RIGHT** = **1908-1926** (the later mark adds
+a Greek-letter office code — α St. Petersburg, δ Moscow). Fineness is **zolotnik** (`84` = .875,
+`88` = .916, `91` = .947; the older `56/72/96` for gold). ⚠ The right-facing kokoshnik was
+**reinstated in 1985**, so right-facing alone is not conclusively pre-1926 — corroborate with maker/
+zolotnik context. Hold the date at `[BEST-CASE]`.
+
+**Mexican silver (VERIFIED).** Two systems:
+- **"Eagle" assay marks** (1948-~1979): a fully-drawn (delineated) eagle ran to ~1955, a silhouette
+  eagle to the early 1970s. The **number on the eagle's chest = city OR maker** (#1 = Mexico City,
+  #3 = Taxco, #16 = Margot de Taxco); pieces also carry `925`, `TAXCO`, maker initials.
+- **Post-~1979 letter/number registration** (guarantees sterling): **1st letter = city** (T Taxco,
+  M Mexico City, G Guadalajara, C Cuernavaca) · **2nd letter = silversmith's surname initial** ·
+  **number = that smith's registration order**. e.g. `TC-45` = Taxco / surname-C / #45, post-1979.
+  Higher number = newer; there is **no published name list**, so it rarely resolves to a person.
+- **Spratling (Taxco)** mark periods: `WS Print` ≈1931-46 · `Spratling de Mexico` ≈1949-51 ·
+  `WS Script` variants ≈1951-67.
+
+**French / Italian / Scandinavian (Georg Jensen) / Asian (Chinese export, Japanese, Thai/Siam)** —
+**[DEEPEN — not yet source-verified here].** Decode via the reference library, hold origin/date at
+`[BEST-CASE]`. Anchors to verify there: **French** eagle-head (18k gold), Minerva (silver), owl
+(import); **Italian** fascione (star + province number + fineness, post-1968); **Georg Jensen**
+post-1945 oval + design numbers; **Chinese export** pseudo-English hallmarks + character chops;
+**Japanese** `950`/`JUNGIN`, "Occupied Japan" (1945-52).
+
+**Country-of-origin wording dates a piece.** The McKinley Tariff (1891) required country marking on
+imports → bare "England"/"France" vs "Made in …" vs "Occupied Japan" (1945-52) are era cues (verify
+in the library before relying on them).
+
+## Signed makers (the names that move price)
+
+Brand is the highest-leverage field here. A confirmed maker can multiply value over scrap. Read the
+signature, then **match it to the reference library** — do not promote a guess.
+
+**FINE — VERIFIED mark structure:**
+- **Tiffany & Co.** — authentic reads `TIFFANY`, `TIFFANY & CO.`, or `T&Co.`, sometimes in a
+  cartouche/circle/oval, with `925`/`STERLING` or a karat mark. Genuine-vs-fake turns on punch
+  alignment/centering/typography — an in-hand authentication check, not the word alone.
+- **Cartier** — the signature appears in many cartouche/frame shapes across Paris/London/New York
+  and ~175 years; genuine pieces carry a **serial number** (its presence is an authentication
+  check). ⚠ The exact serial/reference-number **format is NOT reliably documented** (the
+  commonly-cited online formats failed verification) — do **not** date or authenticate from the
+  serial structure; treat a magnified punch + professional auth as the path.
+- **Mikimoto (pearls) — VERIFIED.** The trademark is an **Akoya-oyster/clamshell outline enclosing
+  an `M`** (or the engraved Mikimoto name) + a fineness mark (`18K`/`S`/`SL`/`Sterling`/`950`). On a
+  strand/bracelet it is **on the BACK OF THE CLASP**, and the strand also carries a signature `M`
+  charm. **Because the clasp is the only marked spot, a strand/bracelet CANNOT be authenticated as
+  Mikimoto without its original clasp** (very early/wartime strands may be unmarked or carry only a
+  plain stamped `M`). The pearls themselves are graded, not branded — see Stones.
+- **Others (VCA, Bulgari, Boucheron, Georg Jensen post-1945 oval + design numbers, Buccellati,
+  David Webb, David Yurman, John Hardy, Harry Winston)** — **[DEEPEN]**: real signed pieces exist
+  and move value hard, but their exact mark/serial structures are **not yet verified here** → settle
+  Brand only by matching the AJU maker-mark database (reference lib); else `[BEST-CASE]`.
+
+**COSTUME — VERIFIED dating cues:**
+- **Marcel Boucher** — `MB + phrygian cap` ≈ **1937-1949**; plain `Boucher` ≈ 1950-1955; **`©Boucher`
+  ≈ 1955 onward** (US designs couldn't be copyrighted until 1955). Inventory numbers rough-date
+  (~2300s c.1945 → 8291 by 1962), later add `P`/`E`/`N` (pin/earring/necklace). The © is firmer than
+  the number. ⚠ The **`©` rule is Boucher-specific / directional — NOT a universal "©=post-1955"
+  law** (that generalization was refuted; some makers differ).
+- **DeLizza & Elster "Juliana"** — essentially **UNSIGNED** ("Juliana" is a collector nickname;
+  only brief paper hang-tags c.1967). Attribute by the **construction battery**, no single trait
+  conclusive: 5-link bracelets, open-back navette/foiled settings, solder "puddling," japanned
+  (blackened) metal, **sparing rivets** (heavy rivet counts → Beaujewels/Judy Lee, *not* Juliana).
+  Authentic bracelets **usually prong-set** the larger stones → **all-glued stones = reproduction
+  red flag** (recent Asian imports glue everything) — EXCEPT genuine *cast* D&E designs are legitimately
+  all-glued (faux prongs).
+- **Trifari (VERIFIED).** `TKF`/`KTF` ≈1935 (KTF on jewelry 1935-37) → switched to the **`Trifari`**
+  mark **Dec 1937** (KTF/Trifari overlap ~1937-39, a gradual transition). `Clip-mates` inside a
+  twin-clip mechanism = 1936-37 (KTF) or Dec 1937+ (with `Trifari`). The **Crown-Trifari mark with
+  `©` dates after 1955** (Crown+© used 1955-1969) — a **Trifari-specific** copyright cue, not a
+  universal rule.
+- **Coro / Vendome / Duette (VERIFIED).** **Vendome** = Coro's upscale line, c.1944-1979 (`Vendome ©`
+  ⇒ after 1955). The **Coro Duette** (two clips on a removable frame) uses a locking mechanism
+  introduced **1935** (Candas patent Coro bought 1933) — a Duette frame is a ~1935+ cue.
+- **Eisenberg (VERIFIED — use the CJCI timeline).** `Eisenberg Original` ≈1935-1945; **sterling**
+  marks 1943-early 1948 (dropped late 1948); **`Eisenberg Ice` in block letters WITH `©` = 1970-
+  present**. (Distinguish the marked-piece era from the 1942 trademark *filing*.)
+- **Schreiner of New York (VERIFIED).** `SCHREINER OF NEW YORK` ≈1939-1977. Unsigned tells:
+  **inverted/keystone stone settings, hook-and-eye construction**.
+- **Miriam Haskell (VERIFIED).** **Unsigned 1926-~1947** → impressed **round** mark 1947-49 →
+  **horseshoe** plaque (earliest signature) mainly 1948-50 → **oval** plaque/hang-tag soldered to
+  filigree, **stamping showing through to the back**, ~1950-51 to today.
+- **Hobé (VERIFIED).** **Triangle** mark 1933-1957; `Sterling` 1941-47; **`©` 1958-1983** (a
+  Hobé-specific window, not the universal © rule). Trademark first used 1926.
+- **Others (Corocraft, Weiss, Schiaparelli, Sherman/Canada, Napier, Monet, Sarah Coventry)** —
+  **[DEEPEN]**: collectible and datable by mark, but **not yet verified here** (a Schiaparelli
+  1931-1973 dating claim specifically **failed** verification — don't state it) → match
+  costumejewelrycollectors.com / morninggloryjewelry / illusionjewels (reference lib) before
+  asserting; else `[BEST-CASE]`.
+
+## Stones & gems (photo-tells + the honest limits)
+
+The recurring truth: **a few tells are photo-checkable, but most identification of a genuine vs
+synthetic/treated/imitation stone needs a loupe, immersion, or a gem lab.** Never state "genuine
+ruby/diamond/jade" from a photo alone — say "appears to be / sold as" and flag the lab step.
+
+**Diamond vs simulant (VERIFIED, GIA):**
+- **Moissanite** is **doubly refractive** → a **doubled back-facet image** under 10× (blurry interior);
+  diamond shows no doubling. In ≥1 ct stones, extreme "disco-ball" fire is a naked-eye non-diamond flag.
+- **CZ** — Mohs 8.5 (vs diamond 10), usually colorless, **yellows over time**, **more fire / less
+  brilliance** than diamond. Most common diamond simulant.
+- A `simulant` (CZ, moissanite, white sapphire, glass/paste) looks like the gem but differs in
+  chemistry/structure; a `synthetic` shares the natural's chemistry. Diamond authenticity beyond
+  these tells (and lab-grown-vs-natural) needs a tester/lab.
+
+**Corundum (ruby/sapphire) & glass (VERIFIED, IGS/Lotus):**
+- **Curved growth lines (striae)** = **synthetic** (Verneuil flame-fusion); no natural mineral shows
+  curved striae. ONE-WAY: curved striae present → synthetic; *absence proves nothing*. Usually needs
+  microscope/immersion → rarely photo-resolvable.
+- **Perfectly round / "tadpole" gas bubbles** = synthetic or **glass** (natural cavities are angular).
+
+**Assembled stones — doublets/triplets (VERIFIED, IGS):**
+- Solid opal looks uniform from the side; a **doublet** shows a **sharp straight-line join** between
+  the opal and a dark base; a **triplet** has a **colorless crown cap** visible from almost any angle
+  (easiest to spot). A **garnet-glass doublet** can show no red face-up and no eye-visible join.
+- **Bubbles trapped in the glue layer** are the strongest assembled-stone tell — but need
+  magnification/immersion. **Closed bezel settings hide the side join** → the side-view tell only
+  works on unset / open-back / open-side mounts.
+
+**Paste / rhinestone / glass (VERIFIED tells, Gem-A/IGS):** foil-backed closed-back "paste" (old)
+and modern rhinestone are **glass**. Photo/loupe tells: **poor lustre** relative to a real gem,
+internal **gas bubbles**, **swirls** (curving internal flow lines), **mould/seam marks**, soft-
+rounded facet edges, and "too-perfect" uniform color. Opaque paste almost always shows small
+chips/scratches with a **glassy lustre** (polycrystalline gem fractures don't). ⚠ A bright foil
+backing inflates apparent brightness — judge lustre with care. Treat any unverified set "gem" in
+costume as **glass until proven otherwise**.
+
+**Pearl (VERIFIED, GIA):** graded on the **GIA 7 Pearl Value Factors** — size, shape, color,
+**luster**, surface, **nacre** (thickness), matching. Photo cues to *quality*, not authenticity:
+high luster (sharp reflections), clean surface, good match across a strand. **What a photo CANNOT
+settle:** natural vs **cultured** vs **imitation**, and nacre thickness — these need a lab (GIA
+X-ray for natural/cultured + nacre). In-hand only: the gritty "tooth test" (real = slightly gritty,
+imitation = smooth) and drill-hole/overtone tells. Brand (e.g. Mikimoto) comes only from the clasp
+mark, never the pearl. Flag "appears cultured/imitation, lab-verify" rather than asserting natural.
+
+**Organics & the legal flag:**
+- **Jade** — A (untreated; wax ok) / **B (bleach + polymer)** / C (dyed). **Conclusive B-jade ID
+  needs LAB FTIR — not photo-confirmable; escalate.** Jadeite-A is the valuable one.
+- **Ivory / tortoiseshell — LEGALLY RESTRICTED (CITES + US state law).** Elephant/mammoth ivory shows
+  **Schreger lines** (cross-hatch) on a *polished transverse section* (outer angle <90° mammoth,
+  >115° elephant, 90-115° overlap — average several) — a measurement test, not a casual photo tell.
+  **Flag for compliance before listing.** ⛔ Do **not** use the "real ivory fluoresces under UV /
+  plastic stays dull" test — it was refuted against CITES.
+- **[DEEPEN]** turquoise (stabilized/block/howlite-dyed), amber (copal/pressed/phenolic — UV/float/
+  hot-needle), coral, emerald (jardin/oiling/doublet), garnet/amethyst/topaz/aquamarine/citrine —
+  not yet verified here; use the reference library and hold genuineness at `[BEST-CASE]` + a
+  lab-verify note. (A "flawless" emerald is almost always glass/synthetic — natural emeralds carry
+  jardin inclusions — but confirm before relying on it.)
+
+## Styles & periods (date by construction — [DEEPEN], hold at [BEST-CASE])
+
+Construction/findings often set a **"no earlier than" bound**, not an exact date. Pending a verified
+deepen pass, use these as *directional* cues and confirm in the reference library (AJU timeline,
+AC Silver clasp guide):
+- **Brooch pin mechanism:** C-clasp (no safety) → generally older (pre-~1910); trombone/tube clasp
+  → late-19thC–1910s (often European); modern safety/roll-over catch → ~1920s+.
+- **Earring findings:** screw-back ≈1900-1950s; clip-back from ~1930s; modern posts (pierced) common
+  ~1960s+.
+- **Settings:** cut-down / collet / closed-back / **foil-backed** → older (foiled closed backs largely
+  pre-~1900); open-back prong/claw settings later.
+- Period bands to assign once construction + style agree: Georgian → Victorian (early/grand/late;
+  mourning/jet) → Art Nouveau → Edwardian → Art Deco → Retro (1940s) → Mid-Century / Modernist → later.
+  Assign with `[ASSUMPTION]` when inferred from style alone.
+
+## Value drivers (priority order)
+
+1. **Metal melt/scrap floor (fine only).** Precious metal sets a hard floor costume lacks. Rough melt
+   = (gold karat % OR silver fineness) × **weight** × **spot price**. Needs the *weight* (a photo
+   can't give it) → request it. Plated/GF/vermeil/HGE have **no** melt floor.
+2. **Signed maker.** A confirmed fine OR collectible-costume maker multiplies value over scrap/base.
+3. **Gemstones.** Genuine, sizeable, well-cut natural stones (esp. diamond, ruby, sapphire, emerald,
+   natural pearl, jadeite-A) — but only when authenticity is supported; assume glass in costume.
+4. **Period / age & design.** Datable antique/period construction + desirable style.
+5. **Condition.** See below — repairs and missing stones cut hard.
+6. **Demand / brand heat.** Live comps decide (PRICE). No fixed price tiers — tiers below are signals.
+
+## Condition grading (jewelry-specific)
+
+Grade and disclose; jewelry damage is specific and value-moving:
+- **Missing / replaced / chipped stones** (note empty seats; replaced ≠ original).
+- **Repairs** — resizing marks, solder blobs at shanks/joints, replaced clasp/findings, re-tipped prongs.
+- **Metal wear** — thin shanks, worn-through plating (costume), dents, porosity, casting pits.
+- **Surface** — scratches, polish loss, patina (desirable on some antiques, not on others).
+- **Function** — clasp/catch works; pin stem straight; hinge tight; safety catch present.
+- State what **cannot be assessed** from photos: metal content, stone authenticity, exact weight,
+  inside-shank marks not shown.
+
+## Authentication & fakes (name the test; flag the lab/bench step)
+
+- **Counterfeit signed marks** (fake `TIFFANY & CO.`/`Cartier`) — check punch alignment/typography
+  against the reference guide; serial-format check (Cartier). High-value calls → professional auth.
+- **Faked precious-metal stamps** — a `925`/`14K` on magnetic or base-metal-worn pieces → magnet
+  (in hand) + acid/XRF; never trust the stamp alone.
+- **Glass sold as gem / doublets-triplets** — side-view join + glue-bubble tells (mag/immersion);
+  closed bezels hide them → escalate.
+- **Undisclosed lab-grown diamond** — needs a tester/lab; cannot be ruled out from a photo.
+- **B-jade (polymer)** — needs FTIR; escalate.
+- **"Married"/repro costume** (e.g. all-glued "Juliana") — construction battery; one trait is not proof.
+- ⛔ **Refuted tests — do NOT use:** UV "real-ivory-glows" test; the universal "©=post-1955 across all
+  makers" rule; the over-specified single-feature Juliana description. (Each failed verification.)
+
+Most decisive tests here are **in-hand or lab**. A photo seller's honest output is "appears to be /
+sold as, pending verification" + the specific test that would confirm.
+
+## Price tiers (coarse signal bands — live comps decide)
+
+Triage signals, **not quotes**; PRICE hunts real comps and applies the silver/precious-metal push-high
+and melt-floor rules. No hard price claims survived verification — treat these as *which bucket to comp*:
+
+| Tier | What lands here |
+|---|---|
+| **Scrap/melt floor** | Any solid precious-metal piece — never sells below its metal melt (compute from karat/fineness × weight × spot). The floor under every fine pull. |
+| **$ (filler)** | Unmarked/base-metal costume, plated (GF/HGE/RGP) with no maker, damaged/missing-stone costume. Sell by the lot. |
+| **$$ (better costume)** | Signed collectible costume in good condition (Trifari, Coro, Boucher, Eisenberg, Juliana-attributed, Bakelite). |
+| **$$$ (mid fine)** | Solid gold/silver or genuine-gemstone pieces above melt; quality period pieces; lesser-signed fine. |
+| **$$$$ (high / designer)** | Signed fine makers (Tiffany, Cartier, VCA, Jensen…), important gemstones, fine antique/period jewelry. |
+| **🏆 trophy** | Major signed designer + important natural stones; museum-grade antique; provenance pieces. |
+
+## Inspection shots (request the SPECIFIC macro, via needs_followup_photo)
+
+- **Mark/hallmark macro, raking light** — the karat/fineness/maker stamp on inner band, clasp, pin
+  stem, or back. The single most valuable shot (and the maker-mark gate's ask).
+- **Weight on a scale (grams)** — required for any melt-floor estimate on precious metal.
+- **Stone setting, side/open-back view** — to check for a doublet/triplet join and the setting type.
+- **Clasp / findings close-up** — for period dating (C-clasp vs trombone vs modern; earring back type).
+- **Any signature / serial** close-up — for signed-maker authentication.
+- **Overall + worn areas** — to grade plating loss, repairs, missing stones.
+
+## Output hooks (maps onto IDENTIFY fields)
+
+- **Brand** → the signed maker when the signature is read+matched (Tiffany, Cartier, Boucher…);
+  `[BEST-CASE]` + bracket for an unconfirmed/`[DEEPEN]` maker; genuinely unmarked → `Unbranded`
+  (last resort, after the maker-mark pass).
+- **Type** → the form + metal/stone (e.g. "14K gold sapphire ring", "sterling brooch", "Boucher
+  enamel pin", "rhinestone parure"). Carry the **metal claim** exactly as the stamp reads.
+- **Era** → from construction/marks, `[ASSUMPTION]` when style-only; never assert antique/origin on a
+  single cue. Country-wording cues held at `[BEST-CASE]`.
+- **Condition** → the jewelry rubric above (missing stones, repairs, plating loss, clasp).
+- **Distinguishing marks** → record the **value tier** ($ / $$ / $$$ / $$$$ / 🏆), the **exact stamp
+  text read** (and what it proves vs needs testing), weight if known, stone read + its limit, and
+  the period/clasp cue. This is what PRICE/CURATE triage on.
+- **needs_followup_photo** → the specific inspection shot above (usually the mark macro + a gram weight).
+- **eBay REQUIRED item specifics (INVESTIGATE must list, DRAFT must emit).** eBay's jewelry
+  categories enforce required aspects — a missing one **rejects the publish** (verified: a ring
+  publish 400'd with errorId 25002 "The item specific Metal is missing"). So for jewelry, INVESTIGATE
+  always lists, and DRAFT always emits, these as item specifics (they are eBay-required, not optional
+  even when unbranded):
+  - **`Metal`** — the metal TYPE: `Yellow Gold` / `White Gold` / `Rose Gold` / **`Two-Tone Gold`** /
+    `Sterling Silver` / `Platinum` / `Gold Filled` / `Base Metal` (costume). This is **separate from
+    Metal Purity** and is the one most often forgotten.
+  - **`Metal Purity`** — `10k` / `14k` / `18k` / `925` / `Platinum`, exactly as the stamp reads.
+  - **`Main Stone`** (when set) — e.g. `Diamond` (with the untested/"appears" caveat in the
+    description, never asserted as tested from a photo).
+  - **Ring** also requires **`Ring Size`**; earrings/necklaces have their own (e.g. fastening,
+    length). Put any beyond the template's standard fields in `item_specifics.extra`.
+
+## Reference library (fetch real marks/stones before committing)
+
+Compare the item's photo to the actual reference image/data — never settle a value-moving maker,
+hallmark origin/date, or "genuine gemstone" from memory.
+
+**Metals, hallmarks & maker marks:**
+
+| Use it for | URL |
+|---|---|
+| US metal/karat/plating LAW (primary) | https://www.law.cornell.edu/cfr/text/16/23.3 , /23.4 |
+| Gold terminology — karat/plumb/GF/RGP/vermeil | https://www.langantiques.com/university/gold-terminology/ |
+| Silver / maker / **foreign assay** marks (the standard ref) | https://www.925-1000.com/ |
+| UK hallmark structure (compulsory marks, date letters) | https://www.assayofficelondon.co.uk/hallmarking/uk-hallmarks |
+| British silver marks / date-letter decoding | https://www.thesilversociety.org/research/identify-your-silver/ |
+| Maker-mark **database** (per-maker pages) | https://www.langantiques.com/university/makers-marks-2/ |
+| Tiffany mark variants | https://www.langantiques.com/university/mark/tiffany-and-co/ |
+| Cartier mark variants + serial check | https://www.langantiques.com/university/mark/cartier/ |
+| Mexican eagle + post-1979 letter/number decode | https://www.925-1000.com/mexican_marks.html |
+| Russian kokoshnik head-direction dating | https://www.silvercollection.it/dictionarykokoshnik.html |
+| Spratling / Mexican mark periods | https://www.spratlingsilver.com/hallmarks.htm |
+| Costume maker marks (Boucher, Juliana, A–Z by signature) | https://www.costumejewelrycollectors.com/vintage-costume-jewelry-research/costume-jewelry-marks/ |
+| Costume maker dating roster (Trifari, Coro, Eisenberg, Schreiner, Haskell, Hobé…) | https://www.morninggloryjewelry.com/articles/jewelry-marks-and-dates/ |
+| DeLizza & Elster "Juliana" construction tells | https://www.costumejewelrycollectors.com/vintage-costume-jewelry-research/designers-manufaturers-and-styles/identifying-delizza-elster-juliana-jewelry-101/ |
+
+**Stones, gems & dating:**
+
+| Use it for | URL |
+|---|---|
+| GIA — gem imitation / simulant definitions | https://www.gia.edu/gem-imitation |
+| GIA — diamond simulants (CZ, moissanite, lab-grown) | https://4cs.gia.edu/en-us/simulants-moissanite-and-lab-grown-diamonds/ |
+| IGS — synthetics/treatments/imitations (curved striae, bubbles) | https://www.gemsociety.org/article/understanding-gem-synthetics-treatments-imitations-part-4-synthetic-gemstone-guide/ |
+| IGS — assembled stones (doublets/triplets) | https://www.gemsociety.org/article/assembled-stones-jewelry-and-gemstone-information/ |
+| IGS — jade treatments (A/B/C) | https://www.gemsociety.org/article/identifying-jade-treatments/ |
+| GIA — bleached & polymer jadeite (FTIR; primary) | https://www.gia.edu/doc/Identification-of-Bleached-and-Polymer-Impregnated-Jadeite.pdf |
+| GIA — the 7 Pearl Value Factors (grading) | https://4cs.gia.edu/en-us/blog/pearl-quality-101-gia-examines-classifies-pearls/ |
+| Gem-A — glass/paste tells (bubbles, swirls, mould marks) | https://gem-a.com/gem-hub/gem-knowledge-what-is-artificial-glass-paste-in-antique-jewellery/ |
+| Mikimoto — pearl authentication (oyster-M clasp mark) | https://www.mikimotoamerica.com/us_en/frequently-asked-questions |
+| Verneuil synthetic corundum tells (mirror; the lotusgemology URL 404s) | https://www.ruby-sapphire.com/ |
+| Old paste / closed-back glass | https://www.langantiques.com/university/paste-2/ |
+| CITES — ivory ID & Schreger lines + legal status | https://cites.org/sites/default/files/eng/resources/pub/E-Ivory-guide.pdf |
+| Period/construction timeline (clasps, findings, settings) | https://www.langantiques.com/university/timeline/ |
+| Gold/silver melt calculator | https://meltvalue.com/gold-calculator |
+
+For an independent visual second opinion on an unmarked / can't-place piece, also see
+`lib/lens_id.py` (Google Lens) per [`../prompts/identify.md`](../prompts/identify.md) — useful for a
+signed-maker design match, far less so for reading an embossed metal stamp (OCR struggles on those).
+
+## Sources
+
+- **US FTC, 16 CFR Part 23** (2018 rev) — the legal definitions for karat, gold-filled, vermeil,
+  plate/HGE, and the refuted "gold flashed/washed" terms. The authority for metal claims.
+- **GIA — gia.edu** — gem imitation/simulant definitions, diamond simulant tells, and the primary
+  jade FTIR study (Fritsch et al.). The authority for gem identification boundaries.
+- **International Gem Society — gemsociety.org** — synthetics/assembled-stone/jade-treatment tells.
+- **Lang Antiques / Antique Jewelry University** — gold terminology, the maker-mark database
+  (Tiffany, Cartier), gem references, and the period timeline.
+- **Goldsmiths' Company Assay Office London + The Silver Society** — UK hallmark structure & date letters.
+- **CITES** — ivory/tortoiseshell identification (Schreger lines) and legal status.
+- **costumejewelrycollectors.com (CJCI)** — costume maker marks; the authority for unsigned "Juliana."
+- **The Online Encyclopedia of Silver Marks (925-1000.com)** + **Spratling Silver** — silver, maker,
+  and foreign/Mexican assay marks.
+
+> **Open items to deepen in a future revision (v2)** — the honest remaining gaps after four
+> research passes (everything marked **[DEEPEN]** above; routed to the reference library in the
+> interim, held `[BEST-CASE]`):
+> - **Hallmarks:** French poinçons (eagle/owl/Minerva), Italian fascione, Georg Jensen oval +
+>   design numbers, and the Asian set (Chinese export, Japanese `JUNGIN`/Occupied Japan, Thai/Siam).
+>   *(German, Russian, Mexican, and British are now verified above.)*
+> - **Fine makers:** VCA, Bulgari, Boucheron, David Webb, David Yurman, John Hardy, Buccellati,
+>   Harry Winston — and the **Cartier serial-number format** (online formats failed verification;
+>   do not state one). *(Tiffany, Cartier mark, and Mikimoto are verified above.)*
+> - **Costume makers:** Corocraft, Weiss, Schiaparelli, Sherman, Napier, Monet, Sarah Coventry.
+>   *(Trifari, Coro/Vendome/Duette, Eisenberg, Schreiner, Miriam Haskell, Hobé, Boucher, Juliana
+>   are verified above.)*
+> - **Stones/organics:** turquoise, amber, coral, tortoiseshell, emerald, and the common quartz/
+>   beryl gems. *(Diamond simulants, corundum, jade, ivory, glass paste, and pearl are verified above.)*
+```

--- a/specializations/marbles.md
+++ b/specializations/marbles.md
@@ -132,6 +132,17 @@ Sort the pile into **PULL** (look closer) vs **FILLER** (jar lot) in seconds:
 - **Marble King** — patches (two-color "rainbows"), the bread-and-butter of
   later mass marbles; mostly common. *Thinner coverage — verify.*
 
+**Modern foreign mass-makers (the bulk of any pile — usually filler):**
+- **Vacor de Mexico** (a.k.a. Mega Marbles; 1990s–2000s+) — the dominant modern
+  maker. Patches & swirls in transparent or opaque glass; named series incl.
+  **"Planet"/"splatterpatch"** (dark transparent base densely packed with
+  embedded opaque multicolor SPECKLE spots — Jupiter, etc.), galaxy/sun/animal
+  themes. **Tell: a faintly pitted "orange-peel" surface + an oily, extra-shiny
+  sheen.** Machine-made (patch/cut marks, not hand pontils — though the two
+  patch-fold marks are easily MISREAD as pontils). Value ~**$1** single (a
+  "Vacor Planet splatterpatch 5/8 Mint" sold for $1.00); lots are the play.
+- **Modern Chinese** — bag/dollar-store cat's-eyes and patches; filler.
+
 > Coverage note: verified depth is strongest on **Christensen Agate, Peltier,
 > Akro, and Lutz/handmade**. For **M.F. Christensen, Vitro, Master, Marble
 > King**, identify cautiously and use `[BEST-CASE]` + Lens/web confirmation
@@ -180,6 +191,12 @@ Pull and price-hunt these on sight:
   base** is rarer than the common white/yellow ground, and bright splotches shade
   toward "Clown". Confirm cloud-vs-onionskin against the End-of-Day reference
   photos (see Reference library) — the two look alike and price differently.
+  ⚠ **Biggest trap:** a dark-base SPECKLED marble is far more often a **modern
+  Vacor "Planet"/splatterpatch (~$1)** than an antique Cloud ($60–95). Before
+  pricing a speckled marble as an antique Cloud, **run Google Lens** (it cleanly
+  flags Vacor Planets) AND check the surface — Vacor's **orange-peel pitting +
+  oily sheen** and the ~5/8″/.61″ size give it away. Antique Clouds have smoother
+  period glass, genuine play-wear, and rough cane pontils (not patch-fold marks).
 - **Clambroths, Indians, large onionskins/micas** in good grade — solid
   mid-to-high tier.
 
@@ -336,6 +353,8 @@ identification.)
 | Christensen Agate (Guineas, flames) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/christensen-agate-co/ |
 | M.F. Christensen & Son (slags, early machine) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/m-f-christensen-son-co/ |
 | Master Marble / Master Glass | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/master-marble-glass-cos/ |
+| Foreign makers (incl. Vacor de Mexico) — MCSA | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/foreign-manufacturers/ |
+| **Vacor de Mexico** "Planet"/splatterpatch + orange-peel tell (BuyMarbles/Basinet) | https://buymarbles.com/marblealan-vacor.html |
 
 **Grading, triage & value:**
 

--- a/specializations/marbles.md
+++ b/specializations/marbles.md
@@ -2,7 +2,7 @@
 
 ```yaml
 triggers: [marble, marbles, shooter, swirl, sulphide, onionskin, "glass ball toy", "marble lot", "marble jar", "marble collection", agate-marble]
-version: 1
+version: 2
 last_reviewed: 2026-06-16
 sources:
   - Marble Collectors Society of America — marblecollecting.com (taxonomy, grading)
@@ -17,6 +17,13 @@ sources:
 > many styles are still sold in dollar stores. Assume any given marble in a
 > bulk collection is filler until a specific cue says otherwise. The job is to
 > *flag the few percent that are worth pulling*, not to grade everything.
+
+> **Match against real photos, not memory.** Before committing any value-moving
+> type or maker, **WebFetch the relevant page(s) in the Reference Library below
+> and compare the item's photos to the actual reference photographs.** Do not
+> settle a type from recall or from a schematic — the look-alikes (Cloud vs
+> Onionskin vs Joseph's Coat vs machine-made Guinea) are exactly where memory
+> misleads. The MCSA guide is the authority for type; auction sites for value.
 
 ## When this applies
 
@@ -48,8 +55,10 @@ Sort the pile into **PULL** (look closer) vs **FILLER** (jar lot) in seconds:
 - Plain clearies, plain opaque "milkies," common single-color glass.
 
 **PULL signals (worth a closer look):**
-- **Two rough pontil marks** (rough/sheared spots at opposite poles) → likely
-  **German handmade**, c.1850–1920. Handmade = the high-end pool.
+- **Two rough pontil marks** (rough/sheared spots at opposite poles) → **handmade**
+  (cane-cut). Handmade is where the high-end pool lives — but pontils prove *method
+  only*, NOT origin or age: antique German, antique American, and modern/contemporary
+  or reproduction handmades all have pontils. Pull it, then judge origin/era separately.
 - **One pontil + an embedded figure** (animal, person, number) → **sulphide**.
 - **Glittery gold/copper bands or sprinkles** in the glass → possible **Lutz**.
 - **Mica flecks** (silvery metallic specks suspended in colored glass) → mica.
@@ -69,9 +78,12 @@ Sort the pile into **PULL** (look closer) vs **FILLER** (jar lot) in seconds:
 ## Taxonomy — makers / types and how to recognize each
 
 **First split: handmade vs machine-made (read it off the surface).**
-- **Handmade** (German, c.1850–1920): **two rough pontil marks** at opposite
-  poles (cut from a cane). Single-gather types — **sulphides, paperweight-style
-  — show ONE pontil** (formed on a punty). No seams.
+- **Handmade** (cane-cut): **two rough pontil marks** at opposite poles.
+  Single-gather types — **sulphides, paperweight-style — show ONE pontil**
+  (formed on a punty). No seams. Pontils establish the marble is **handmade**;
+  they do NOT by themselves establish German origin or antique age — those are
+  separate inferences (see the method≠origin≠era caution below). Antique German
+  handmades fall ~c.1850–1920, but modern studio/art makers make handmades too.
 - **Transitional / early machine** (turn of the century): a pontil on one end
   but machine character on the other; MCSA lists distinct pontil styles
   (regular, ground, melted, pinpoint, fold, pinch, crease).
@@ -80,6 +92,16 @@ Sort the pile into **PULL** (look closer) vs **FILLER** (jar lot) in seconds:
 - ⚠ Do **not** try to date a handmade marble by how "smooth" the pontil is —
   the once-common pre-1880-smooth / post-1880-rough heuristic is **not
   reliable** (specifically refuted against the specialist sources).
+- ⚠ **Method ≠ origin ≠ era — the cardinal anti-bias rule.** A pontil tells you
+  HOW a marble was made (handmade), not WHERE or WHEN. "Two pontils" is NOT proof
+  of German manufacture or pre-1920 age: modern studio/art marbles and deliberate
+  reproductions are handmade with pontils too. Treat **German origin** and
+  **antique era** as SEPARATE inferences, each earned from glass quality, color
+  idiom, genuine play-wear, size, and any signature/date cane — and held at
+  `[BEST-CASE]` unless the evidence is strong. When it doesn't clearly add up,
+  default to **"handmade — origin/era undetermined"**, never "German antique".
+  (This is a known failure mode: do not let the module's German-handmade emphasis
+  bias an unmarked handmade toward antique German.)
 
 **Handmade categories (the collectible ones):**
 - **Swirls / core swirls** — colored core or bands twisting through clear.
@@ -151,6 +173,13 @@ Pull and price-hunt these on sight:
 - **Sulphides** — clear sphere with embedded figure; **colored or rare-figure
   (human, numbers, painted) sulphides** are the valuable ones; plain animal
   sulphides are more common.
+- **End-of-Day Clouds & Onionskins** — handmade, transparent base with colored
+  flecks. **Cloud** = flecks suspended *unstretched* (spotted); **Onionskin** =
+  flecks *stretched* into a surface skin (converge at poles). Both are a real
+  mid-to-high tier (clouds in ~5/8″ NM–Mint commonly $60–95+); a **dark/colored
+  base** is rarer than the common white/yellow ground, and bright splotches shade
+  toward "Clown". Confirm cloud-vs-onionskin against the End-of-Day reference
+  photos (see Reference library) — the two look alike and price differently.
 - **Clambroths, Indians, large onionskins/micas** in good grade — solid
   mid-to-high tier.
 
@@ -211,8 +240,12 @@ Pull and price-hunt these on sight:
 - **Reproductions / modern art-glass.** Contemporary art-glass makers produce
   beautiful spheres that can be mistaken for antiques; modern handmades often
   have **one ground/polished pontil or a maker's signature/cane date**, very
-  saturated modern colors, and large size. Genuine antique German handmades
-  show **two rough (sheared) pontils** and period color/wear.
+  saturated modern colors, and large size. But **two rough pontils do NOT prove
+  antique** — some modern pieces and deliberate reproductions carry two pontils
+  as well. Separate antique German from modern handmade on glass quality, color
+  idiom, genuine play-wear (vs artificial distressing), size, and design; when
+  they don't clearly add up, stay at **"handmade — era undetermined"** rather
+  than asserting antique.
 - **Faked rarities.** The holy-grail types (Guineas especially) are faked.
   Demand crisp type-specific structure, sensible size, period wear, and ideally
   provenance; when a "Guinea/Superman/Popeye" looks too clean/cheap, assume
@@ -246,6 +279,10 @@ When the photos can't settle identity or condition, request (via
   detect buffing/grinding flats.
 - **Backlit / transmitted-light shot** — for swirls, NLR ribbons, oxblood,
   Lutz glitter, mica, and to see a sulphide figure clearly.
+- ⚠ **Light it from the SIDE, never flat/overhead.** Flat overhead light makes a
+  **transparent base read as opaque/black** and hides the type (verified on a
+  smoky-base Cloud: flat shots looked black; side-lit shots revealed the clear
+  base + suspended flecks). Side/backlight before judging transparency or type.
 - **In-hand with a scale/coin** — size is a value driver; need diameter
   (calipers/ruler ideal; note inches).
 - **Close-up of any printed image/letters** — for a suspected comic/picture
@@ -255,19 +292,63 @@ When the photos can't settle identity or condition, request (via
 
 - **Brand** → the maker when a named type/seam/pattern confirms it (Christensen
   Agate, Akro, Peltier…); `[BEST-CASE]` + bracket for thin-coverage makers
-  (M.F.C., Vitro, Master, Marble King) or unconfirmed rarities; handmade German
-  marbles are typically **Unbranded/maker-unknown** (German handmade) — say so.
+  (M.F.C., Vitro, Master, Marble King) or unconfirmed rarities; **handmade**
+  marbles are **Unbranded/maker-unknown** — call them "handmade" (cane-cut) and
+  only add "German" when origin evidence supports it, not from pontils alone.
 - **Type** → the named type/pattern (e.g. "NLR Superman", "Akro Popeye
   corkscrew", "4-panel onionskin", "sulphide — dog"). This is the highest-
   leverage field for marbles.
-- **Era** → handmade German c.1850–1920; Golden Age machine ~1905–1950s; modern
-  1980s+. `[ASSUMPTION]` when inferred from style only.
+- **Era** → earn it separately from method. Handmade: antique (~1850–1920) vs
+  modern/contemporary studio is often unresolvable from photos → default
+  **"handmade — era undetermined" [BEST-CASE]** unless glass/wear/signature
+  decide it. Machine: Golden Age ~1905–1950s; modern 1980s+. `[ASSUMPTION]` when
+  inferred from style only; never upgrade to "antique German" on pontils alone.
 - **Condition** → MCSA grade + band (e.g. "Near Mint 8.5 — two small subsurface
   moons; no chips") per the rubric above; flag buffed/polished as **no grade**.
 - **Distinguishing marks** → record the **value tier** ($ / $$ / $$$ / $$$$ /
   🏆) here so PRICE/CURATE know which to comp-hunt vs jar; plus size (diameter),
   pontil/seam read, and Lutz/mica/oxblood presence.
 - **needs_followup_photo** → the inspection shot above (usually the pole macro).
+
+## Reference library (fetch real photos before committing)
+
+These are the authoritative pages with **actual reference photographs**. When a
+type/maker is uncertain or value-moving, **WebFetch the matching page and compare
+the item's photos to the real images there** before settling the field — never
+from memory or a schematic. All links verified against MCSA / Block's; if a
+sub-type isn't listed, navigate from the ID-guide index. (These are reference
+*knowledge*; the fresh-investigation rule still applies — judge THIS item on its
+own photos, using the references only to recognize the type, not to import a prior
+identification.)
+
+**Type identification — MCSA "Online Marble ID Guide" (marblecollecting.com):**
+
+| Use it for | URL |
+|---|---|
+| Index — all marble types/makers (start + navigate) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/ |
+| **End of Day — Cloud vs Onionskin** (our key fork) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/end-of-days/ |
+| Handmade overview (swirls, cores, etc.) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/handmade-marbles/ |
+| Lutz (gold/copper glitter types) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/lutzes/ |
+| Other handmades (Indian, Clambroth, Mica, Sulphide, etc.) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/all-other-handmades/ |
+| Earthenware / clay marbles | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/earthenware/ |
+| Akro Agate (corkscrew, Popeye, patch) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/akro-agate-co/ |
+| Peltier (NLR, comics, Peerless patch) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/peltier-glass-co/ |
+| Christensen Agate (Guineas, flames) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/christensen-agate-co/ |
+| M.F. Christensen & Son (slags, early machine) | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/m-f-christensen-son-co/ |
+| Master Marble / Master Glass | https://www.marblecollecting.com/marble-reference/online-marble-id-guide/master-marble-glass-cos/ |
+
+**Grading, triage & value:**
+
+| Use it for | URL |
+|---|---|
+| MCSA grading guide (0–10 scale, defect terms) | https://www.marblecollecting.com/marble-reference/marble-grading-guide/ |
+| MCSA "Get a Marble Identified" (the 90%-modern reality check) | https://www.marblecollecting.com/marble-reference/get-a-marble-identified/ |
+| MCSA collector FAQ | https://www.marblecollecting.com/marble-reference/marble-faq/ |
+| Block's condition-grading policy (conservative, no-grade-for-buffed) | https://www.marbleauctions.com/condition-grading |
+| Block's realized auction comps (e.g. Christensen Agate) | https://bid.marbleauctions.com/category/christensen-agate-company-241 |
+
+For an independent visual second opinion on a markless/can't-place marble, also
+see `lib/lens_id.py` (Google Lens) per [`../prompts/identify.md`](../prompts/identify.md).
 
 ## Sources
 
@@ -283,7 +364,7 @@ When the photos can't settle identity or condition, request (via
   *Collecting Antique Marbles*; Robert Block, *Marbles Identification & Price
   Guide*; Everett Grist, *Antique & Collectible Marbles*.
 
-> Open items to deepen in v2 of this module: realized (hammer, not estimate)
+> Open items to deepen in a future revision: realized (hammer, not estimate)
 > price ranges separating the $50/$500/$5,000 tiers; deeper ID for M.F.
 > Christensen, Vitro, Master, Marble King; sharper fake-detection tells; and
 > size-vs-value thresholds beyond the Akro "over 1″" data point.

--- a/specializations/marbles.md
+++ b/specializations/marbles.md
@@ -1,0 +1,290 @@
+# Marbles — specialization module
+
+```yaml
+triggers: [marble, marbles, shooter, swirl, sulphide, onionskin, "glass ball toy", "marble lot", "marble jar", "marble collection", agate-marble]
+version: 1
+last_reviewed: 2026-06-16
+sources:
+  - Marble Collectors Society of America — marblecollecting.com (taxonomy, grading)
+  - Block's Marble Auctions — marbleauctions.com / bid.marbleauctions.com (realized market + grading policy)
+  - Morphy Auctions, LiveAuctioneers (auction comps)
+  - Reference books (corroborated indirectly): Paul Baumann, "Collecting Antique Marbles"; Robert Block, "Marbles Identification & Price Guide"; Everett Grist, "Antique & Collectible Marbles"
+```
+
+> **Reality check first (the single most useful fact for a 1000+ pile).**
+> Per the MCSA, **well over 90% of marbles people submit for ID are modern
+> Mexican or Chinese marbles made since the 1980s with next to no value** —
+> many styles are still sold in dollar stores. Assume any given marble in a
+> bulk collection is filler until a specific cue says otherwise. The job is to
+> *flag the few percent that are worth pulling*, not to grade everything.
+
+## When this applies
+
+Any glass (or rarely clay/stone/steel) toy marble: loose, in jars, in lots, or
+boxed. Includes "shooters" (larger marbles) and any item described as a swirl,
+agate, cat's-eye, sulphide, onionskin, Lutz, or comic marble.
+
+**Carve-outs / look-alikes that are NOT this module:**
+- *Agate* as a loose gemstone, cabochon, or jewelry stone — that's a mineral,
+  not a marble. Only an agate *marble* (a sphere, toy) qualifies.
+- Decorative glass spheres / paperweights / "witch balls" / nest eggs — larger
+  art-glass orbs, not toy marbles (a paperweight has one pontil but is its own
+  category).
+- Steel ball bearings, clay "commies" sold as craft filler, modern craft/vase-
+  filler glass gems (flat-backed) — filler, note and move on.
+
+## Fast triage (the big-lot pass)
+
+Sort the pile into **PULL** (look closer) vs **FILLER** (jar lot) in seconds:
+
+**FILLER signals (the 90%) — leave in the bulk jar:**
+- **Cat's-eye** with a simple injected color "vane/propeller" insert in clear
+  glass — the classic 1950s+ mass-made style; common ones are pennies. (A few
+  vintage/odd-vane cat's-eyes have minor value, but assume common.)
+- Perfectly uniform, glossy, modern-looking color; bag-fresh; identical
+  repeats by the hundred → modern Mexican/Chinese.
+- Obvious chips/grinding on an otherwise common machine-made marble (damage
+  guts common-marble value — see grading).
+- Plain clearies, plain opaque "milkies," common single-color glass.
+
+**PULL signals (worth a closer look):**
+- **Two rough pontil marks** (rough/sheared spots at opposite poles) → likely
+  **German handmade**, c.1850–1920. Handmade = the high-end pool.
+- **One pontil + an embedded figure** (animal, person, number) → **sulphide**.
+- **Glittery gold/copper bands or sprinkles** in the glass → possible **Lutz**.
+- **Mica flecks** (silvery metallic specks suspended in colored glass) → mica.
+- A **printed picture/character or letters** on the surface → **comic/picture
+  marble** (Peltier) — rare, pull immediately.
+- Crisp **named machine-made patterns**: tight pole-to-pole spirals
+  (**corkscrew**), opaque base with thin ribbons (Peltier **NLR**), white
+  filaments + color in clear (**Popeye**).
+- **Oxblood**: a dense, dark brownish-red opaque streak (prized on Akros and
+  others — a value-adder when present). *(Specific oxblood sub-claims vary by
+  source — treat as a "pull and verify," not a settled ID.)*
+- **Size**: anything notably large for its type (≥ ~1 inch) — large examples of
+  named types are disproportionately rare (e.g. *any Akro corkscrew over 1″ is
+  extremely rare*).
+- Anything you simply can't place. **When in doubt, pull it.**
+
+## Taxonomy — makers / types and how to recognize each
+
+**First split: handmade vs machine-made (read it off the surface).**
+- **Handmade** (German, c.1850–1920): **two rough pontil marks** at opposite
+  poles (cut from a cane). Single-gather types — **sulphides, paperweight-style
+  — show ONE pontil** (formed on a punty). No seams.
+- **Transitional / early machine** (turn of the century): a pontil on one end
+  but machine character on the other; MCSA lists distinct pontil styles
+  (regular, ground, melted, pinpoint, fold, pinch, crease).
+- **Machine-made** (American, ~1905–1950s "Golden Age" + later): **seams**
+  (fold/cutoff lines), **no pontils**, high sphericity.
+- ⚠ Do **not** try to date a handmade marble by how "smooth" the pontil is —
+  the once-common pre-1880-smooth / post-1880-rough heuristic is **not
+  reliable** (specifically refuted against the specialist sources).
+
+**Handmade categories (the collectible ones):**
+- **Swirls / core swirls** — colored core or bands twisting through clear.
+- **Onionskins** — flecked/stretched colored "skin" over a clear/opaque core;
+  panels common (e.g. 4-panel). End-of-day family.
+- **End-of-day** — random multicolored flecks/cloud (made from leftover glass).
+- **Lutz** — defined by **Lutz material** (ground copper / goldstone) as
+  glittering bands or sprinkles; NOT a maker (see "money types").
+- **Indians** — dark/black opaque base with colored surface bands.
+- **Clambroths** — opaque base (often white) with many evenly-spaced thin
+  colored lines pole-to-pole.
+- **Micas** — colored glass with suspended silvery mica flakes.
+- **Sulphides** — clear single-gather sphere with an embedded white figure.
+
+**American machine-made makers (Golden Age core four + later majors):**
+- **M.F. Christensen & Son** (1905–1917) — earliest US machine maker;
+  "slags" (single-color transparent + white swirl) and "brick/oxblood."
+  *(Identification of M.F.C. specifically is finicky — verify before claiming.)*
+- **Christensen Agate Co.** (1927–1933) — short-lived, brilliant colors;
+  home of the **Guinea** (see money types). Highly collectible.
+- **Akro Agate** (1911–1951) — corkscrews, patches, **Popeye**, oxblood.
+- **Peltier Glass** (marbles ~1920s–) — **National Line Rainbo** swirls,
+  **comic/picture** marbles, Peerless patches.
+- **Master Marble / Master Glass** — swirls/patches; *thinner reference
+  coverage — verify before a confident maker call.*
+- **Vitro Agate** — cat's-eyes, patches; mostly common, some collectible early
+  lines. *Thinner coverage — verify.*
+- **Marble King** — patches (two-color "rainbows"), the bread-and-butter of
+  later mass marbles; mostly common. *Thinner coverage — verify.*
+
+> Coverage note: verified depth is strongest on **Christensen Agate, Peltier,
+> Akro, and Lutz/handmade**. For **M.F. Christensen, Vitro, Master, Marble
+> King**, identify cautiously and use `[BEST-CASE]` + Lens/web confirmation
+> before stating the maker.
+
+## The money types (named high-value items — the watch-list)
+
+Pull and price-hunt these on sight:
+
+- **Christensen Agate "Guineas"** — *holy-grail tier.* Transparent base
+  (often clear/amber) with stretched, peppered multicolored flecks across the
+  surface. Genuine Guineas reach **four figures** (a mint 19/32″ example
+  carried a $750–$1,500 estimate / $1,400 bid at Block's). Heavily faked —
+  verify hard.
+- **Peltier National Line Rainbo (NLR)** — opaque base with **4–8 thin
+  translucent ribbons** and **two seams**. Named by exact base/ribbon colors:
+  - *Two-color:* Zebra (black/white), Bumblebee (black/yellow), Cub Scout
+    (yellow/blue), Wasp (black/red), Tiger (black/orange), Chocolate Cow
+    (black/brown).
+  - *Tri-color (top):* **Christmas Tree** (white base, red+green), **Superman**
+    (light-blue base, yellow+red), **Liberty** (white base, red+blue).
+  - Named NLRs in mint run tens to several hundred dollars (Superman ~$125–$400+).
+- **Peltier Comic / Picture marbles** — Peerless-patch base with a **fired-on
+  black character transfer** under clear overglaze. Twelve King-Syndicate
+  characters, ascending rarity: Emma, Koko, Bimbo, Smitty, Andy, Herbie,
+  Skeezix, Annie, Sandy, Betty, Moon, Kayo — plus **Tom Mix** (red transfer,
+  extremely rare). Any genuine comic is a serious pull.
+- **Akro "Popeye" corkscrews** — **transparent clear base with opaque WHITE
+  filaments** plus colored spirals (commonly red/yellow or green/yellow). The
+  white filaments are *required* to be a Popeye. **Hybrids** (3+ colors) and
+  **patch Popeyes** are rare and highly prized.
+- **Akro corkscrews (general)** — two+ **non-intersecting** color spirals
+  running pole-to-pole. Rarity rises with color count (**five-color "Specials"
+  extremely rare**) and with **size — any corkscrew over 1″ is extremely rare.**
+- **Lutz marbles** — any handmade with **Lutz material** (glittering ground-
+  copper/goldstone bands or sprinkles). Subtypes: Banded, Onionskin, Ribbon,
+  Indian, Mist/Solid-Core. **More Lutz on the core = more value** (most
+  precisely true of onionskin cores).
+- **Sulphides** — clear sphere with embedded figure; **colored or rare-figure
+  (human, numbers, painted) sulphides** are the valuable ones; plain animal
+  sulphides are more common.
+- **Clambroths, Indians, large onionskins/micas** in good grade — solid
+  mid-to-high tier.
+
+## Value drivers (priority order)
+
+1. **Rarity** — the deep driver everything else proxies for. Handmade and
+   short-run makers (Christensen Agate) are scarce; later mass makers (Marble
+   King, common Vitro/Akro patches) are not.
+2. **Maker + named type/pattern** — a *named* pattern (Guinea, NLR Superman,
+   Popeye, a specific comic) is worth multiples of a generic swirl/patch.
+3. **Color combination** — within a type, specific named/contrasty color sets
+   command premiums (this is literally how NLRs are named and tiered).
+4. **Condition / grade** — see below; interacts hard with #1.
+5. **Size** — larger-than-typical examples of a named type are
+   disproportionately rare and valuable (≥ ~1″ is a strong signal).
+
+> ⚠ Do **not** use "made after 1932 = worthless" as a rule — that specific
+> production-date heuristic was **refuted** against the specialist sources.
+> Date matters only through rarity, not as a hard cutoff.
+
+## Condition grading
+
+**MCSA / standard scale (0–10, four named bands):**
+
+| Grade | Range | Meaning |
+|---|---|---|
+| **Mint** | 9.0–10.0 | Original, unmarked, undamaged surface. *Factory-origin* defects are OK (popped air holes, melt/contact marks, annealing fractures, minor rubbing). |
+| **Near Mint** | 8.0–8.9 | Tiny-to-small post-use defects. |
+| **Good** | 7.0–7.9 | Numerous hit marks. |
+| **Collectible** | below 7.0 | Defects overall, may obscure the core. |
+
+- Grading is **subjective**; dealers vary. Block's grades **conservatively**
+  (treats Mint as 9.0–9.9, a true 10 as unattainable) and uses in-band
+  plus/minus (e.g. Mint(−) ≈ 9.2, Near Mint(+) ≈ 8.8). Plus/minus points are
+  dealer convention, not codified.
+- **Damage vocabulary** (post-use): **moon** (subsurface ring fracture, no
+  glass loss), **bruise** (subsurface discoloration, no loss), **chip** (deep
+  angular break with loss), **flake** (shallow surface loss), **hit mark**.
+- **Condition cuts value far harder on machine-made than handmade.** Per MCSA,
+  *even a small chip reduces a machine-made marble's value by more than half* —
+  because they're common. A **rare handmade** marble (e.g. a Clambroth) holds
+  much of its value even damaged. So: damage on a common marble → filler;
+  damage on a rare handmade → still pull.
+- **Buffed / polished / remelted / reworked → NO grade.** Such marbles get no
+  condition grade because the original surface is altered. **This is a red flag
+  to detect**, not a value-add (see below).
+
+## Authentication & fakes
+
+> This area had thinner verified coverage — treat the items below as working
+> guidance and confirm on high-value calls; don't over-claim authenticity.
+
+- **Buffing/polishing detection (high-value skill).** Buffing removes minor
+  haze and tiny pits to *fake* a higher grade, but **chips and subsurface moons
+  remain** — look for a too-glassy/soft surface, rounded-over former chips,
+  loss of crisp original "as-made" texture, or facets/flats from grinding.
+  A buffed marble should be called out and **not graded** as mint.
+- **Reproductions / modern art-glass.** Contemporary art-glass makers produce
+  beautiful spheres that can be mistaken for antiques; modern handmades often
+  have **one ground/polished pontil or a maker's signature/cane date**, very
+  saturated modern colors, and large size. Genuine antique German handmades
+  show **two rough (sheared) pontils** and period color/wear.
+- **Faked rarities.** The holy-grail types (Guineas especially) are faked.
+  Demand crisp type-specific structure, sensible size, period wear, and ideally
+  provenance; when a "Guinea/Superman/Popeye" looks too clean/cheap, assume
+  reproduction until proven otherwise.
+- **Honesty guard:** an unconfirmed rare type is `[BEST-CASE]` with the exact
+  resolution step, never a stated ID. A wrong "Guinea" call is the most
+  expensive mistake in this category in both directions (over- and under-value).
+
+## Price tiers (coarse bands)
+
+Triage signals, **not quotes** — PRICE still hunts live comps. The $1 floor and
+~$1,000+ ceiling are source-anchored; the middle bands are inferred from the
+type+condition matrix.
+
+| Tier | Band | What lands here |
+|---|---|---|
+| **$ (filler)** | ~$0.05–$2 | Modern Mexican/Chinese, common cat's-eyes, plain clearies/milkies, common patches, any common machine-made with chips. Sell by the **jar/lot**. |
+| **$$** | ~$2–$25 | Identifiable named machine-made in lower grade; common Akro/Peltier/Vitro patches & swirls in NM+; common handmade swirls with damage. |
+| **$$$** | ~$25–$150 | **Mint** named machine-made patterns (corkscrews, common NLRs, good swirls); better handmade (onionskins, micas, Indians) in good grade. |
+| **$$$$** | ~$150–$1,000 | Top named patterns in mint (Popeye hybrids, NLR Superman/Christmas Tree, comics, figural/colored sulphides, heavy-Lutz, clambroths); large mint examples of named types. |
+| **🏆 trophy** | $1,000+ | **Christensen Agate Guineas**, rarest comics (Tom Mix), exceptional sulphides, rare hybrids, exceptional large mint rarities. |
+
+## Inspection shots
+
+When the photos can't settle identity or condition, request (via
+`needs_followup_photo`) the SPECIFIC shot, not "more photos":
+
+- **Pole macro (both ends)** — to read pontils (handmade: two rough; sulphide/
+  paperweight: one) vs seams (machine-made). The decisive method shot.
+- **Raking-light surface macro** — to grade: reveal chips/moons/flakes and
+  detect buffing/grinding flats.
+- **Backlit / transmitted-light shot** — for swirls, NLR ribbons, oxblood,
+  Lutz glitter, mica, and to see a sulphide figure clearly.
+- **In-hand with a scale/coin** — size is a value driver; need diameter
+  (calipers/ruler ideal; note inches).
+- **Close-up of any printed image/letters** — for a suspected comic/picture
+  marble.
+
+## Output hooks (maps onto IDENTIFY fields)
+
+- **Brand** → the maker when a named type/seam/pattern confirms it (Christensen
+  Agate, Akro, Peltier…); `[BEST-CASE]` + bracket for thin-coverage makers
+  (M.F.C., Vitro, Master, Marble King) or unconfirmed rarities; handmade German
+  marbles are typically **Unbranded/maker-unknown** (German handmade) — say so.
+- **Type** → the named type/pattern (e.g. "NLR Superman", "Akro Popeye
+  corkscrew", "4-panel onionskin", "sulphide — dog"). This is the highest-
+  leverage field for marbles.
+- **Era** → handmade German c.1850–1920; Golden Age machine ~1905–1950s; modern
+  1980s+. `[ASSUMPTION]` when inferred from style only.
+- **Condition** → MCSA grade + band (e.g. "Near Mint 8.5 — two small subsurface
+  moons; no chips") per the rubric above; flag buffed/polished as **no grade**.
+- **Distinguishing marks** → record the **value tier** ($ / $$ / $$$ / $$$$ /
+  🏆) here so PRICE/CURATE know which to comp-hunt vs jar; plus size (diameter),
+  pontil/seam read, and Lutz/mica/oxblood presence.
+- **needs_followup_photo** → the inspection shot above (usually the pole macro).
+
+## Sources
+
+- **Marble Collectors Society of America — marblecollecting.com** — the
+  authority for taxonomy, the maker ID guides (Akro, Peltier, Lutz, etc.), the
+  "Get a Marble Identified" reality check, and the grading guide. Start here.
+- **Block's Marble Auctions — marbleauctions.com / bid.marbleauctions.com** —
+  realized market behavior, conservative grading policy (plus/minus, no-grade-
+  for-buffed), and named-type comps (Guineas, NLRs).
+- **Morphy Auctions, LiveAuctioneers** — additional auction comps for high-end
+  types.
+- **Reference books** (corroborated indirectly via the above): Paul Baumann,
+  *Collecting Antique Marbles*; Robert Block, *Marbles Identification & Price
+  Guide*; Everett Grist, *Antique & Collectible Marbles*.
+
+> Open items to deepen in v2 of this module: realized (hammer, not estimate)
+> price ranges separating the $50/$500/$5,000 tiers; deeper ID for M.F.
+> Christensen, Vitro, Master, Marble King; sharper fake-detection tells; and
+> size-vs-value thresholds beyond the Akro "over 1″" data point.
+```


### PR DESCRIPTION
Builds a local, prompt-readable **knowledge base** for collectables plus a suite of **visual-similarity + seller-intelligence tools**, developed against marbles as the first deep category.

## What's in it

**KB scaffold & references** (`kb/`)
- `README.md` — purpose, the "how a run uses the KB" contract, new-source policy, resource registry, and a **Tools** section + a reusable *"studying a new category"* recipe.
- `articles/` — silver hallmarks; eBay sold-comp methodology.
- `taxonomies/marble-types-top100.md` — the 100 most-collectable marble types (reference **and** the keyword matcher for the eBay library).

**Visual-similarity indexes** (code tracked; `kb/index/` data gitignored/regenerable)
- `lib/marble_index.py` — index marble photos from the Marble Connection "Marble I.D.'s" forum; query by photo → most-similar threads. Includes `refresh` (periodic sync) and an opt-in **fast/concurrent mode** (`MARBLE_IMG_WORKERS`).
- `lib/ebay_visual.py` — same featurizer over **eBay sold listings** → priced visual comp finder, bucketed by the top-100 taxonomy.

**eBay API + seller intelligence**
- `lib/ebay_browse.py` — Browse-API reader for other sellers' **active** listings (documents that sold-by-seller is gated/unavailable; realized comps still need Apify).
- `lib/seller_intel.py` — joins Apify sold comps (`sellerName`) to the live Browse API: `rank`, `profile`, and `landscape` (category competitive map: who has the most inventory, who prices highest).
- `lib/apify_ebay.py` — adds `thumbnail` to the normalized comp so one standard comp pull feeds both the visual library and seller-intel.

## Notes
- Backend is a no-torch pHash featurizer (color+structure); CLIP is a one-flag upgrade once the VC++ Redistributable is installed.
- Honesty contract throughout: similarity finds *candidates*, not authenticated IDs; sold = realized, active = asking.
- This branch also carries 6 pre-existing commits (jewelry specialization, marbles debias, list_edit auction, condition spec) that predate this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)