### PR TITLE
prep_run: re-read and redo when the manifest moved under a worker

### DIFF
--- a/tests/test_prep_run_retry.py
+++ b/tests/test_prep_run_retry.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""The batch runner's response to a manifest conflict.
+
+`save_manifest` refuses when another writer moved the file since it was read.
+In a worker pool that is expected rather than exceptional — several workers,
+plus whatever else is running against the same tree — so a conflict must not
+fail the shoot. The worker re-reads and redoes the work.
+
+Two properties matter as much as the retry itself, and both are tested here:
+it is BOUNDED (a conflict that never clears is a bug, and must surface as one),
+and it is REPORTED (a retry nobody sees hides exactly the contention that
+compare-and-swap was built to make visible).
+
+Run:  python tests/test_prep_run_retry.py
+  or: pytest tests/test_prep_run_retry.py
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "tools"))
+
+import prep_run as R                                         # noqa: E402
+from lib.photo_prep import prep as P                         # noqa: E402
+
+
+def _flaky(n_conflicts: int):
+    """A call that raises ManifestConflict n times, then succeeds."""
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        if calls["n"] <= n_conflicts:
+            raise P.ManifestConflict("moved under us")
+        return {"photos": {"a": {}, "b": {}}, "chosen_preset": "crisp"}
+    return fn, calls
+
+
+def _no_sleep(monkey=None):
+    R.time.sleep = lambda _s: None
+
+
+def test_a_conflict_is_retried_and_succeeds():
+    _no_sleep()
+    fn, calls = _flaky(1)
+    m, note = R._with_retry(fn, lambda m: f"{len(m['photos'])} frames")
+    assert calls["n"] == 2, calls
+    assert m["chosen_preset"] == "crisp"
+    assert "2 frames" in note
+
+
+def test_the_retry_is_reported_not_swallowed():
+    """Contention has to stay visible. Silently absorbing it would hide the
+    races compare-and-swap exists to expose."""
+    _no_sleep()
+    fn, _ = _flaky(2)
+    _m, note = R._with_retry(fn, lambda m: "done")
+    assert "attempts" in note and "contention" in note, note
+
+
+def test_a_clean_run_says_nothing_about_retries():
+    _no_sleep()
+    fn, calls = _flaky(0)
+    _m, note = R._with_retry(fn, lambda m: "done")
+    assert calls["n"] == 1
+    assert "attempt" not in note, note
+
+
+def test_a_conflict_that_never_clears_is_raised():
+    """Bounded on purpose. Retrying forever turns a bug into a hang."""
+    _no_sleep()
+    fn, calls = _flaky(999)
+    try:
+        R._with_retry(fn, lambda m: "done")
+        raise AssertionError("looped without bound")
+    except P.ManifestConflict:
+        pass
+    assert calls["n"] == R.MANIFEST_ATTEMPTS, calls
+
+
+def test_only_conflicts_are_retried():
+    """A real bug must fail on the first attempt, not be tried four times and
+    reported as contention."""
+    _no_sleep()
+    calls = {"n": 0}
+
+    def boom():
+        calls["n"] += 1
+        raise ValueError("a real bug")
+
+    try:
+        R._with_retry(boom, lambda m: "done")
+        raise AssertionError("the error was swallowed")
+    except ValueError:
+        pass
+    assert calls["n"] == 1, f"a non-conflict error was retried {calls['n']} times"
+
+
+def test_the_backoff_table_covers_every_retry():
+    """One pause per retry — an attempt with no entry would raise IndexError
+    inside the handler, turning a survivable conflict into a crash."""
+    assert len(R.RETRY_BACKOFF) >= R.MANIFEST_ATTEMPTS - 1
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items())
+           if k.startswith("test_") and callable(v)]
+    bad = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except Exception as e:                               # noqa: BLE001
+            bad += 1
+            print(f"FAIL  {fn.__name__}: {e}")
+    print(f"{len(fns) - bad}/{len(fns)} passed")
+    sys.exit(1 if bad else 0)

--- a/tools/prep_run.py
+++ b/tools/prep_run.py
@@ -24,6 +24,7 @@ import argparse
 import json
 import multiprocessing as mp
 import os
+import random
 import sys
 import time
 import traceback
@@ -53,6 +54,45 @@ def _needs(shoot: Path, mode: str) -> bool:
     return not m.get("chosen_preset")
 
 
+# A manifest write refuses when someone else moved the file since it was read.
+# In a pool that is expected rather than exceptional, so the worker re-reads and
+# redoes the work instead of failing the shoot. Bounded, because a conflict that
+# never clears is a bug and should surface as one.
+MANIFEST_ATTEMPTS = 4
+RETRY_BACKOFF = (0.4, 1.2, 3.0)      # seconds before attempts 2, 3 and 4
+
+
+def _with_retry(fn, note_fn):
+    """Run `fn`, re-running it from a fresh read if the manifest moved under us.
+
+    Retrying is only correct because `run_check` and `run_apply` load the
+    manifest themselves, so calling again IS the re-read — there is no stale
+    state carried across an attempt. Anything that merged the two versions
+    instead would be guessing which set of decisions the operator meant.
+
+    The backoff is jittered so two workers that collide do not lock-step into
+    colliding again on the same schedule.
+
+    The attempt count is REPORTED, not swallowed. A retry that nobody sees would
+    hide exactly the contention this was built to make visible — the point was
+    never to make races quiet, only to make them survivable.
+    """
+    from lib.photo_prep import prep as P
+
+    for attempt in range(1, MANIFEST_ATTEMPTS + 1):
+        try:
+            m = fn()
+            note = note_fn(m)
+            if attempt > 1:
+                note += f"  [after {attempt} attempts — manifest contention]"
+            return m, note
+        except P.ManifestConflict:
+            if attempt == MANIFEST_ATTEMPTS:
+                raise
+            pause = RETRY_BACKOFF[attempt - 1] * (0.5 + random.random())
+            time.sleep(pause)
+
+
 def _worker(job):
     """One shoot. Imports live at module scope in the worker after first call,
     so the model load is amortised across every shoot this worker handles."""
@@ -64,14 +104,18 @@ def _worker(job):
         from lib.photo_prep import prep as P
 
         if mode == "check":
-            m = P.run_check(shoot, aspect, pad, pop, quiet=True)
-            n = len(m.get("photos", {}))
-            ask = sum(1 for r in m["photos"].values() if r["orientation"]["needs_ask"])
-            note = f"{n} frames, {ask} ASK"
+            def _ask(m):
+                n = len(m.get("photos", {}))
+                ask = sum(1 for r in m["photos"].values()
+                          if r["orientation"]["needs_ask"])
+                return f"{n} frames, {ask} ASK"
+            m, note = _with_retry(
+                lambda: P.run_check(shoot, aspect, pad, pop, quiet=True), _ask)
         else:
-            m = P.run_apply(shoot, quiet=True)
-            n = len(m.get("photos", {}))
-            note = f"{n} frames, preset {m.get('chosen_preset')}"
+            m, note = _with_retry(
+                lambda: P.run_apply(shoot, quiet=True),
+                lambda m: f"{len(m.get('photos', {}))} frames, "
+                          f"preset {m.get('chosen_preset')}")
         return dict(shoot=shoot_s, ok=True, note=note, secs=round(time.monotonic() - t0, 1))
     except Exception as e:                                    # noqa: BLE001
         return dict(shoot=shoot_s, ok=False,


### PR DESCRIPTION
Follow-on to #24, and the last item on #21 apart from the stage nobody is doing.

`save_manifest` now refuses to clobber a manifest another writer moved. In a worker pool that is expected rather than exceptional — several workers, plus whatever else is running against the same tree — so a conflict was **failing the shoot outright**, which is a worse outcome than the silent clobber it replaced.

The worker retries. That is only correct because `run_check` and `run_apply` load the manifest themselves, so calling again **is** the re-read: no stale state crosses an attempt, and nothing merges the two versions — merging would be guessing which set of decisions the operator meant.

## Three properties, each tested

| | |
|---|---|
| **Bounded** | four attempts. A conflict that never clears is a bug; retrying forever turns it into a hang |
| **Reported** | the note carries `[after N attempts — manifest contention]`. A retry nobody sees hides exactly the contention compare-and-swap was built to expose — the goal was survivable races, never quiet ones |
| **Narrow** | only `ManifestConflict` retries. A `ValueError` fails on the first attempt rather than being tried four times and reported as contention |

Backoff is jittered so two colliding workers don't lock-step into colliding again on the same schedule. One test asserts the backoff table covers every retry — an attempt with no entry would raise `IndexError` inside the handler and turn a survivable conflict into a crash.

## Worth knowing

A retried `--apply` redoes the whole render, ~64s per frame per preset. That's the right trade while conflicts are rare; if they stop being rare the fix is narrowing the window, not raising the bound.

## Testing

`python tests/run_all.py` — ALL SUITES PASSED. Six new tests in `tests/test_prep_run_retry.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)