### PR TITLE
fix(draft): periodicals ship Ground Advantage, not Media Mail

### DIFF
--- a/lib/SETUP_EBAY_API.md
+++ b/lib/SETUP_EBAY_API.md
@@ -239,7 +239,9 @@ live.
 - **`fulfillment_policy_id`** — the default (ground) policy, used for most items.
 - **`fulfillment_policy_id_media`** *(optional)* — a USPS **Media Mail** policy.
   When a draft's `primary_service` is Media Mail (DRAFT sets this for books /
-  magazines / comics / music / movies) and this policy is set, the offer uses
+  sheet music / recordings / computer media — **not** magazines, catalogs, or
+  anything carrying advertising, which are excluded by DMM 173.4.2) and this
+  policy is set, the offer uses
   it; otherwise it falls back to the ground policy. To create one, add a
   fulfillment policy with shipping service `USPSMedia` (free flat-rate) and
   paste its ID here.

--- a/lib/config.example.yaml
+++ b/lib/config.example.yaml
@@ -68,7 +68,10 @@ ebay:
     merchant_location_key: null
     fulfillment_policy_id: null          # default (ground) shipping policy
     fulfillment_policy_id_media: null    # optional: Media Mail policy; used for
-                                         # books/magazines/comics/music/movies
+                                         # books/sheet music/recordings/computer
+                                         # media. NOT magazines/catalogs/any paper
+                                         # with ads (DMM 173.4.2 excludes
+                                         # periodicals) — those ship ground.
     fulfillment_policy_id_local_pickup: null  # optional: local-pickup-only policy;
                                          # used for ship-risky items (fragile/over-
                                          # sized) marked fulfillment_mode LOCAL_PICKUP.
@@ -89,7 +92,10 @@ ebay:
     merchant_location_key: null
     fulfillment_policy_id: null          # default (ground) shipping policy
     fulfillment_policy_id_media: null    # optional: Media Mail policy; used for
-                                         # books/magazines/comics/music/movies
+                                         # books/sheet music/recordings/computer
+                                         # media. NOT magazines/catalogs/any paper
+                                         # with ads (DMM 173.4.2 excludes
+                                         # periodicals) — those ship ground.
     fulfillment_policy_id_local_pickup: null  # optional: local-pickup-only policy;
                                          # used for ship-risky items (fragile/over-
                                          # sized) marked fulfillment_mode LOCAL_PICKUP.

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -747,8 +747,10 @@ def _resolve_policies_and_location(creds: EbayCredentials) -> tuple[dict, str]:
         "payment": _ebay_extra("payment_policy_id"),
         "return": _ebay_extra("return_policy_id"),
     }
-    # Optional: a Media Mail fulfillment policy used for media items (books,
-    # magazines, comics, music, movies). Not required — falls back to default.
+    # Optional: a Media Mail fulfillment policy used for true media items
+    # (books, sheet music, recordings, computer media). NOT magazines /
+    # catalogs / anything carrying advertising — periodicals are excluded from
+    # Media Mail (DMM 173.4.2). Not required — falls back to default.
     policies["fulfillment_media"] = _ebay_extra("fulfillment_policy_id_media")
     # Optional: a Local-pickup-only policy used for ship-risky items (fragile /
     # oversized). Not required — only items the user marks LOCAL_PICKUP need it.
@@ -1004,9 +1006,10 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
        local-pickup policy.
     2. Else if `shipping.international: true` AND the item clears the
        dangerous-goods / weight gate, use the international (eIS) policy.
-    3. Else if `primary_service` is Media Mail (DRAFT sets this for
-       books/magazines/comics/music/movies) AND a media policy is configured,
-       use it.
+    3. Else if `primary_service` is Media Mail (DRAFT sets this for books /
+       sheet music / recordings / computer media — NOT magazines, catalogs, or
+       anything carrying advertising, which are excluded from Media Mail by
+       DMM 173.4.2) AND a media policy is configured, use it.
     4. Else use the default (USPS Ground) policy.
     Returns (chosen_fulfillment_id, messages).
 

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -289,10 +289,16 @@ the only case eBay quantity > 1.
 ### Service map
 Applies only when `fulfillment_mode: SHIP`. (LOCAL_PICKUP offers no parcel
 service — leave `primary_service` blank.)
-Books/catalogs/magazines/media → `USPSMediaMail`. ≤15 lb non-media →
-`USPSGroundAdvantage`. >15 lb / oversized → `UPSGround`. freight/movers →
-blank + flag (needs a quote) — also a strong local-pickup candidate (gate
-above).
+**Media Mail is narrower than it looks.** Books (bound, 8+ pages), sheet
+music, printed music/test materials, sound/video recordings, and computer
+media → `USPSMediaMail`. **Periodicals — magazines, newspapers, catalogs,
+mailers, any paper carrying advertising — are EXCLUDED from Media Mail**
+(DMM 173.4.2) and route to `USPSGroundAdvantage`, at 2–3× the postage
+(25–35% of a typical paper-lot sale price — feed that into the net-floor
+check above). A "book" that is really an ad-carrying catalog is a
+periodical, not a book. Other ≤15 lb non-media → `USPSGroundAdvantage`.
+>15 lb / oversized → `UPSGround`. freight/movers → blank + flag (needs a
+quote) — also a strong local-pickup candidate (gate above).
 
 ## Markdown body (description)
 

--- a/templates/listing-v1.md
+++ b/templates/listing-v1.md
@@ -139,7 +139,10 @@ shipping:
   domestic_shipping_type: "FREE_FLAT_RATE"
   # Primary service code (eBay Fulfillment policy). Common defaults:
   #   USPSGroundAdvantage    — default for items <15 lb
-  #   USPSMediaMail          — books, catalogs, magazines, sheet music
+  #   USPSMediaMail          — books, sheet music, recordings, computer media
+  #                            NOT magazines/catalogs/any paper with ads:
+  #                            periodicals are excluded (DMM 173.4.2) and
+  #                            ship USPSGroundAdvantage
   #   UPSGround              — heavy / oversized
   primary_service: "USPSGroundAdvantage"
   handling_time_days: 1        # business days from sale to shipment


### PR DESCRIPTION
## What

The DRAFT **Service map** routed `Books/catalogs/magazines/media → USPSMediaMail`. Magazines, newspapers, catalogs, mailers — anything carrying advertising — are periodicals and are **excluded from Media Mail under DMM 173.4.2**. They ship USPS Ground Advantage at 2–3× the postage, which on a cheap heavy paper lot is 25–35% of the sale price.

Media Mail now covers what it actually covers: bound books (8+ pages), sheet music, recordings, computer media.

## Where the same rule was encoded

- `prompts/draft.md` — the service map itself, with the postage note wired into the net-floor check directly above it
- `templates/listing-v1.md` — the `USPSMediaMail` field comment ("books, catalogs, magazines, sheet music")
- `lib/list_edit.py` — two sites describing the media fulfillment policy ("books, magazines, comics, music, movies")
- `lib/config.example.yaml` — `fulfillment_policy_id_media` comment, sandbox + production blocks
- `lib/SETUP_EBAY_API.md` — shipping-policies section

`prompts/review.md` says "Media Mail vs ground", which is neutral and needed no change.

## Not in this PR

No routing code changed — the policy picker keys off `primary_service`, which DRAFT sets, so fixing the map fixes the routing.

Six inventory item records had the wrong rule baked in (including the `esquire-gentleman` draft note claiming "magazine qualifies for Media Mail") and were corrected on disk; `inventory/` is gitignored, so those aren't in the diff. Five live listings currently sit on the Media Mail policy — Gilhe's catalogs `206449282835` / `206454286597` / `206454286643` and Decatur `206446247446` / `206446247475`. Per the user's call, **those are being left as-is**; only the local records were corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
