### PR TITLE
fix(prep): every occurrence of a per-frame flag counts, not just the last

### DIFF
--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -2113,6 +2113,22 @@ def _print_status(shoot: Path, m: dict) -> None:
     print(f"  review: {shoot / '.prep' / 'prep_review.jpg'}")
 
 
+# EVERY OCCURRENCE OF A PER-FRAME FLAG COUNTS, NOT JUST THE LAST ONE.
+#
+# These flags take NAME=VALUE pairs, and a generated command routinely repeats
+# the flag once per frame rather than listing thirteen values after one. With a
+# plain nargs="+" argparse keeps only the final occurrence and drops the rest
+# in silence: `--crop A=off --crop B=off` set B and left A cropped, with the log
+# showing one line and the operator believing both had been set. `action=
+# "append"` keeps them all; this flattens the list-of-lists back into the flat
+# pair list every run_* helper already expects.
+def _pairs(v) -> list:
+    """Flatten an appended nargs list-of-lists into one list (None -> [])."""
+    if not v:
+        return []
+    return [x for group in v for x in group]
+
+
 def main(argv=None) -> int:
     try:
         sys.stdout.reconfigure(encoding="utf-8")
@@ -2134,11 +2150,11 @@ def main(argv=None) -> int:
                     help="open a review stage: orientation | crop | color")
     ap.add_argument("--approve-stage", metavar="NAME",
                     help="sign off ONE stage (orientation | crop | color)")
-    ap.add_argument("--detail", nargs="+", metavar="NAME=on|off",
+    ap.add_argument("--detail", action="append", nargs="+", metavar="NAME=on|off",
                     help="mark named frames as detail macros (on) so the colour pass leaves "
                          "the non-subject pixels alone — use when the 'backdrop' is the item's "
                          "own card, box or mount; off hands them back to backdrop treatment")
-    ap.add_argument("--crop", nargs="+", metavar="NAME=off|on|padF",
+    ap.add_argument("--crop", action="append", nargs="+", metavar="NAME=off|on|padF",
                     help="override the crop decision for named frames")
     ap.add_argument("--sheet", action="store_true",
                     help="rebuild the rotation sheet from the manifest (no segmentation)")
@@ -2147,9 +2163,9 @@ def main(argv=None) -> int:
     ap.add_argument("--apply-repoint", action="store_true",
                     help="actually write draft.md for --repoint-draft")
     ap.add_argument("--approve", action="store_true", help="stamp approval (explicit operator yes only)")
-    ap.add_argument("--rotate", nargs="+", metavar="NAME=DEG", help="record a looked-at orientation answer (DEG is RELATIVE to what the sheet shows)")
-    ap.add_argument("--only", nargs="+", metavar="PRESET", help="render ONLY these presets (batch use; default renders all for comparison)")
-    ap.add_argument("--set-rotate", nargs="+", metavar="NAME=DEG", dest="set_rotate", help="record the ABSOLUTE subject angle — idempotent, use this in generated commands")
+    ap.add_argument("--rotate", action="append", nargs="+", metavar="NAME=DEG", help="record a looked-at orientation answer (DEG is RELATIVE to what the sheet shows)")
+    ap.add_argument("--only", action="append", nargs="+", metavar="PRESET", help="render ONLY these presets (batch use; default renders all for comparison)")
+    ap.add_argument("--set-rotate", action="append", nargs="+", metavar="NAME=DEG", dest="set_rotate", help="record the ABSOLUTE subject angle — idempotent, use this in generated commands")
     ap.add_argument("--gc", action="store_true",
                     help="list the regenerable byproducts an APPROVED shoot is still holding "
                          "(unchosen preset renders, answered ask panels); removes nothing")
@@ -2218,9 +2234,9 @@ def main(argv=None) -> int:
         print(f"  {catmod.describe(category)}")
 
     if args.rotate:
-        m = run_rotate(shoot, args.rotate)
+        m = run_rotate(shoot, _pairs(args.rotate))
     if getattr(args, "set_rotate", None):
-        m = run_rotate(shoot, args.set_rotate, absolute=True)
+        m = run_rotate(shoot, _pairs(args.set_rotate), absolute=True)
         _print_status(shoot, m)
         return 0
     if args.auto:
@@ -2237,10 +2253,10 @@ def main(argv=None) -> int:
         run_approve_stage(shoot, args.approve_stage)
         return 0
     if args.crop:
-        run_set_crop(shoot, args.crop)
+        run_set_crop(shoot, _pairs(args.crop))
         return 0
     if args.detail:
-        run_set_detail(shoot, args.detail)
+        run_set_detail(shoot, _pairs(args.detail))
         return 0
     if args.sheet:
         run_sheet(shoot, quiet=args.quiet)
@@ -2289,7 +2305,7 @@ def main(argv=None) -> int:
         print(f"PREP apply — {shoot}")
         if not load_manifest(shoot).get("photos"):
             run_check(shoot, args.aspect, args.pad, args.pop, subject, category, quiet=True)
-        m = run_apply(shoot, quiet=args.quiet, only=tuple(getattr(args, 'only', None) or ()))
+        m = run_apply(shoot, quiet=args.quiet, only=tuple(_pairs(getattr(args, 'only', None))))
         _print_status(shoot, m)
     return 0
 

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -1430,6 +1430,56 @@ def test_force_is_available_for_a_deliberate_overwrite():
         assert set(P.load_manifest(shoot)["photos"]) == {"mine"}
 
 
+def test_a_repeated_per_frame_flag_sets_every_frame():
+    """Thirteen --crop flags must set thirteen frames, not just the last one.
+
+    Observed on inventory/FR/books/coloring2: one invocation passed --crop
+    NAME=off once per frame, argparse kept only the final occurrence, and three
+    frames shipped cropped while the log showed a single REFUSED line. Printed
+    media makes this a live hazard — prompts/prep.md tells the operator to force
+    --crop <every frame>=off, so a silently dropped argument is the normal case,
+    not an edge one.
+    """
+    names = ["IMG_0.jpg", "IMG_1.jpg", "IMG_2.jpg"]
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=3)
+        m = P.load_manifest(shoot)
+        m["photos"] = {n: {"orientation": {"exif_angle": 0, "subject_angle": 0,
+                                           "applied": 0, "needs_ask": False},
+                           "crop": {"applied": True, "box": [0, 0, 10, 10]}}
+                       for n in names}
+        P.save_manifest(shoot, m)
+
+        argv = [str(shoot)]
+        for n in names:
+            argv += ["--crop", f"{n}=off"]
+        assert P.main(argv) == 0
+
+        photos = P.load_manifest(shoot)["photos"]
+        for n in names:
+            assert photos[n]["crop"]["applied"] is False, f"{n} kept its crop"
+            assert photos[n]["crop"]["operator"] is True, f"{n} was never set"
+
+
+def test_a_repeated_rotation_flag_sets_every_frame():
+    """Same accumulation contract for the other per-frame flags."""
+    names = ["IMG_0.jpg", "IMG_1.jpg"]
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=2)
+        m = P.load_manifest(shoot)
+        m["photos"] = {n: {"orientation": {"exif_angle": 0, "subject_angle": 0,
+                                           "applied": 0, "needs_ask": True}}
+                       for n in names}
+        P.save_manifest(shoot, m)
+
+        P.main([str(shoot), "--set-rotate", "IMG_0.jpg=90",
+                "--set-rotate", "IMG_1.jpg=270"])
+
+        photos = P.load_manifest(shoot)["photos"]
+        assert photos["IMG_0.jpg"]["orientation"]["subject_angle"] == 90
+        assert photos["IMG_1.jpg"]["orientation"]["subject_angle"] == 270
+
+
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items())
            if k.startswith("test_") and callable(v)]


### PR DESCRIPTION
## The bug

`python -m lib.photo_prep.prep <shoot> --crop A=off --crop B=off ... --crop M=off` set only the **last** frame. `argparse` with a plain `nargs="+"` keeps one occurrence and silently discards the others — no warning.

Observed 2026-08-26 on `inventory/FR/books/coloring2`: thirteen `--crop ...=off` flags printed a single `ZZ250013.JPG: crop -> REFUSED` line, and ZZ250001, ZZ250007 and ZZ250008 shipped cropped while the operator believed every frame had been set.

This is worst for printed media, where `prompts/prep.md` instructs the operator to force `--crop <every frame>=off` — so the repeated-flag form is the normal case, not an edge one.

## Wider than `--crop`

All five multi-value flags had it: `--crop`, `--detail`, `--rotate`, `--set-rotate`, `--only`. `--set-rotate` only *looked* correct because that invocation listed thirteen values after a single flag; repeat the flag and it drops all but one too (the new rotation test fails against the old code).

## The fix

- All five use `action="append", nargs="+"`.
- New `_pairs()` flattens the resulting list-of-lists into the flat pair list every `run_*` helper already expects.
- Both call forms work, and so does any mix: `--crop A=off B=off`, `--crop A=off --crop B=off`.

## Tests

- `test_a_repeated_per_frame_flag_sets_every_frame` — the thirteen-flag `--crop` case, asserting every frame ends `applied=False` / `operator=True`.
- `test_a_repeated_rotation_flag_sets_every_frame` — same accumulation contract on `--set-rotate`.

Full suite: 81/81 passing.

## Follow-up (not in this PR)

The coloring2 shoot still carries the three crops from the failed invocation; it needs re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)