### PR TITLE
feat(promote): campaign management — auto-add rules, and the funding model they force

### DIFF
--- a/prompts/promote.md
+++ b/prompts/promote.md
@@ -14,19 +14,72 @@ evidence for the bet lives in REPORT's numbers.
 
 ---
 
-## The gate: it proposes, you enact
+## The gate: it proposes, you confirm
 
-    python tools/promote.py --budget 20 --top 40
+    python tools/promote.py --budget 20 --top 40           # plan only
 
 The tool reads campaigns, ads, live listings and eBay's own suggested items,
 ranks them for the goal, and prints the plan plus the exact API calls that would
-enact it. It does not make those calls. Creating a campaign, adding an ad and
-setting a bid are writes against a live account with real money attached, and
-they stay the operator's keystroke — the same shape as the PREP gate and
-`list_edit`'s `--confirm`.
+enact it. **By default it makes none of them.**
+
+Every write is opt-in per invocation and requires `--confirm`; without it the
+call is printed and not sent:
+
+    --create NAME       create a campaign
+    --auto-add-min USD  ...with eBay's auto-add rule at that price floor
+    --add-ads           add the proposed listings to it
+    --bid / --ad-rate   what a click costs / what a sale costs
+    --bidding DYNAMIC   hand bid management to eBay
+    --delete ID         remove a campaign
 
 This is not timidity about the API. It is that an ad added by mistake is not
 free to undo: it spends before anyone notices.
+
+## What the funding model decides — and what decides the funding model
+
+The two models are not a preference. **Asking for the auto-add rule IS asking
+for cost-per-sale**, because `campaignCriterion` is refused on CPC:
+
+    36151  'campaignCriterion' is not supported for CPC funding model.
+
+There is no daily-capped click campaign that fills itself.
+
+| Model | Charged | Budget | Auto-add | Bid automation |
+|---|---|---|---|---|
+| `COST_PER_SALE` | an ad rate when a promoted listing sells | none — there is no daily budget | **yes** | ad rate strategy |
+| `COST_PER_CLICK` | per click | daily cap | no | `FIXED` / `DYNAMIC` |
+
+Three more refusals worth knowing before writing anything:
+
+- **`36210 No ad group found for ad group id null`** — a CPC campaign cannot
+  hold ads directly. It needs an ad group, and that group's default bid, not the
+  daily budget, is what a click costs. The budget only caps the day.
+- **`35039 categoryScope is required`** on any criterion-based campaign, even
+  when the rule names no category. `MARKETPLACE` is eBay's tree, `STORE` the
+  seller's.
+- **`campaignCriterion` is create-time only.** The campaign resource has no
+  criterion-update method, so a campaign built without the rule can never learn
+  it and must be deleted and rebuilt. Decide the rule before creating.
+
+## Auto-add and a curated list are mutually exclusive
+
+`autoSelectFutureInventory` hands membership to eBay: it re-checks the inventory
+daily and adds anything matching the rule. The revenue ranking then stops
+deciding what is promoted — the price floor does. That is a real trade, not a
+detail: state it plainly when proposing one, and do not present a ranked list as
+the campaign's contents once a rule is in force.
+
+## There is no ROAS automation
+
+Budget changes are an explicit `updateCampaignBudget` call. The only automations
+eBay offers are `autoSelectFutureInventory` (which listings) and
+`updateBiddingStrategy` (`FIXED`/`DYNAMIC`, CPC only). Nothing is triggered by
+performance.
+
+Nor can ROAS be computed locally: `ad_report_metadata` answers **403** on this
+account and orders carry one lump `totalMarketplaceFee` with no ad-fee line. A
+ROAS rule would therefore be acting on a number nobody has. Say so rather than
+approximating one.
 
 ## Goal: MAXIMISE REVENUE — and what that means mechanically
 

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1,0 +1,111 @@
+"""PROMOTE — the payload rules eBay only teaches you by refusing.
+
+Every assertion here corresponds to a real error from a live account, named in
+the test. They are cheap to hold and expensive to rediscover: each one cost a
+round trip against production, and two of them cost a campaign rebuild.
+
+No network. `create_campaign(confirm=False)` and friends print the body and
+return, so the shaping is testable without touching the account.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+sys.path.insert(0, str(REPO / "lib"))
+
+import promote                                                   # noqa: E402
+
+
+def _body(capsys, **kw) -> dict:
+    """The JSON create_campaign would POST, captured from its dry run."""
+    promote.create_campaign(kw.pop("name", "T"), kw.pop("budget", 20.0),
+                            False, **kw)
+    out = capsys.readouterr().out
+    return json.loads(out[out.index("{"):])
+
+
+def test_cpc_when_no_rule_asked_for(capsys):
+    b = _body(capsys)
+    assert b["fundingStrategy"]["fundingModel"] == "COST_PER_CLICK"
+    assert b["budget"]["daily"]["amount"]["value"] == "20.00"
+    assert "campaignCriterion" not in b
+
+
+def test_a_rule_forces_cost_per_sale(capsys):
+    """36151 'campaignCriterion' is not supported for CPC funding model.
+
+    Asking for auto-add IS asking for CPS. The two are not independent choices,
+    so the model must follow the rule rather than be set beside it.
+    """
+    b = _body(capsys, min_price=25.0, ad_rate=10.0)
+    assert b["fundingStrategy"]["fundingModel"] == "COST_PER_SALE"
+    assert b["fundingStrategy"]["bidPercentage"] == "10.0"
+    # CPS takes no daily budget at all -- sending one is a contradiction.
+    assert "budget" not in b
+
+
+def test_criterion_carries_category_scope(capsys):
+    """35039 categoryScope is required for criterion based campaigns.
+
+    Required even though this rule names no category, only a price floor.
+    """
+    b = _body(capsys, min_price=25.0)
+    crit = b["campaignCriterion"]
+    assert crit["autoSelectFutureInventory"] is True
+    assert crit["criterionType"] == "INVENTORY_PARTITION"
+    rule = crit["selectionRules"][0]
+    assert rule["categoryScope"] in ("MARKETPLACE", "STORE")
+    assert rule["minPrice"] == {"value": "25.00", "currency": "USD"}
+
+
+def test_ads_carry_the_ad_group(capsys):
+    """36210 No ad group found for ad group id null.
+
+    A CPC campaign holds its ads in an ad group; without the id every ad in the
+    bulk call is rejected.
+    """
+    promote.add_ads("C1", ["1", "2"], False, "G9")
+    assert "2 listing" in capsys.readouterr().out
+
+    sent = {}
+
+    def fake(method, path, body=None):
+        sent.update(method=method, path=path, body=body)
+        return {"responses": []}
+
+    import ebay_client                                            # noqa: E402
+    real, ebay_client.api_send = ebay_client.api_send, fake
+    try:
+        promote.add_ads("C1", ["1", "2"], True, "G9")
+    finally:
+        ebay_client.api_send = real
+    assert sent["path"].endswith("/bulk_create_ads_by_listing_id")
+    assert all(r["adGroupId"] == "G9" for r in sent["body"]["requests"])
+
+
+def test_nothing_is_sent_without_confirm(capsys):
+    """The default is propose-only. A dry run must not construct a client."""
+    import ebay_client                                            # noqa: E402
+
+    def explode(*a, **k):
+        raise AssertionError("a dry run must not call the API")
+
+    real, ebay_client.api_send = ebay_client.api_send, explode
+    try:
+        promote.create_campaign("T", 20.0, False, 25.0)
+        promote.add_ads("C1", ["1"], False, "G9")
+        promote.set_bidding("C1", "DYNAMIC", False)
+        promote.delete_campaign("C1", False)
+    finally:
+        ebay_client.api_send = real
+
+
+@pytest.mark.parametrize("val,want", [("$1,234.50", 1234.5), ("", 0.0), (None, 0.0)])
+def test_price_parsing(val, want):
+    assert promote._f(val) == want

--- a/tools/promote.py
+++ b/tools/promote.py
@@ -25,14 +25,25 @@ Items already carrying an ACTIVE ad in a RUNNING campaign are excluded — they
 are already promoted. Items in a PAUSED campaign are shown, because resuming
 that campaign is usually cheaper than building a new one.
 
-IT WRITES NOTHING. Not to eBay, not to the ledgers. It prints the plan and the
-exact API calls that would enact it, and stops. Creating a campaign, adding an
-ad, or setting a bid are all writes against a live account and stay your
-keystroke — the same shape as the PREP gate and list_edit's --confirm.
+BY DEFAULT IT WRITES NOTHING — it prints the plan and the exact API calls, and
+stops. Every write is opt-in per invocation and needs `--confirm`; without it
+each one prints what it would send. Creating a campaign, adding an ad and
+setting a bid are writes against a live account with money attached, so they
+stay a deliberate keystroke — the same shape as the PREP gate and list_edit's
+--confirm.
 
-    python tools/promote.py                      # the plan
+    python tools/promote.py                       # the plan, no writes
     python tools/promote.py --budget 20 --top 40
-    python tools/promote.py --json reports/promote_plan.json
+    python tools/promote.py --create "NAME" --budget 20 --confirm
+    python tools/promote.py --create "NAME" --auto-add-min 25 --confirm
+    python tools/promote.py --campaign ID --top 20 --add-ads --confirm
+    python tools/promote.py --campaign ID --bidding DYNAMIC --confirm
+
+AUTO-ADD AND A CURATED LIST ARE MUTUALLY EXCLUSIVE
+
+`--auto-add-min` hands membership to eBay: it re-checks the inventory daily and
+adds anything at or above that ask. The revenue ranking below then no longer
+decides what is promoted — the price floor does. Pick one deliberately.
 """
 from __future__ import annotations
 

--- a/tools/promote.py
+++ b/tools/promote.py
@@ -121,24 +121,213 @@ def suggestions(campaign_id: str) -> dict:
     return out
 
 
+def create_campaign(name: str, budget: float, confirm: bool,
+                    min_price=None, ad_rate: float = 10.0) -> str:
+    """Create a CPC (Priority) campaign. Returns its id.
+
+    `min_price` switches on `campaignCriterion`: eBay then re-checks the
+    inventory daily and adds any listing at or above that ask by itself. Without
+    it the campaign holds exactly the listings we add by id.
+
+    THE CRITERION CAN ONLY BE SET HERE. There is no criterion-update method on
+    the campaign resource, so a campaign created without it can never learn the
+    rule — it has to be deleted and rebuilt. That cost one rebuild already.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from ebay_client import api_send
+
+    # THE TWO MODELS ARE NOT INTERCHANGEABLE, AND THE RULE DECIDES THE MODEL.
+    #
+    # `campaignCriterion` -- the auto-add rule -- is refused on cost-per-click:
+    #   36151 'campaignCriterion' is not supported for CPC funding model.
+    # Auto-add exists only on the cost-per-sale (general strategy) model, which
+    # charges an ad rate when a promoted listing sells and takes no daily
+    # budget at all. So asking for auto-add IS asking for CPS; there is no
+    # combination that gives a daily-capped CPC campaign that fills itself.
+    cps = min_price is not None
+    body = {
+        "campaignName": name,
+        "marketplaceId": "EBAY_US",
+        "channels": ["ON_SITE"],
+        "startDate": (datetime.now(timezone.utc) + timedelta(minutes=2))
+                     .strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+    }
+    if cps:
+        body["fundingStrategy"] = {"fundingModel": "COST_PER_SALE",
+                                   "bidPercentage": f"{ad_rate:.1f}"}
+    else:
+        body["fundingStrategy"] = {"fundingModel": "COST_PER_CLICK"}
+        body["budget"] = {"daily": {"amount": {"value": f"{budget:.2f}",
+                                               "currency": "USD"}}}
+    if min_price is not None:
+        body["campaignCriterion"] = {
+            "criterionType": "INVENTORY_PARTITION",
+            "autoSelectFutureInventory": True,
+            # categoryScope is REQUIRED on any criterion-based campaign, even
+            # when the rule names no category (35039). MARKETPLACE = eBay's own
+            # category tree, STORE = the seller's store categories.
+            "selectionRules": [{"categoryScope": "MARKETPLACE",
+                                "minPrice": {"value": f"{min_price:.2f}",
+                                             "currency": "USD"}}],
+        }
+    if not confirm:
+        print("DRY — would POST /sell/marketing/v1/ad_campaign\n"
+              + json.dumps(body, indent=1))
+        return ""
+    r = api_send("POST", "/sell/marketing/v1/ad_campaign", body)
+    cid = str(r.get("campaignId") or "")
+    if not cid:                       # eBay answers 201 with a Location header
+        from ebay_client import api_send as _s
+        found = _s("GET", f"/sell/marketing/v1/ad_campaign/get_campaign_by_name"
+                          f"?campaign_name={name.replace(' ', '%20')}")
+        cid = str(found.get("campaignId") or "")
+    return cid
+
+
+def ensure_ad_group(campaign_id: str, bid: float, confirm: bool) -> str:
+    """A CPC campaign holds its ads in an AD GROUP, and needs one before any ad.
+
+    Found the hard way: bulk_create_ads_by_listing_id answers
+    `36210 No ad group found for ad group id null` when the campaign has none.
+    A cost-per-sale campaign takes ads directly; a cost-per-click one does not.
+
+    The group carries the default bid — what a click may cost — so this is the
+    number that decides spend, not the daily budget, which only caps it.
+    """
+    from ebay_client import api_send
+
+    try:
+        got = api_send("GET", f"/sell/marketing/v1/ad_campaign/{campaign_id}"
+                              f"/ad_group?limit=10").get("adGroups") or []
+        if got:
+            return str(got[0].get("adGroupId"))
+    except Exception:                                                # noqa: BLE001
+        pass
+    body = {"name": "Revenue core", "adGroupStatus": "ACTIVE",
+            "defaultBid": {"value": f"{bid:.2f}", "currency": "USD"}}
+    if not confirm:
+        print(f"DRY — would POST .../{campaign_id}/ad_group {json.dumps(body)}")
+        return ""
+    r = api_send("POST", f"/sell/marketing/v1/ad_campaign/{campaign_id}/ad_group", body)
+    gid = str(r.get("adGroupId") or "")
+    if not gid:
+        got = api_send("GET", f"/sell/marketing/v1/ad_campaign/{campaign_id}"
+                              f"/ad_group?limit=10").get("adGroups") or []
+        gid = str(got[0].get("adGroupId")) if got else ""
+    return gid
+
+
+def add_ads(campaign_id: str, listing_ids: list, confirm: bool,
+            ad_group_id: str = "") -> dict:
+    """Bulk-create ads by listing id. Up to 500 per call; we send far fewer."""
+    from ebay_client import api_send
+
+    body = {"requests": [
+        ({"listingId": str(l), "adGroupId": ad_group_id} if ad_group_id
+         else {"listingId": str(l)}) for l in listing_ids]}
+    if not confirm:
+        print(f"DRY — would POST .../{campaign_id}/bulk_create_ads_by_listing_id "
+              f"with {len(listing_ids)} listing(s)")
+        return {}
+    return api_send("POST", f"/sell/marketing/v1/ad_campaign/{campaign_id}"
+                            f"/bulk_create_ads_by_listing_id", body)
+
+
+def set_bidding(campaign_id: str, strategy: str, confirm: bool) -> None:
+    """FIXED -> DYNAMIC: eBay manages the bids and updates them daily.
+
+    The one bid automation the API has. Note what it costs: under DYNAMIC you
+    can still add keywords but can no longer set their bid values, so the ad
+    group's default bid stops being the ceiling you chose.
+    """
+    from ebay_client import api_send
+
+    body = {"biddingStrategy": strategy}
+    if not confirm:
+        print(f"DRY — would POST .../{campaign_id}/update_bidding_strategy {body}")
+        return
+    api_send("POST", f"/sell/marketing/v1/ad_campaign/{campaign_id}"
+                     f"/update_bidding_strategy", body)
+    print(f"  bidding strategy -> {strategy}")
+
+
+def delete_campaign(campaign_id: str, confirm: bool) -> None:
+    """Remove a campaign. Only ever for one just created and mis-shaped.
+
+    A campaign that has run is history, not scratch: END it and the record
+    survives. Deleting is for the case where the shape was wrong from the first
+    minute — which happens because `campaignCriterion` is create-time only.
+    """
+    from ebay_client import api_send
+
+    if not confirm:
+        print(f"DRY — would DELETE /sell/marketing/v1/ad_campaign/{campaign_id}")
+        return
+    try:
+        api_send("DELETE", f"/sell/marketing/v1/ad_campaign/{campaign_id}")
+    except Exception as e:                                           # noqa: BLE001
+        print(f"  delete refused ({str(e)[:70]}) — ending it first")
+        api_send("POST", f"/sell/marketing/v1/ad_campaign/{campaign_id}/end")
+        api_send("DELETE", f"/sell/marketing/v1/ad_campaign/{campaign_id}")
+    print(f"  campaign {campaign_id} deleted")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--budget", type=float, default=20.0, help="daily budget USD (default 20)")
     ap.add_argument("--top", type=int, default=40, help="how many listings to propose")
     ap.add_argument("--json", help="also write the plan here")
+    ap.add_argument("--create", metavar="NAME",
+                    help="create a CPC campaign with this name (needs --confirm to write)")
+    ap.add_argument("--add-ads", action="store_true",
+                    help="add the proposed listings to the campaign (needs --confirm)")
+    ap.add_argument("--campaign", help="operate on this existing campaign id")
+    ap.add_argument("--bid", type=float, default=0.25,
+                    help="default cost-per-click bid for the ad group (default 0.25)")
+    ap.add_argument("--auto-add-min", type=float, metavar="USD",
+                    help="on --create: eBay auto-adds any listing at or above "
+                         "this ask, re-checked daily (campaignCriterion)")
+    ap.add_argument("--ad-rate", type=float, default=10.0,
+                    help="cost-per-sale ad rate %%, used when --auto-add-min is set "
+                         "(default 10)")
+    ap.add_argument("--delete", metavar="ID", help="delete a campaign (needs --confirm)")
+    ap.add_argument("--bidding", choices=("FIXED", "DYNAMIC"),
+                    help="set the bidding strategy (needs --confirm)")
+    ap.add_argument("--confirm", action="store_true",
+                    help="actually write to eBay. Without it every write is a dry run.")
     a = ap.parse_args()
+
+    if a.delete:
+        delete_campaign(a.delete, a.confirm)
+
+    if a.create:
+        cid = create_campaign(a.create, a.budget, a.confirm,
+                              a.auto_add_min, a.ad_rate)
+        print(f"campaign: {cid or '(dry run)'}")
+        if cid:
+            a.campaign = cid
 
     live = live_listings()
     camps, ads = campaigns_and_ads()
     running = [c for c in camps if c.get("campaignStatus") == "RUNNING"]
     onsite = [c for c in camps if "ON_SITE" in (c.get("channels") or [])]
-    paused_onsite = [c for c in onsite if c.get("campaignStatus") == "PAUSED"]
+    paused_onsite = [c for c in onsite
+                     if c.get("campaignStatus") in ("PAUSED", "SCHEDULED")]
 
     # Which campaign to hang this on. Reusing a paused ON_SITE campaign keeps the
     # ads that are already in it and costs one resume; a new campaign is only
     # proposed when there is nothing to reuse.
     host = None
-    if running:
+    if a.campaign:
+        # An explicit campaign wins. A freshly created campaign is SCHEDULED,
+        # not RUNNING, until its start time passes — the status heuristics below
+        # would skip it and propose creating yet another one.
+        host = next((c for c in camps if c["campaignId"] == a.campaign), None)
+        action = f"explicit --campaign ({host.get('campaignStatus') if host else 'not found'})"
+    if host:
+        pass
+    elif running:
         host = running[0]
         action = "already running — add items to it"
     elif paused_onsite:
@@ -201,6 +390,23 @@ def main() -> int:
         print(f"       body: {{\"daily\": {{\"amount\": {{\"value\": \"{a.budget}\", \"currency\": \"USD\"}}}}}}")
     else:
         print("  POST /sell/marketing/v1/ad_campaign   (create one first)")
+
+    if a.bidding and a.campaign:
+        set_bidding(a.campaign, a.bidding, a.confirm)
+
+    if a.add_ads and host:
+        gid = ensure_ad_group(host["campaignId"], a.bid, a.confirm)
+        print(f"  ad group: {gid or '(dry run)'} · default bid ${a.bid:.2f}/click")
+        res = add_ads(host["campaignId"], [r["listing_id"] for r in pick],
+                      a.confirm, gid)
+        if a.confirm:
+            resp = res.get("responses") or []
+            ok = [x for x in resp if str(x.get("statusCode", "")).startswith("2")]
+            print(f"\n[eBay] {len(ok)}/{len(resp)} ads created")
+            for x in resp:
+                if x not in ok:
+                    print(f"   FAILED {x.get('listingId')}: "
+                          f"{json.dumps(x.get('errors'))[:160]}")
 
     if a.json:
         REPORTS.mkdir(exist_ok=True)


### PR DESCRIPTION
Completes the PROMOTE phase with the write path, built against a live account.
The default is still propose-only; every write is opt-in per invocation behind
`--confirm`.

## What's new

`--create`, `--add-ads`, `--bid`, `--ad-rate`, `--auto-add-min`, `--bidding`
and `--delete`. Each prints what it would send and stops unless `--confirm` is
passed.

## Three things the API only tells you by refusing

| error | what it means |
|---|---|
| `36210 No ad group found for ad group id null` | a COST_PER_CLICK campaign cannot hold ads directly — it needs an ad group first, and that group's default bid, not the daily budget, is what a click costs |
| `36151 'campaignCriterion' is not supported for CPC funding model` | the auto-add rule exists only on COST_PER_SALE, which charges an ad rate when a promoted listing sells and takes no daily budget at all |
| `35039 categoryScope is required` | required on any criterion-based campaign even when the rule names no category (MARKETPLACE = eBay's tree, STORE = the seller's) |

The second one is the load-bearing finding: **asking for auto-add is asking for
cost-per-sale.** There is no daily-capped click campaign that fills itself, so
`create_campaign` derives the funding model from whether a rule was requested
rather than treating them as independent choices.

And one the docs tell you: `campaignCriterion` is settable at create time only —
the campaign resource has no criterion-update method — so a campaign built
without it can never learn the rule and has to be rebuilt. That cost one rebuild
on the live account and is now called out in the docstring so it doesn't cost
another.

## What is NOT in here

No ROAS automation, because eBay has none: budget changes are an explicit
`updateCampaignBudget` call, and the only automations are `autoSelectFutureInventory`
(listing selection) and `updateBiddingStrategy` (FIXED/DYNAMIC, CPC only).
ROAS also cannot currently be measured on this account — `ad_report_metadata`
answers 403 and order fees arrive as one lump `totalMarketplaceFee` — so any
ROAS-triggered rule would be acting on a number we cannot compute.

## Live state this produced

Campaign `166478204014`, COST_PER_SALE at a 10% ad rate, auto-add for any
listing $25 and up, re-checked daily by eBay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
