### PR TITLE
PREP: refuse to clobber a manifest another writer moved (#21 stage 2)

### DIFF
--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -245,11 +246,37 @@ def manifest_path(shoot: Path) -> Path:
     return shoot / ".prep" / "prep.json"
 
 
+# What the manifest looked like when we read it. Stamped into the loaded dict
+# and popped before writing, so it never reaches disk and never widens the
+# format. Its only job is to let save_manifest tell "nobody touched this" from
+# "someone did".
+READ_FINGERPRINT = "_read_fingerprint"
+
+
+class ManifestConflict(RuntimeError):
+    """The manifest changed on disk between our read and our write.
+
+    Raised rather than resolved. Whoever holds the stale copy cannot know which
+    of the two sets of decisions the operator meant, and merging them silently
+    is how a look got adopted that nobody picked.
+    """
+
+
+def _manifest_fingerprint(p: Path) -> Optional[str]:
+    """A hash of the bytes on disk, or None when there are none."""
+    try:
+        return hashlib.sha256(p.read_bytes()).hexdigest()[:16]
+    except OSError:
+        return None
+
+
 def load_manifest(shoot: Path) -> dict:
     p = manifest_path(shoot)
     if p.exists():
         try:
-            return json.loads(p.read_text(encoding="utf-8"))
+            m = json.loads(p.read_text(encoding="utf-8"))
+            m[READ_FINGERPRINT] = _manifest_fingerprint(p)
+            return m
         except Exception:
             pass
     return {
@@ -261,6 +288,7 @@ def load_manifest(shoot: Path) -> dict:
         "approved_at": None,
         "settings": {},
         "photos": {},
+        READ_FINGERPRINT: None,          # we read an absence; it must stay absent
     }
 
 
@@ -286,11 +314,64 @@ def category_of(m: dict) -> str:
     return m.get("settings", {}).get("category", DEFAULT_CATEGORY)
 
 
-def save_manifest(shoot: Path, m: dict) -> None:
-    m["updated"] = _now()
+def save_manifest(shoot: Path, m: dict, force: bool = False) -> None:
+    """Write the manifest, refusing to clobber another writer.
+
+    PREP is not run by one process at a time. Batches run in a pool, an
+    operator runs a command against a shoot a background --apply is halfway
+    through, and more than one agent works the same tree. This used to be a
+    bare write_text: last writer won, silently.
+
+    It cost three incidents in two days. Twice a background --apply's auto-pick
+    landed after an operator's --pick, so the manifest named one look while
+    listing/ held another and --pick reported success either way. Once a
+    concurrent session overwrote a full set of eight orientation calls, which
+    only surfaced because a contact sheet was rendered afterwards and looked
+    wrong.
+
+    So: compare-and-swap. A writer that read fingerprint X refuses to overwrite
+    a manifest now at Y, and raises instead of merging — whoever holds the stale
+    copy cannot know which of the two sets of decisions was meant. Callers
+    re-read and retry; that is the whole protocol.
+
+    The write itself is tmp-and-rename. It was not atomic either, so a crash
+    mid-write left a truncated manifest rather than the previous one.
+
+    `force` exists for the deliberate overwrite. It is never the default.
+    """
     p = manifest_path(shoot)
+    if not force and READ_FINGERPRINT in m:
+        expected, actual = m[READ_FINGERPRINT], _manifest_fingerprint(p)
+        if expected != actual:
+            what = ("created by another writer" if expected is None else
+                    "gone" if actual is None else "changed under us")
+            raise ManifestConflict(
+                f"{p} was {what} since it was read "
+                f"(read {expected}, now {actual}). Re-read the manifest and "
+                f"re-apply the change; nothing has been written.")
+
+    m["updated"] = _now()
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(m, indent=2), encoding="utf-8")
+    body = {k: v for k, v in m.items() if k != READ_FINGERPRINT}
+    # Serialise BEFORE touching the disk, so an unserialisable value fails
+    # without having created anything, and clean up the temp file if the write
+    # itself dies — a stray .tmp never replaces the manifest, but it does make
+    # the next person wonder whether it should have.
+    text = json.dumps(body, indent=2)
+    tmp = p.with_name(p.name + ".tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, p)
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    # Re-stamp, so a caller that saves the same dict twice is not told its own
+    # write was somebody else's.
+    if READ_FINGERPRINT in m:
+        m[READ_FINGERPRINT] = _manifest_fingerprint(p)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -1310,6 +1310,126 @@ def test_an_unknown_category_is_refused_not_ignored():
     else:
         raise AssertionError("an unknown category was accepted")
 
+def test_a_second_writer_cannot_clobber_the_first():
+    """PREP is not run by one process at a time.
+
+    Batches run in a pool, an operator runs a command against a shoot while a
+    background --apply is halfway through it, and more than one agent works the
+    same tree. save_manifest was a bare write_text, so the last writer won in
+    silence. Three incidents in two days: twice an auto-pick landed after an
+    operator's --pick so the manifest named one look while listing/ held
+    another, and once a concurrent session overwrote eight orientation calls.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        shoot = Path(td) / "s"
+        shoot.mkdir()
+        first = P.load_manifest(shoot)
+        first["photos"] = {"a.jpg": {}}
+        P.save_manifest(shoot, first)
+
+        r1 = P.load_manifest(shoot)
+        r2 = P.load_manifest(shoot)
+        r1["photos"]["from_r1"] = {}
+        P.save_manifest(shoot, r1)
+
+        r2["photos"]["from_r2"] = {}
+        try:
+            P.save_manifest(shoot, r2)
+            raise AssertionError("the stale writer clobbered the fresh one")
+        except P.ManifestConflict as e:
+            assert "nothing has been written" in str(e)
+
+        on_disk = json.loads((shoot / ".prep" / "prep.json").read_text(encoding="utf-8"))
+        assert "from_r1" in on_disk["photos"], "the first writer's work was lost"
+        assert "from_r2" not in on_disk["photos"], "the refused write landed anyway"
+
+
+def test_the_refused_writer_succeeds_after_re_reading():
+    """Refusing is only useful if the retry is obvious: re-read, re-apply, write."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = Path(td) / "s"
+        shoot.mkdir()
+        P.save_manifest(shoot, P.load_manifest(shoot))
+        stale = P.load_manifest(shoot)
+        fresh = P.load_manifest(shoot)
+        fresh["photos"] = {"theirs": {}}
+        P.save_manifest(shoot, fresh)
+
+        try:
+            stale["photos"] = {"mine": {}}
+            P.save_manifest(shoot, stale)
+            raise AssertionError("expected a conflict")
+        except P.ManifestConflict:
+            pass
+
+        again = P.load_manifest(shoot)
+        again["photos"]["mine"] = {}
+        P.save_manifest(shoot, again)
+
+        photos = P.load_manifest(shoot)["photos"]
+        assert {"theirs", "mine"} <= set(photos), photos
+
+
+def test_saving_the_same_dict_twice_is_not_a_conflict():
+    """A writer must not be told its own write was somebody else's."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = Path(td) / "s"
+        shoot.mkdir()
+        m = P.load_manifest(shoot)
+        m["photos"] = {"a": {}}
+        P.save_manifest(shoot, m)
+        m["photos"]["b"] = {}
+        P.save_manifest(shoot, m)          # must not raise
+        assert set(P.load_manifest(shoot)["photos"]) == {"a", "b"}
+
+
+def test_the_fingerprint_never_reaches_disk():
+    """It is bookkeeping, not part of the format — the format lock would
+    rightly fail if it widened the manifest."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = Path(td) / "s"
+        shoot.mkdir()
+        P.save_manifest(shoot, P.load_manifest(shoot))
+        raw = json.loads((shoot / ".prep" / "prep.json").read_text(encoding="utf-8"))
+        assert P.READ_FINGERPRINT not in raw, raw.keys()
+
+
+def test_a_crash_mid_write_cannot_truncate_the_manifest():
+    """tmp-and-rename. The old write_text left a half-written manifest when it
+    failed, losing the previous one as well as the update."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = Path(td) / "s"
+        shoot.mkdir()
+        good = P.load_manifest(shoot)
+        good["photos"] = {"keep": {}}
+        P.save_manifest(shoot, good)
+        before = (shoot / ".prep" / "prep.json").read_text(encoding="utf-8")
+
+        m = P.load_manifest(shoot)
+        m["photos"]["boom"] = {1 + 2j: "not serialisable"}
+        try:
+            P.save_manifest(shoot, m)
+        except Exception:                                    # noqa: BLE001
+            pass
+        after = (shoot / ".prep" / "prep.json").read_text(encoding="utf-8")
+        assert after == before, "a failed write damaged the manifest"
+
+
+def test_force_is_available_for_a_deliberate_overwrite():
+    with tempfile.TemporaryDirectory() as td:
+        shoot = Path(td) / "s"
+        shoot.mkdir()
+        P.save_manifest(shoot, P.load_manifest(shoot))
+        stale = P.load_manifest(shoot)
+        fresh = P.load_manifest(shoot)
+        fresh["photos"] = {"theirs": {}}
+        P.save_manifest(shoot, fresh)
+
+        stale["photos"] = {"mine": {}}
+        P.save_manifest(shoot, stale, force=True)
+        assert set(P.load_manifest(shoot)["photos"]) == {"mine"}
+
+
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items())
            if k.startswith("test_") and callable(v)]


### PR DESCRIPTION
Stage 2 of #21. Branched off `feat/v3.1-prep-fast` so it lands with the rest of v3.1.

`save_manifest` was a bare `write_text` — last writer won, silently. PREP is not run by one process at a time: batches run in a pool, an operator runs a command against a shoot a background `--apply` is halfway through, and more than one agent works the same tree.

**Three incidents in two days.** Twice a background `--apply`'s auto-pick landed after an operator's `--pick`, so the manifest named one look while `listing/` held another and `--pick` printed success either way. Once a concurrent session overwrote a full set of eight orientation calls, which surfaced only because a contact sheet was rendered afterwards and looked wrong.

## What changed

**Compare-and-swap.** `load_manifest` stamps a fingerprint of the bytes it read into the returned dict; `save_manifest` refuses when the file has moved since. It **raises rather than merging** — whoever holds the stale copy cannot know which of the two sets of decisions the operator meant, and guessing is how a look got adopted that nobody picked. Re-read, re-apply, write; that is the whole protocol.

Carrying it in the loaded dict rather than as a new argument is what makes it worth having: all 21 call sites already load, mutate and save, so **every one gets the check without being touched**. The fingerprint is popped before writing, so it never reaches disk — `tests/test_formats.py` would rightly have failed if the manifest format had widened.

**The write is now tmp-and-rename.** It was not atomic either: a crash mid-write left a truncated manifest, losing the previous one along with the update.

## Two cases that must not be conflicts

- saving the same dict twice — the fingerprint is re-stamped after each write, so a writer is never told its own write was somebody else's;
- a dict a caller built rather than loaded — no stamp, no expectation.

`force=True` exists for a deliberate overwrite and is never the default.

## Testing

`python tests/run_all.py` — ALL SUITES PASSED, 79 in `test_prep.py`. Six new tests, including one asserting a failed write leaves the previous manifest byte-identical, and one that walks the full refuse-then-retry protocol.

Also smoke-tested read-only against a live manifest in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)