### PR TITLE
Token diet, first slice: price.md rules-only + ebay_client money-path tests (#30)

### DIFF
--- a/prompts/price.md
+++ b/prompts/price.md
@@ -4,65 +4,41 @@ Obeys [`_shared.md`](_shared.md). Read it first.
 
 **Output:** `<shoot-dir>/price.txt` (overwrite).
 
-Find what the same or nearly-identical item actually sold for, establish
-a defensible price, and surface category-specific selling risks. Reads
-IDENTIFY records.
+Characterize the cleaned sold distribution, then place tiers on it. Stage B pulls
+two sold-market views (`best_match` = representative body; `price_high` =
+ceiling); [`lib/price_stats.py`](../lib/price_stats.py) does the filtering +
+statistics. An exact comp, when found, short-circuits the distribution and
+anchors Recommended directly. Rationale + history:
+[reference/price-notes.md](reference/price-notes.md).
 
-**Pricing model (v2 — distribution-based):** the goal is no longer "pick
-the strongest comp." It is **characterize the cleaned sold distribution,
-then place tiers on it.** Stage B pulls two complementary views of the sold
-market (`best_match` = the representative body; `price_high` = the ceiling),
-[`lib/price_stats.py`](../lib/price_stats.py) does the deterministic
-filtering + statistics, and the tiers trace to a sample size + percentiles
-rather than a hand-picked comp. Full rationale:
-[docs/price-strategy-v2.md](../docs/price-strategy-v2.md). The exact-match
-hunt below still runs — an exact comp, when one exists, short-circuits the
-distribution and anchors Recommended directly. All tiers are placed on the
-**DELIVERED (sold + shipping) basis** whenever the listing is free-shipping
-(our default) — see "Delivered-price basis" below; never anchor a free-shipping
-price on a comp's item-only `sold_price`.
-
-## Autonomy (Goal: dig for the exact match, don't ask permission to look)
-
-No step in PRICE gates or stops. v2 made you propose queries and wait,
-and Apify used to require cost approval — v3 does neither. You construct
-queries, run the stages, and iterate them yourself. PRICE runs
-end-to-end without ever stopping for the user.
+**Autonomy:** no step gates or stops. Construct queries, run the stages, iterate
+yourself, end-to-end.
 
 ## Selling-unit awareness
 
-Query the selling unit, not pieces. `pair` → include "pair";
-`set` → "set"/"set of N"; `lot` → "lot of N"/"mixed lot" (lots sell at a
-discount to sum-of-parts — single-item comps ×N are Tier C reference
-only); `duplicate` → price one piece (CURATE scales). All quoted prices
-are per-listing-unit except `duplicate` (per-piece).
+Query the selling unit, not pieces. `pair` → include "pair"; `set` → "set"/"set
+of N"; `lot` → "lot of N"/"mixed lot" (lots discount to sum-of-parts —
+single-item comps ×N are Tier C reference only); `duplicate` → price one piece
+(CURATE scales). Quoted prices are per-listing-unit except `duplicate`
+(per-piece).
 
-## Delivered-price basis (anchor on sold + shipping — the default)
+## Delivered-price basis (default)
 
-eBay comps almost always charge BUYER-PAID shipping, so a comp's `sold_price` is
-the ITEM price only — the buyer's real outlay is `sold_price + shipping_cost`, the
-**delivered price**. Our listings default to FREE shipping, so OUR list price IS the
-delivered price. Comparing our free-ship price to a comp's item-only `sold_price`
-understates the comp by its shipping (often $10–25 on breakables / heavier items)
-and makes a fair price look like a push above the market. So:
+A comp's `sold_price` is item-only; the buyer's real outlay is
+`sold_price + shipping_cost` = **delivered**. Our listings default to free
+shipping, so our list price IS the delivered price. Never anchor a free-shipping
+price on a comp's item-only `sold_price`.
 
-1. **Anchor on the DELIVERED price.** Stage B carries `total_price` =
-   `sold_price + shipping_cost`. `lib/ebay_sold_browse.py` computes and saves it
-   automatically — the in-page extractor reads "+$24.25 delivery" → 24.25 and
-   "Free delivery" → 0 straight off the card, so `total_price` is always present.
-2. **Run the distribution on the delivered basis when the listing is free-shipping**
-   (the default): `price_stats.py … --price-field total`. The delivered tiers are the
-   headline and decide the sale price; an item-only run (`--price-field sold`) is at
-   most a secondary read. (If the listing will use buyer-paid / calculated shipping
-   instead, anchor item-only — then our list price is the item price and the buyer
-   covers shipping exactly like the comps.)
-3. **Translate to NET-TO-US.** Free shipping means we absorb postage AND pay eBay
-   fees on the full delivered amount: `net ≈ list − our_postage − fees`
-   (postage from IDENTIFY's weight/dims). **Fee rate — measured, not assumed.**
-   This prompt used to say 13% + $0.40; across 92 real sales the account actually
-   paid **16.0% blended**, and the rate is regressive, so use the band:
+1. Anchor on delivered: Stage B saves `total_price` = sold + shipping.
+2. Free-shipping listing → `price_stats.py … --price-field total` is the
+   headline run; item-only (`--price-field sold`) is secondary at most.
+   Buyer-paid/calculated shipping listing → anchor item-only.
+3. Translate to **net-to-us** for each candidate price:
+   `net ≈ list − our_postage − fees` (postage from IDENTIFY weight/dims).
+   Fee band (measured; re-measure with `python lib/report.py --performance`
+   when bands move — never quote from a remembered rate):
 
-   | delivered price | fee rate to use |
+   | delivered price | fee rate |
    |---|---|
    | under $25 | 18% |
    | $25–50 | 17.5% |
@@ -70,283 +46,169 @@ and makes a fair price look like a push above the market. So:
    | $100–250 | 16.5% |
    | $250+ | 15% |
 
-   Re-measure with `python lib/report.py --performance` (REPORT, Function 7) and
-   update this table when the bands move — never quote a net-to-us figure from a
-   remembered rate. Surface net-to-us for
-   each candidate price so the user sees what each option actually returns — two
-   listings at the same delivered price net differently if one ships a 1 lb item and
-   the other a 10 lb one.
+State the basis (`delivered` / `item-only`) on the Distribution line.
 
-State the basis used (`delivered` / `item-only`) on the Distribution line so the
-choice is visible at REVIEW.
+## Silver — category override: rarity-check, exact comp, push HIGH
 
-## Silver — rarity double-check, exact comp, push HIGH (category override)
+Trigger: "silver" in ANY sense, regardless of content — sterling/.925, coin,
+.800/.835/.900, hallmarked, silver-on-copper, silverplate/EPNS, nickel
+silver/German silver/alpaca/silver-tone. No exemptions. Then:
 
-Silver gets special handling. In practice our silver has been UNDER-priced and
-sells immediately — money left on the table. The trigger is the word "silver" in
-ANY form, **regardless of precious-metal content** — base-metal "silver" counts
-too: sterling / .925, coin silver, .800/.835/.900 continental, hallmarked silver,
-silver-on-copper, silverplate / EPNS, AND **nickel silver / German silver /
-alpaca / silver-tone / "silver" plate over base metal**. Do NOT exempt a piece
-just because it isn't precious — push high on all of it. Whenever IDENTIFY tags
-an item as silver in any of these senses, apply ALL of the following and OVERRIDE
-the plain distribution defaults:
+1. **Rarity double-check (mandatory).** Work maker/hallmark/pattern/assay +
+   weight. Sought maker, rare pattern, early assay, unusual form, matched
+   pair/set, heavy gauge? Solid silver: compute the **melt floor**
+   (troy-oz × spot × purity) — price never below melt. One-line `Rarity:`
+   verdict in price.txt.
+2. **Hunt the EXACT comp harder.** No era-peer settling; run the full ladder,
+   widen the bracket rather than fall back. Silver is identifiable — an exact
+   maker+pattern+form comp anchors the ceiling.
+3. **Push HIGH by default.** Working/list price = **Push-high (vetted ceiling)**
+   tier, NOT median, with Best Offer ON and auto-decline at Recommended.
+   Bounded by vetted comps — honest ceiling only (plate/silver-on-copper stays
+   modest; solid never below melt).
 
-1. **Rarity double-check (mandatory).** Before settling a price, explicitly work
-   the maker / hallmark / pattern / assay + (for solid silver) the weight. Ask:
-   is THIS piece scarce — a sought maker (Tiffany, Georg Jensen, Gorham, Jensen,
-   Kirk, etc.), a rare or discontinued pattern, an early assay date, an unusual
-   form, a matched pair/set, or heavy gauge? For solid silver compute the **melt
-   floor** (troy-oz × spot × purity) — price NEVER drops below melt. Record a
-   one-line `Rarity:` verdict in price.txt.
-2. **Hunt the EXACT comp harder.** Do NOT settle for an era-peer on silver. Run
-   the full query ladder, and if Stage B is thin, descend the ladder and widen
-   the bracket rather than falling back — an exact maker+pattern+form comp
-   anchors the ceiling. Silver is identifiable; an exact match usually exists if
-   you dig.
-3. **Push HIGH by default.** For silver the provisional working / list price is
-   the **Push-high (vetted ceiling)** tier, NOT the median — with Best Offer ON
-   and auto-decline at the Recommended/median (the DRAFT Best Offer gate does
-   this automatically once list > Recommended). List at the top of the supported
-   range and let Best Offer capture the market; "sold immediately" means we
-   listed too low. Still bounded by VETTED comps — push to the honest ceiling,
-   never invent value above it (plate / silver-on-copper ceilings stay modest;
-   solid silver never below melt).
+State `SILVER: push-high strategy applied` in price.txt.
 
-State `SILVER: push-high strategy applied` in price.txt so the choice is visible
-at the REVIEW gate.
+## The exact-match hunt (before any era-peer fallback)
 
-## The exact-match hunt (run before any era-peer fallback)
+Escalate only as each stage dries up; never stop to ask.
 
-For each item, hunt the exact match, escalating only as each stage dries
-up. Do NOT settle for an era-peer until the hunt is exhausted. Every
-stage is autonomous — PRICE never stops to ask.
+1. **Canonical query** — IDENTIFY's short Brand+Type+Era (not the marks prose).
+   Bare words, no punctuation/filler, 5–9 high-signal keywords. Era only if a
+   printed date is visible in a photo.
 
-1. **Canonical query** — built from IDENTIFY's short Brand+Type+Era
-   values (not the Distinguishing-marks prose). Bare words; drop
-   punctuation and filler ("with/and/the"). 5–9 high-signal keywords —
-   real seller-title density, so exact comps can exist. Include era ONLY
-   if a printed date is visible in a photo.
+2. **Stage A — WebSearch** (free, broad). Tag `[A — WebSearch]`. Log each usable
+   hit to `<shoot-dir>/comps.csv` as stage A.
 
-2. **Stage A — WebSearch** (free, ~5s, broad). Casts wide across the open
-   web + marketplaces. Tag `[A — WebSearch]`. **Log each usable hit to
-   `<shoot-dir>/comps.csv` as stage A** (see "Saved comp artifacts").
+3. **Stage B — eBay sold via the LOGGED-IN BROWSER (dual query — the core).**
+   Tag `[B — Browser]`. Free, no gate.
 
-3. **Stage B — eBay sold via the LOGGED-IN BROWSER (DUAL QUERY — the v2 core).**
-   The default direct-eBay comp source; no gate. Tag `[B — Browser]`. **Free.**
-
-   > **APIFY IS DISABLED** (2026-08-15, `apify.enabled: false`). Every actor
-   > we depended on was eventually blocked or deleted, and a blocked actor
-   > returns 0 items with a SUCCEEDED status — indistinguishable from a thin
-   > market. Calling it now raises `ApifyDisabledError`. Do not re-enable it
-   > to "just get comps"; use the browser.
-
-   **The anonymous in-app browser does NOT work for this** — eBay serves it a
-   "Security Measure / verify yourself" CAPTCHA. Never try to solve it. Use
-   **claude-in-chrome** (the user's real, logged-in Chrome), which is not
-   challenged.
+   > **APIFY IS DISABLED** (`apify.enabled: false`; raises
+   > `ApifyDisabledError`). Do not re-enable it; use the browser.
+   > The anonymous in-app browser gets a CAPTCHA — never solve it. Use
+   > **claude-in-chrome** (the user's logged-in Chrome).
 
    Procedure:
-   1. `python lib/ebay_sold_browse.py "<query>" --urls [--ladder]` — prints
-      the `best_match` (representative body) and `price_high` (**ceiling,
-      delivered basis**) URLs.
-   2. Navigate **claude-in-chrome** to each URL.
-   3. Run the in-page extractor: `python lib/ebay_sold_browse.py --js` prints
-      it; paste that into `javascript_tool`. It returns
-      `{ok, header, n, rows:[…]}` — one row per real sold listing, with the
-      item URL and thumbnail.
-   4. Save that JSON and
+   1. `python lib/ebay_sold_browse.py "<query>" --urls [--ladder]` → the two
+      sold-search URLs (`best_match` + `price_high`, delivered-basis ceiling).
+   2. Navigate claude-in-chrome to each URL.
+   3. `python lib/ebay_sold_browse.py --js` prints the in-page extractor; paste
+      into `javascript_tool` → `{ok, header, n, rows:[…]}`.
+   4. Save the JSON;
       `python lib/ebay_sold_browse.py "<query>" --ingest-json <file> --sort <sort>`
-      → writes a run JSON in the SAME shape the Apify path produced.
-   5. `price_stats.py` and `comps_csv.py` consume it unchanged.
-   6. **ALWAYS give the user both URLs in your reply** so they can browse the
-      identical comp set themselves. This is not optional — they price with
-      you, not after you.
+      → run JSON for `price_stats.py`/`comps_csv.py`.
+   5. **ALWAYS give the user both URLs in your reply** — they price with you,
+      not after you.
 
-   `--parse <textfile>` is a fallback for when JS execution isn't available.
-   It cannot recover item URLs or thumbnails; prefer the extractor.
+   `--parse <textfile>` is the no-JS fallback (no URLs/thumbnails).
+   `Best offer accepted` on a comp ⇒ the ask wasn't the clearing price — treat
+   as a **soft** ceiling. Do NOT "simplify" the extractor's anti-scrape guards
+   (fake-id placeholder cards, reversed `derosnopS` sponsored tag, welded
+   spans — see [reference/price-notes.md](reference/price-notes.md)).
 
-   What the browser gives that no actor did: **`Best offer accepted`** — a
-   sale at that flag means the ASK was not the clearing price, so treat it as
-   a **soft** ceiling, not a hard one. Also delivered shipping, seller
-   feedback score + %, bid counts, item URLs and thumbnails. Measured on a
-   live 60-comp page: every field populated, 0 missing.
+   No Chrome MCP ⇒ record `B — UNAVAILABLE: no logged-in browser`, fall through
+   to Stage A only. Never silently skip B; never re-enable Apify.
 
-   **Anti-scrape traps the extractor already handles — do not "simplify" them
-   away.** eBay salts results with placeholder cards pointing at a FAKE item
-   id (`/itm/123456`); the extractor requires a >=9-digit id. eBay also
-   renders "Sponsored" REVERSED as `derosnopS`, so it can't be string-matched
-   — and it appears on nearly every card, so it is useless as a filter.
-   Finally, adjacent spans have no whitespace between them, so raw
-   `textContent` welds them ("Sell one like this" + seller name →
-   `thiscelticitaliansilver`); the extractor joins leaf nodes with newlines
-   instead.
+   **Zero comps:** `challenge:true` ⇒ verification page — don't solve, reload
+   and retry. `n:0` on a page that visibly has results ⇒ selector drift — fix
+   the extractor, don't guess. A real "0 results" page ⇒ thin market — descend
+   the ladder.
 
-   **If the browser path is unavailable** (no Chrome MCP in this environment):
-   record `B — UNAVAILABLE: no logged-in browser` in the Research log and fall
-   through to Stage A only. Do NOT silently skip B, and do NOT re-enable Apify.
+4. **Thin → query ladder** (internal to PRICE; never changes draft/SEO/SKU):
+   - L1: Brand + Type + Era [+ one distinguishing word]
+   - L2: Type + material
+   - L3: category noun (+ material)
 
-   **Zero comps.** With the browser there is no silent-block ambiguity — you
-   can SEE the page. If the extractor returns `challenge:true`, eBay served a
-   verification page: do NOT solve it, reload in Chrome and retry. If it
-   returns `n:0` on a page that visibly has results, the `li.s-card` selector
-   has drifted again — fix the extractor, don't guess a price. A real 0 on a
-   page that says "0 results" is a genuinely thin market: descend the ladder.
+   Run the dual query at L1; if unique surviving comps < 3, step down and
+   re-run. Log each formulation in the Hunt line. `price_high` often has data
+   when `best_match` is empty — `price_stats` then uses it as the
+   representative set (flagged).
 
-4. **Thin results → broaden the query (query ladder, NOT a new draft).** The
-   comp *search query* is internal to PRICE; broadening it never changes the
-   `draft.md`, SEO title, SKU, or ledger record. Build queries from
-   IDENTIFY's short Brand / Type / Era / Category fields as a specificity
-   ladder:
-   - **L1 (specific):** Brand + Type + Era [+ one distinguishing word].
-   - **L2 (broader):** Type + material; drop era + modifiers.
-   - **L3 (broadest):** category noun (+ material).
+5. **Stage C — Chrome sold-search browse (only if confidence still LOW after
+   A+B):** no exact match or <~3 usable USD comps; dispersion >2× among
+   candidate anchors; Stage B unavailable/suspect; or high-value item. URL with
+   `LH_Sold=1&LH_Complete=1&_sop=3`; rows prefixed "Sold <date>"; skip
+   Sponsored/house ads. Tag `[C — Chrome]`. If per-item hrefs can't be
+   captured, cite the sold-search URL and say so. Log to comps.csv as stage C.
 
-   Run the dual query (`best_match` + `price_high`) at L1. If the combined
-   unique comps that survive `price_stats` filters are **below 3**, step down
-   (L2, then L3) and re-run, until enough comps or the ladder is exhausted.
-   Log each formulation in the Hunt line. Note: `price_high` often returns
-   data when `best_match` is empty (observed: mask-red `best_match`=0,
-   `price_high`=25) — an empty `best_match` doesn't block, since
-   `price_stats` uses `price_high` as the representative set when `best_match`
-   is empty (flagged in its output).
+6. **Active fallback** (zero sold matches only): active listings, tag
+   `[active — ASKING PRICE]`, Tier C ceiling-context only.
 
-5. **Stage C — Chrome → eBay sold (OPTIONAL — low-confidence only).** The
-   browser browse path is no longer routine. Invoke it ONLY when
-   confidence is still LOW after A+B — i.e. any of:
-   - no exact match, or fewer than ~3 usable USD sold comps;
-   - dispersion too wide to anchor a tier (roughly >2× spread among the
-     candidate anchors);
-   - Apify was unavailable/suspect and you need direct-eBay data;
-   - high-value item where a wrong anchor is costly and a ~60s second read
-     is worth it.
+7. **Cross-reference:** A vs B (vs C). Agreement = high confidence; divergence
+   = trust direct-eBay sold (B/C) over A.
 
-   When triggered: SOLD URL with `LH_Sold=1&LH_Complete=1&_sop=3`. Extract
-   rows prefixed "Sold <date>"; skip Sponsored / "Shop on eBay" house ads.
-   Tag `[C — Chrome]`. `get_page_text` gives titles/prices/dates but not
-   per-item URLs; when you can't capture each href (via `read_page`/
-   `find`), cite the SOLD-search URL as the verifiable source and say so.
-   Subject to browser read-tier limits (see [list_edit_chrome.md](list_edit_chrome.md)).
-   **Log each comp to `<shoot-dir>/comps.csv` as stage C** (see "Saved comp
-   artifacts").
+Only after the hunt dries up, fall back to the closest era-peer — and state how
+hard you looked. An exact match beats any era-peer; commit to it (per _shared).
 
-6. **Active fallback** (only when sold returns zero direct matches): drop
-   the sold filters, capture active listings, tag `[active — ASKING
-   PRICE]`, treat as Tier C ceiling-context only.
+## Tooling — CLI contracts (do NOT read the .py source)
 
-7. **Cross-reference** A vs B (vs C if it ran): agreement = high-confidence
-   anchor; divergence = trust the direct-eBay sold source (B/C) over A's
-   broad web results.
+`python lib/ebay_sold_browse.py`:
+- `"<query>" --urls [--ladder] [--condition <new|used>]` → the two URLs.
+- `--js` → the in-page extractor JS (returns `challenge:true` on a
+  verification page — don't solve it).
+- `"<query>" --ingest-json <file> --sort <best_match|price_high> [--page N] --save-dir <shoot-dir>`
+  → field-coverage line + `Saved results: <path>`.
+- `--parse <pagetext.txt>` fallback.
+- Saved JSON: `comps` list with `sold_price`, `total_price`, `shipping_cost`,
+  `title`, `url`, `item_id`, `thumbnail`, `sold_date`, `listing_type`,
+  `bids_count`, `bo_accepted`, `seller_username`, `seller_feedback_score`/`_pct`;
+  top-level `charm_price_share` / `currency_leak_suspected`.
 
-Only after the hunt dries up do you fall back to the closest era-peer —
-and then state how hard you looked ("3 formulations, A+B+C, no exact
-match"). Per _shared, an exact match found this way beats any era-peer;
-commit to it.
-
-## Tooling — CLI contracts (use these; do NOT read the .py source)
-
-Everything PRICE needs from `lib/` is below — treat it as the interface and
-don't open the implementation files (reading them is wasted tokens). Stage B
-runs twice per item (`best_match` + `price_high`) through the user's logged-in
-Chrome; every save runs the charm-price currency check + flags a suspected FX
-leak. No token, no cost, no actor. No Chrome MCP ⇒ Stage B `UNAVAILABLE`.
-
-`python lib/ebay_sold_browse.py` — eBay sold comps via the browser:
-- URLs: `"<query>" --urls [--ladder] [--condition <new|used>]` — prints the
-  `best_match` + `price_high` sold-search URLs. **Give these to the user.**
-- extractor: `--js` — prints the in-page JS. Paste into claude-in-chrome's
-  `javascript_tool` on each loaded page; returns `{ok, header, n, rows:[…]}`.
-  If it returns `challenge:true`, eBay wants verification — do NOT solve it.
-- ingest: `"<query>" --ingest-json <file> --sort <best_match|price_high> [--page N] --save-dir <shoot-dir>`
-  → prints a field-coverage line (urls / delivered / seller / Best-Offer-accepted
-  / auctions) and `Saved results: <path>`.
-- fallback: `--parse <pagetext.txt>` when JS isn't available (no URLs/thumbnails).
-- Saved JSON has a `comps` list with `sold_price`, `total_price` (=sold+shipping),
-  `shipping_cost`, `title`, `url`, `item_id`, `thumbnail`, `sold_date`,
-  `listing_type`, `bids_count`, `bo_accepted`, `seller_username`,
-  `seller_feedback_score`/`_pct`, plus top-level `charm_price_share` /
-  `currency_leak_suspected`. Same shape the Apify path wrote, so `price_stats.py`
-  and `comps_csv.py` are unchanged.
-
-`python lib/price_stats.py` — distribution tiers from the saved JSON(s):
+`python lib/price_stats.py`:
 - `--best-match <bm.json> [--price-high <ph.json>] --unit <single|pair|set|lot|duplicate> --condition <new|used> [--require-tokens <tok>...] [--price-field <sold|total>]`
-- prints the Distribution line (n / median / IQR / dispersion), vetted ceiling, the three tiers, a confidence label, and the per-filter drop log. `--price-field total` for free-ship listings (default — see Delivered-price basis). Fold its block into `price.txt`; n<3 ⇒ confidence `thin`, fall back to the closest era-peer (it says so).
+- Prints the Distribution line (n/median/IQR/dispersion), vetted ceiling, three
+  tiers, confidence, per-filter drop log. `--price-field total` for free-ship.
+  Fold the block into `price.txt`; n<3 ⇒ `thin` ⇒ era-peer fallback.
 
 ## Saved comp artifacts (every stage leaves a reviewable record)
 
-The user reviews the raw research, so each stage persists its comps:
-
-- **Stage B (Browser)** → **two** JSONs, one per sort, saved beside `price.txt`
-  by `--save-dir <shoot-dir>` (live run auto-saves; MCP path saves via
-  `--ingest`). `price_stats.py` reads both.
-- **Stages A (WebSearch) and C (Chrome)** → rows in **`<shoot-dir>/comps.csv`**,
-  the single spreadsheet the user opens to review every comp across sources.
-  Append each usable comp with `lib/comps_csv.py`:
+- **Stage B** → two JSONs (one per sort) beside `price.txt` via `--save-dir`.
+- **Stages A + C** → rows in `<shoot-dir>/comps.csv` via:
 
       python lib/comps_csv.py --shoot-dir <dir> --item <N> --stage A \
         --query "<q>" --price <p> --title "<t>" --url "<url>" \
         --sold-date <YYYY-MM-DD> --condition "<c>" --note "<why>"
 
-  (stage `C` for Chrome). **No shell?** Write `<shoot-dir>/comps.csv`
-  directly with the Write tool using this exact header:
+  No shell? Write comps.csv directly, exact header:
   `captured_at,item,stage,query,price,title,sold_date,condition,listing_type,url,note`
-- **Unify (recommended):** fold Stage B into the same CSV so one file holds
-  all three —
-  `python lib/comps_csv.py --shoot-dir <dir> --from-apify-json <run.json>`.
-- **Fresh per run:** `python lib/comps_csv.py --shoot-dir <dir> --reset`
-  once at the start of pricing an item, before appending.
+- Unify: `python lib/comps_csv.py --shoot-dir <dir> --from-apify-json <run.json>`.
+- Fresh per run: `--reset` once before appending.
+- A priceless comp (context hit, asking price) still gets a row — blank price,
+  reason in `note`.
 
-A comp with no price (a WebSearch context hit, a dealer asking price) still
-gets a row — leave `price` blank and say why in `note`.
+## URLs (mandatory — the user verifies comps by clicking)
 
-## URLs (mandatory — the user verifies comps by clicking them)
+A comp without a URL is not a comp. Direct `ebay.com/itm/<id>` URLs; sold-search
+URL only when a per-item href genuinely can't be captured (say so). Every output
+ends with the consolidated Comp URLs block; never a bare price without its URL.
 
-A comp without a URL is not a comp. Use **direct per-item** `ebay.com/itm/<id>`
-URLs (Stage B returns one per comp; Stage A / Chrome hrefs too); fall back to the
-sold-search URL only when a per-item href genuinely can't be captured (e.g.
-Chrome `get_page_text`) — and say so. Every output also ends with the
-consolidated **Comp URLs** block (exact/near-exact first, then ceiling/context,
-then the sold-search URL — format under Output); never list a bare price without
-its URL there.
+## Research log (MANDATORY — proof every stage actually ran)
 
-## Research log (MANDATORY — proof every search type actually ran)
-
-Every PRICE run, for every item, emits a Research log accounting for ALL
-THREE stages explicitly. This is non-negotiable evidence: it shows what
-research happened, not just the comps that survived. Stages A and B run on
-EVERY item; C is conditional. Each stage is `RAN` (with proof) /
-`SKIPPED` / `UNAVAILABLE` (with a reason) / `NOT TRIGGERED` (C only).
-
-(Note: "Stage A/B" = the search METHOD — WebSearch / logged-in Chrome.
-Don't confuse with the comp-quality "Tier A/B/C" further down.)
+Per item, account for all three stages: `RAN` (with proof) / `SKIPPED` /
+`UNAVAILABLE` (reason) / `NOT TRIGGERED` (C only). (Stage A/B/C = search
+method; distinct from comp-quality Tier A/B/C.)
 
     Research log — Item <N>
       A · WebSearch : RAN — query "<q>" — <n> hits — <one-line finding> — logged to comps.csv
-      B · Apify     : RAN via <MCP|CLI> — query "<q>" — best_match run <id> (<n>) + price_high run <id> (<n>) — USD-validated (charm <x>%) — saved 2 JSONs — price_stats n_kept=<n>, conf=<good|partial|thin>
-                      [ALT] UNAVAILABLE — <no Apify MCP tool AND no shell/egress | api.apify.com egress blocked (sandbox proxy) | no token | CurrencyLeakError>
-                      [ALT] THIN (verified) — 0 comps, control query "<q>" returned <n> — backend healthy, market genuinely empty
-                      [ALT] BLOCKED — 0 comps AND control query "<q>" returned <n> (< 5) — backend down, NOT thin; Stage B contributes NO tier
-                      [NOTE] served by FALLBACK <actor> — primary returned 0 (silently blocked)
-                      (run ids come from each sort's MCP result / CLI `Apify run:` line; no `pip install` needed)
+      B · Browser   : RAN — query "<q>" — best_match n=<n> + price_high n=<n> — saved 2 JSONs — price_stats n_kept=<n>, conf=<good|partial|thin>
+                      [ALT] UNAVAILABLE — <no claude-in-chrome in this environment | challenge page persisted>
+                      [ALT] THIN — dual query ran, page says "0 results" — market genuinely empty (ladder descended to L<k>)
+                      [ALT] BLOCKED — extractor n:0 on a page with visible results — selector drift; Stage B contributes NO tier until fixed
       C · Chrome    : NOT TRIGGERED — confidence OK (price_stats conf good/partial)
-                      [ALT] RAN — <low-confidence trigger: conf=thin or dispersion too wide> — <n> rows — logged to comps.csv
-                      [ALT] UNAVAILABLE — <no browser/Chrome MCP in this environment>
+                      [ALT] RAN — <trigger> — <n> rows — logged to comps.csv
+                      [ALT] UNAVAILABLE — <reason>
 
-Hard rules for the log:
-- **A and B must show `RAN` on every item.** If either is `SKIPPED`/
-  `UNAVAILABLE`, that is a flagged problem — also append a line to
-  `NEEDS_REVIEW.md` so the user sees research was incomplete.
-- **B's `RAN` line MUST carry both run ids** (best_match + price_high — proof
-  it hit the Apify backend). No run id ⇒ it did not run ⇒ write
-  `UNAVAILABLE — <reason>`, never `RAN`. (If a thin/empty market means only
-  one sort returned data, note which and why.)
-- **C must be accounted for** — `NOT TRIGGERED` + why, `RAN` + trigger, or
-  `UNAVAILABLE` + why. Never omit the C line.
-- The log records what you DID; the tiers below record what you CONCLUDED.
+Hard rules:
+- A and B must show `RAN` on every item; otherwise it's a flagged problem —
+  also append to `NEEDS_REVIEW.md`.
+- B's `RAN` line must carry both per-sort counts + the saved-JSON proof. No
+  saved JSONs ⇒ it did not run ⇒ `UNAVAILABLE — <reason>`, never `RAN`.
+- C is always accounted for — never omit the line.
+- The log records what you DID; the tiers record what you CONCLUDED.
 
 ## Output
 
-Lead with the headline, then the Research log, then comps, then tiers.
+Lead with the headline, then Research log, comps, tiers.
 
     Max supported price: $X   [anchored on: <exact match | era-peer + gap>]
 
@@ -354,143 +216,99 @@ Per item:
 
     === PRICE — Item <N> (<short name>) ===
     Comps refreshed: YYYY-MM-DD   ·   Data quality: good / partial / thin
-    Research log:  (the A/B/C block above — REQUIRED)
-    Hunt: <one line — ladder levels + formulations tried, sources, exact-match yes/no>
-    Distribution: n=<k> median=$<m> IQR=$<p25>–$<p75> ceiling=$<c> dispersion=<d>
-                  (best_match run <id> + price_high run <id>)
+    Research log:  (the A/B/C block — REQUIRED)
+    Hunt: <one line — ladder levels + formulations, sources, exact-match yes/no>
+    Distribution: n=<k> median=$<m> IQR=$<p25>–$<p75> ceiling=$<c> dispersion=<d>  basis=<delivered|item-only>
 
-The **Distribution** line is REQUIRED whenever Stage B ran — it is the
-`price_stats.py` output folded in, and it is the proof the tiers came from a
-sample, not a vibe. Also fold in `price_stats`'s row-0 flag, ceiling
-candidates to vet, and the per-filter drop log (so the user sees what was
-excluded and why). If Stage B was UNAVAILABLE / thin, say so here instead.
+Distribution line is REQUIRED whenever Stage B ran — `price_stats.py` output
+folded in, plus its row-0 flag, ceiling candidates to vet, and the per-filter
+drop log. Stage B unavailable/thin ⇒ say so here instead.
 
-For each scenario (or just "primary" when no bracket — most items):
+Per scenario (or just "primary"):
 
     Query: <query>   Source(s): <A / B / C>
     Tier A — direct match (anchors price):
       • $<price> — "<title>"  ·  Sold <date>, <condition>
                   Match: <one line>   URL: <url>
     Tier B — branded/mint ceiling (the vetted price_high comp):
-      • $<price> — "<title>"  ·  Ceiling note: <why ceiling not anchor>   URL: <url>
+      • $<price> — "<title>"  ·  Ceiling note: <why not anchor>   URL: <url>
     Tier C — excluded:
       • $<price> — "<title>"  ·  Reason: <single bid / <50 fb seller / wrong unit / wrong condition / >2.5× median / asking price>   URL: <url>
 
-Mark comps >12 months old `[STALE]`. Every Tier C needs a specific reason.
-When Stage B ran, the Tier-C exclusions are exactly `price_stats`'s
-per-filter drop log (unit / token / condition / single-bid / low-feedback) —
-transcribe them rather than re-judging.
+Comps >12 months old ⇒ `[STALE]`. Every Tier C needs a specific reason; when
+Stage B ran, Tier C = `price_stats`'s drop log, transcribed not re-judged.
 
-### Comp URLs — verify these yourself (MANDATORY, ends every item)
-
-A consolidated, click-through list so the user can open the comps directly.
-Exact/near-exact anchors first; include the price + a short title with each
-URL so the list is scannable on its own. Required on every item.
-
-**Chat presentation — thumbnail board (HARD RULE — see [_shared.md](_shared.md)
-"Showing comps to the user").** Any time eBay comps are surfaced to the user in
-chat — the PRICE output, a comp walkthrough, or any answer that quotes comps —
-you MUST render them as a visual board where EVERY comp carries all three:
-**its thumbnail image EMBEDDED as a base64 `data:` URI** (download + resize +
-inline — NOT `<img src="https://i.ebayimg.com/...">`, which the sandbox CSP
-blocks into a broken image), **a clickable link to the real eBay listing**
-(`<a href>` to the comp's genuine `https://www.ebay.com/itm/<id>` — never a
-hand-written id), and **the delivered price** (+ a match/ceiling/excluded tag).
-Deliver as a self-contained HTML file via `SendUserFile(display:"render")`, or
-inline the same self-contained HTML into `show_widget`. A plain markdown table,
-a text list, or remote-`src` images are NOT acceptable — the user requires
-seeing real thumbnails and clicking through to verify each listing himself.
-Build the HTML with a small script straight from the saved comp JSON (it has
-`thumbnail` + `url` per comp). This is the chat layer; the text `price.txt` +
-`comps.csv` artifacts stay as specified above. Dial the query
-(material/size/origin qualifiers) for a tight exact-match cohort BEFORE showing
-the board.
+### Comp URLs (MANDATORY, ends every item)
 
     Comp URLs — Item <N> (open to verify):
       Exact / near-exact match:
-        • $<price> — "<short title>" — <https://www.ebay.com/itm/...>
         • $<price> — "<short title>" — <https://www.ebay.com/itm/...>
       Ceiling / context:
         • $<price> — "<short title>" — <https://www.ebay.com/itm/...>
       All sold results (eBay search): <sold-search URL>
 
-If NO exact match exists, say so on the "Exact / near-exact" line
-("none found") and still list the closest era-peers + the sold-search URL.
+No exact match ⇒ say "none found" on that line, still list closest era-peers +
+the sold-search URL.
+
+**Chat presentation — thumbnail board (HARD RULE — _shared.md "Showing comps
+to the user").** Any comps surfaced in chat MUST be a visual board where every
+comp has all three: thumbnail **embedded as a base64 `data:` URI** (remote
+`img src` is CSP-blocked), a clickable link to the genuine
+`https://www.ebay.com/itm/<id>`, and the delivered price + a
+match/ceiling/excluded tag. Self-contained HTML via
+`SendUserFile(display:"render")` or `show_widget`; build it from the saved comp
+JSON (`thumbnail` + `url` per comp). Markdown tables / text lists / remote
+images are NOT acceptable. Dial the query for a tight exact-match cohort BEFORE
+showing the board. `price.txt` + `comps.csv` stay as specified.
 
 ### Distribution-based tiers (always)
 
-The three tiers come from `price_stats.py` on the cleaned `best_match`
-distribution. Adopt its numbers; don't re-derive by eye. For a free-shipping
-listing these are **delivered** prices (run with `--price-field total`), so the
-list price maps to them 1:1; always pair them with the net-to-us figure (list −
-our_postage − fees) per the Delivered-price basis section.
+From `price_stats.py` on the cleaned set — adopt its numbers, don't re-derive.
+Free-shipping ⇒ these are delivered prices; always pair with net-to-us.
 
-- **Conservative** — **25th percentile** of the like-condition cleaned set
-  (no-objection floor).
-- **Recommended (max supported)** — **median** of the like-condition cleaned
-  set (the typical sold price, not the ceiling). **In headless flow this is
-  the provisional working price** (SOFT gate — logged to NEEDS_REVIEW, not a
-  stop).
-- **Push-high** — the **vetted `price_high` ceiling**: the highest surviving
-  `price_high` comp that you confirm is the same item/condition. If
-  `price_stats` flagged it `needs_vetting` (>2.5× median) and it does NOT
-  vet out as comparable (it's a bundle/mislisting/different model), drop to
-  the **90th-percentile fallback** it prints. State which you used.
+- **Conservative** — 25th percentile of the like-condition cleaned set.
+- **Recommended (max supported)** — median. In headless flow this is the
+  provisional working price (SOFT gate — logged to NEEDS_REVIEW, not a stop).
+- **Push-high** — the vetted `price_high` ceiling. If flagged `needs_vetting`
+  (>2.5× median) and it doesn't vet as comparable, drop to the
+  90th-percentile fallback it prints. State which you used.
 
-**Exact-match short-circuit (keep):** if the hunt found ≥1 *true* exact-match
-comp (same item, same condition), anchor **Recommended** on the median of
-those exact matches instead of the distribution median, and say so. Keep the
-distribution as context. The exact comp beats the distribution — commit to it
-(per _shared).
+**Exact-match short-circuit:** ≥1 true exact comp (same item + condition) ⇒
+anchor Recommended on the exact-match median instead; say so; keep the
+distribution as context.
 
-**Thin market (`price_stats` confidence = `thin`, n<3):** do NOT use
-percentiles. Fall back to today's closest-comp / era-peer method — anchor on
-the nearest comp/era-peer, widen the bracket, flag rarity (see "No-exact-
-match case"). The three tiers still apply, anchored on the era-peer.
+**Thin market (conf=thin, n<3):** no percentiles — closest-comp/era-peer
+method, widen the bracket, flag rarity. The three tiers still apply, anchored
+on the era-peer.
 
-**Best Offer gate (unchanged):** enable Best Offer if list > Recommended;
-set auto-decline at Recommended.
+**Best Offer gate:** enable if list > Recommended; auto-decline at Recommended.
 
 ### No-exact-match case
 
-State plainly that no exact comp was found; anchor on the closest
-era-peer with the gap noted; flag the rarity signal; suggest saving the
-eBay search as a watch; note the SEO upside of year-specific attribution.
-The three tiers still apply, anchored on the era-peer.
+Say so plainly; anchor on the closest era-peer with the gap noted; flag the
+rarity signal; suggest a saved-search watch; note the SEO upside of
+year-specific attribution.
 
 ### Close
 
     Working price (provisional): $X (Recommended tier). Final price is the
     user's call at publish time; recorded here for review.
 
-(No stop. Headless adopts the provisional price and logs it; PRICE runs
-end-to-end without a gate.)
+## Research notes (per item — 2–4 lines each; `N/A — <reason>` if inapplicable)
 
-## Research notes (per item — catches what comps can't)
-
-Keep each to 2–4 lines; `N/A — <reason>` if a section truly doesn't apply.
-
-- **Authenticity & fakes** — does this category have a repro problem?
-  Name the tell + an auth step (e.g. Bakelite hot-water test; band-tee
-  tag dating; Tiffany lamps mostly repro). Else "no significant risk".
-- **Restrictions & legal** — eBay-prohibited, CITES (ivory/fur/
-  taxidermy), NAGPRA, militaria region-bans, hazmat, recalls, intl-ship
-  eligibility, US-state rules. Answer: sellable internationally? Else
-  "none identified".
-- **Scams & buyer issues** — switch-in-box, altered slabs, "didn't work"
-  returns, vintage-clothing disputes — + the protection. Else "none".
-- **Authenticity Guarantee** — does eBay cover this category at this
-  value tier? Else N/A.
-- **Disclosure** — what to state up front to head off returns (rim/foot
-  chips, odors, untested status, foxing). Else "standard sufficient".
+- **Authenticity & fakes** — repro problem? Name the tell + an auth step.
+- **Restrictions & legal** — eBay-prohibited, CITES, NAGPRA, militaria bans,
+  hazmat, recalls, intl-ship eligibility, state rules. Sellable internationally?
+- **Scams & buyer issues** — category-typical scams + the protection.
+- **Authenticity Guarantee** — covered at this value tier?
+- **Disclosure** — what to state up front to head off returns.
 
 ## Skip / honesty
 
-- Skip `none (not for sale)` items. DO run PRICE on
-  `needs_followup_photo: yes` items (tells the user if a re-shoot pays).
+- Skip `none (not for sale)`. DO run on `needs_followup_photo: yes` (tells the
+  user if a re-shoot pays).
 - Don't invent comps — say "thin/absent" outright.
-- Fresh-comp rule: gather for THIS item every run; never reuse prior
-  classifications.
+- Fresh comps every run; never reuse prior classifications.
 
 ## Closing
 

--- a/prompts/reference/price-notes.md
+++ b/prompts/reference/price-notes.md
@@ -1,0 +1,94 @@
+# PRICE — rationale, history, and evidence
+
+Companion to [prompts/price.md](../price.md). The prompt holds the rules; this
+file holds *why* they exist, so the prompt stays a checklist. Read this only
+when a rule is disputed or being changed — never as part of a routine PRICE run.
+
+## Why distribution-based (v2)
+
+v1 picked "the strongest comp" by eye. v2 replaced that with: characterize the
+cleaned sold distribution, then place tiers on it. Two complementary sold-market
+views (`best_match` = representative body, `price_high` = ceiling) feed
+`lib/price_stats.py`, which does deterministic filtering + statistics, so the
+tiers trace to a sample size + percentiles rather than a hand-picked comp. The
+exact-match hunt survives because a true exact comp beats any distribution.
+Full design: [docs/price-strategy-v2.md](../../docs/price-strategy-v2.md).
+
+## Fee band — measured, not assumed
+
+The prompt used to say "13% + $0.40". Across 92 real sales the account actually
+paid **16.0% blended**, and the rate is regressive (small sales pay a larger
+share), hence the banded table in the prompt. Re-measure with
+`python lib/report.py --performance` (REPORT, Function 7) and update the
+prompt's table when the bands move. Never quote net-to-us from a remembered
+rate — that's how the 13% figure went stale.
+
+## Why the delivered basis
+
+eBay comps almost always charge buyer-paid shipping, so a comp's `sold_price`
+understates the buyer's real outlay by the shipping cost — often $10–25 on
+breakables and heavier items. Our free-shipping default means OUR list price is
+a delivered price; comparing it to comps' item-only prices made fair prices
+look like pushes above market. `lib/ebay_sold_browse.py` computes and saves
+`total_price` automatically — the in-page extractor reads "+$24.25 delivery" →
+24.25 and "Free delivery" → 0 straight off the card, so `total_price` is
+always present.
+
+## Why silver pushes high
+
+Our silver was systematically UNDER-priced and sold immediately — money left
+on the table, confirmed across multiple sales. "Sold immediately" is the tell
+that the list price was below market. The trigger is deliberately broad (any
+"silver", precious or not) because the under-pricing pattern showed up on
+plate and base-metal "silver" too, not just sterling.
+
+## Apify history (why Stage B is the browser)
+
+Stage B used to run through Apify actors. Every actor we depended on was
+eventually blocked or deleted, and a blocked actor returns 0 items with a
+SUCCEEDED status — indistinguishable from a genuinely thin market, which is
+how a dead backend once nearly priced a batch. Disabled 2026-08-15
+(`apify.enabled: false`; calls raise `ApifyDisabledError`). The logged-in
+browser replaced it: the anonymous in-app browser is served a "Security
+Measure / verify yourself" CAPTCHA (never solve it), but the user's real
+logged-in Chrome (claude-in-chrome) is not challenged.
+
+What the browser gives that no actor did: `Best offer accepted` (a sale at
+that flag means the ask was NOT the clearing price — soft ceiling), delivered
+shipping, seller feedback score + %, bid counts, item URLs and thumbnails.
+Measured on a live 60-comp page: every field populated, 0 missing.
+
+The Research-log template once demanded Apify run ids as proof Stage B ran;
+after the browser migration the equivalent proof is the two saved per-sort
+JSONs + their `n` counts. The BLOCKED/THIN distinction survives in browser
+form: THIN = the page itself says "0 results"; BLOCKED = the extractor returns
+`n:0` on a page with visible results (selector drift — fix the extractor, and
+Stage B contributes no tier until it's fixed).
+
+## Extractor anti-scrape guards (do not "simplify" away)
+
+Three traps the in-page extractor already handles, each learned the hard way:
+
+1. **Placeholder cards** — eBay salts results with fake cards pointing at item
+   id `/itm/123456`; the extractor requires a ≥9-digit id.
+2. **Reversed "Sponsored"** — rendered as `derosnopS` so it can't be
+   string-matched; it also appears on nearly every card, so it is useless as a
+   filter either way.
+3. **Welded spans** — adjacent spans have no whitespace, so raw `textContent`
+   joins them ("Sell one like this" + seller name →
+   `thiscelticitaliansilver`); the extractor joins leaf nodes with newlines.
+
+## Why the thumbnail board is a hard rule
+
+The user verifies every comp by eye and by click — a text list forces them to
+open each URL blind. Remote `<img src="https://i.ebayimg.com/…">` renders as a
+broken image in the sandboxed chat surface (CSP blocks the host), which is why
+the thumbnails must be downloaded, resized, and embedded as base64 `data:`
+URIs. See `_shared.md` "Showing comps to the user".
+
+## Ladder empirics
+
+`price_high` often returns data when `best_match` is empty (observed:
+mask-red query — `best_match`=0, `price_high`=25). That's why an empty
+`best_match` doesn't block: `price_stats` promotes `price_high` to the
+representative set and flags it in its output.

--- a/tests/test_ebay_client.py
+++ b/tests/test_ebay_client.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""lib/ebay_client.py — the money path, tested offline (GH #30).
+
+Every listing create/update/publish and every ledger reconcile goes through
+this module, and until now none of it had tests: token caching, the retry
+policy, and — most important — how a non-2xx surfaces. The live 400s we've
+debugged (UPC checksum, missing Model aspect, transient republish 400) were
+all diagnosed from EbayAPIError.body, so that body surviving intact is a
+contract, not a nicety.
+
+All HTTP is faked by patching urllib.request.urlopen; no network, no creds.
+
+Run:  python tests/test_ebay_client.py
+  or: pytest tests/test_ebay_client.py
+"""
+import io
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "lib"))
+
+import ebay_client  # noqa: E402
+from ebay_client import (  # noqa: E402
+    EbayAPIError,
+    EbayAuthError,
+    EbayCredentials,
+    api_get,
+    api_send,
+    get_app_access_token,
+    get_user_access_token,
+)
+
+CREDS = EbayCredentials(environment="sandbox", app_id="app-x", cert_id="cert-x",
+                        user_refresh_token="refresh-x")
+APP_ONLY = EbayCredentials(environment="sandbox", app_id="app-x", cert_id="cert-x")
+NO_CREDS = EbayCredentials(environment="sandbox")
+
+
+class _FakeResponse:
+    def __init__(self, payload, raw=None):
+        self._raw = raw if raw is not None else json.dumps(payload).encode()
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _http_error(code, body=b'{"errors":[{"message":"boom"}]}'):
+    return urllib.error.HTTPError("https://x", code, f"HTTP {code}",
+                                  None, io.BytesIO(body))
+
+
+class _Fake:
+    """Scripted stand-in for urllib.request.urlopen. Each entry in `script`
+    is a _FakeResponse to return or an exception to raise; requests beyond
+    the script repeat the last entry."""
+
+    def __init__(self, *script):
+        self.script = list(script)
+        self.requests = []
+
+    def __call__(self, req, timeout=None):
+        self.requests.append(req)
+        step = self.script[min(len(self.requests), len(self.script)) - 1]
+        if isinstance(step, Exception):
+            raise step
+        return step
+
+
+def _patched(fake, fn):
+    """Run fn with urlopen faked, retry sleeps zeroed, and token caches
+    cleared — before AND after, so no test leaks a cached token."""
+    real_open, real_sleep = urllib.request.urlopen, ebay_client.time.sleep
+    urllib.request.urlopen = fake
+    ebay_client.time.sleep = lambda s: None
+    _reset_caches()
+    try:
+        return fn()
+    finally:
+        urllib.request.urlopen, ebay_client.time.sleep = real_open, real_sleep
+        _reset_caches()
+
+
+def _reset_caches():
+    ebay_client._app_cache.token = None
+    ebay_client._app_cache.expires_at = 0.0
+    ebay_client._user_cache.token = None
+    ebay_client._user_cache.expires_at = 0.0
+
+
+def _token_response(token="tok-1", ttl=7200):
+    return _FakeResponse({"access_token": token, "expires_in": ttl})
+
+
+# ---------------------------------------------------------------------------
+# App token
+# ---------------------------------------------------------------------------
+
+def test_app_token_missing_creds_raises_auth_error():
+    try:
+        get_app_access_token(NO_CREDS)
+        raise AssertionError("expected EbayAuthError")
+    except EbayAuthError as e:
+        assert "app_id" in str(e)
+
+
+def test_app_token_is_cached_across_calls():
+    fake = _Fake(_token_response("tok-app"))
+
+    def go():
+        assert get_app_access_token(APP_ONLY) == "tok-app"
+        assert get_app_access_token(APP_ONLY) == "tok-app"
+        return len(fake.requests)
+
+    assert _patched(fake, go) == 1  # second call served from cache
+
+
+def test_app_token_force_refresh_refetches():
+    fake = _Fake(_token_response("tok-1"))
+
+    def go():
+        get_app_access_token(APP_ONLY)
+        fake.script = [_token_response("tok-2")]
+        assert get_app_access_token(APP_ONLY, force_refresh=True) == "tok-2"
+        return len(fake.requests)
+
+    assert _patched(fake, go) == 2
+
+
+def test_app_token_near_expiry_refetches():
+    # A token with 30s left is inside the 60s guard band — must refetch.
+    fake = _Fake(_token_response("tok-short", ttl=30))
+
+    def go():
+        get_app_access_token(APP_ONLY)
+        fake.script = [_token_response("tok-fresh")]
+        assert get_app_access_token(APP_ONLY) == "tok-fresh"
+        return len(fake.requests)
+
+    assert _patched(fake, go) == 2
+
+
+def test_app_token_http_error_surfaces_ebay_body():
+    fake = _Fake(_http_error(401, b'{"error":"invalid_client"}'))
+
+    def go():
+        try:
+            get_app_access_token(APP_ONLY)
+            raise AssertionError("expected EbayAuthError")
+        except EbayAuthError as e:
+            assert "invalid_client" in str(e)
+            assert "401" in str(e)
+
+    _patched(fake, go)
+
+
+# ---------------------------------------------------------------------------
+# User token
+# ---------------------------------------------------------------------------
+
+def test_user_token_missing_refresh_token_raises_with_recapture_steps():
+    try:
+        get_user_access_token(APP_ONLY)
+        raise AssertionError("expected EbayAuthError")
+    except EbayAuthError as e:
+        assert "user_refresh_token" in str(e)
+
+
+def test_user_token_cached_and_grant_is_refresh_token():
+    fake = _Fake(_token_response("tok-user"))
+
+    def go():
+        assert get_user_access_token(CREDS) == "tok-user"
+        assert get_user_access_token(CREDS) == "tok-user"
+        assert len(fake.requests) == 1
+        body = fake.requests[0].data.decode()
+        assert "grant_type=refresh_token" in body
+        assert "refresh-x" in body
+
+    _patched(fake, go)
+
+
+def test_user_token_expired_refresh_token_says_recapture():
+    fake = _Fake(_http_error(400, b'{"error":"invalid_grant"}'))
+
+    def go():
+        try:
+            get_user_access_token(CREDS)
+            raise AssertionError("expected EbayAuthError")
+        except EbayAuthError as e:
+            assert "re-capture" in str(e)
+
+    _patched(fake, go)
+
+
+# ---------------------------------------------------------------------------
+# api_send — error surfacing + retry policy
+# ---------------------------------------------------------------------------
+
+def test_api_send_400_preserves_status_and_ebay_body():
+    # The live-seen publish 400s (UPC checksum, Model aspect) are diagnosed
+    # from this body — it must arrive verbatim, not summarized.
+    ebay_body = b'{"errors":[{"errorId":25002,"message":"Invalid UPC"}]}'
+    fake = _Fake(_token_response(), _http_error(400, ebay_body))
+
+    def go():
+        try:
+            api_send("POST", "/sell/inventory/v1/offer", {"sku": "x"}, creds=CREDS)
+            raise AssertionError("expected EbayAPIError")
+        except EbayAPIError as e:
+            assert e.status == 400
+            assert "Invalid UPC" in e.body
+            assert len(fake.requests) == 2  # token + one attempt, no retry on 4xx
+
+    _patched(fake, go)
+
+
+def test_api_send_5xx_on_post_does_not_retry():
+    # A POST create must never double-fire on a transient 500.
+    fake = _Fake(_token_response(), _http_error(500))
+
+    def go():
+        try:
+            api_send("POST", "/sell/inventory/v1/offer", {"sku": "x"}, creds=CREDS)
+            raise AssertionError("expected EbayAPIError")
+        except EbayAPIError as e:
+            assert e.status == 500
+            assert len(fake.requests) == 2  # token + exactly ONE attempt
+
+    _patched(fake, go)
+
+
+def test_api_send_5xx_on_put_retries_then_succeeds():
+    fake = _Fake(_token_response(), _http_error(503), _http_error(503),
+                 _FakeResponse({"ok": True}))
+
+    def go():
+        out = api_send("PUT", "/sell/inventory/v1/inventory_item/SKU1",
+                       {"a": 1}, creds=CREDS)
+        assert out == {"ok": True}
+        assert len(fake.requests) == 4  # token + 3 attempts
+
+    _patched(fake, go)
+
+
+def test_api_send_network_error_retries_even_for_post():
+    # URLError = the request likely never reached eBay, so POST may retry.
+    fake = _Fake(_token_response(), urllib.error.URLError("reset"),
+                 _FakeResponse({"ok": True}))
+
+    def go():
+        out = api_send("POST", "/sell/inventory/v1/offer", {"sku": "x"}, creds=CREDS)
+        assert out == {"ok": True}
+        assert len(fake.requests) == 3
+
+    _patched(fake, go)
+
+
+def test_api_send_empty_2xx_body_returns_empty_dict():
+    fake = _Fake(_token_response(), _FakeResponse(None, raw=b""))
+
+    def go():
+        assert api_send("DELETE", "/sell/inventory/v1/offer/123", creds=CREDS) == {}
+
+    _patched(fake, go)
+
+
+def test_api_send_sets_auth_marketplace_and_language_headers():
+    fake = _Fake(_token_response("tok-user"), _FakeResponse({"ok": True}))
+
+    def go():
+        api_send("PUT", "sell/inventory/v1/inventory_item/SKU1", {"a": 1},
+                 creds=CREDS)
+        req = fake.requests[-1]
+        assert req.get_header("Authorization") == "Bearer tok-user"
+        assert req.get_header("X-ebay-c-marketplace-id") == "EBAY_US"
+        assert req.get_header("Content-language") == "en-US"
+        assert req.full_url.endswith("/sell/inventory/v1/inventory_item/SKU1")
+
+    _patched(fake, go)
+
+
+# ---------------------------------------------------------------------------
+# api_get
+# ---------------------------------------------------------------------------
+
+def test_api_get_encodes_query_and_returns_json():
+    fake = _Fake(_token_response(), _FakeResponse({"total": 3}))
+
+    def go():
+        out = api_get("/buy/browse/v1/item_summary/search",
+                      query={"q": "rogers bros", "limit": 5}, creds=APP_ONLY)
+        assert out == {"total": 3}
+        assert "q=rogers+bros" in fake.requests[-1].full_url
+
+    _patched(fake, go)
+
+
+def test_api_get_http_error_becomes_api_error_with_body():
+    fake = _Fake(_token_response(), _http_error(404, b'{"errors":[{"errorId":11001}]}'))
+
+    def go():
+        try:
+            api_get("/buy/browse/v1/item/nope", creds=APP_ONLY)
+            raise AssertionError("expected EbayAPIError")
+        except EbayAPIError as e:
+            assert e.status == 404
+            assert "11001" in e.body
+
+    _patched(fake, go)
+
+
+if __name__ == "__main__":
+    fails = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except Exception as e:  # noqa: BLE001
+                fails += 1
+                print(f"FAIL {name}: {e}")
+    sys.exit(1 if fails else 0)


### PR DESCRIPTION
First slice of #30, scoped to files that do NOT collide with the in-flight `feat/seller-style-study` branch (`prep.md` / `draft.md` diverge there, so their diets wait for that merge).

## What's here

**`prompts/price.md` diet — 497 → 315 lines, 4,021 → 2,037 words (−49%)**
- Every normative rule preserved: silver push-high override, delivered basis + fee band, selling-unit rules, exact-match hunt + ladder, Research-log hard rules, thumbnail-board hard rule, tier definitions, Best Offer gate.
- The *why* (v2 rationale, 92-sale fee measurement, Apify post-mortem, extractor anti-scrape forensics, ladder empirics) moved to `prompts/reference/price-notes.md`, read only when a rule is disputed.
- Fixes a real staleness: the Research-log template still demanded **Apify run ids** as Stage B proof, impossible since the 2026-08-15 browser migration. Proof is now the two saved per-sort JSONs + counts; BLOCKED (extractor `n:0` on a page with visible results = selector drift) vs THIN (page says "0 results") restated in browser terms.

**`tests/test_ebay_client.py` — 16 tests, first coverage for the money path**
- Token caching + 60s expiry guard, `force_refresh`, auth errors carrying eBay's body.
- The `EbayAPIError.body` contract (how the live UPC-checksum / Model-aspect 400s get diagnosed).
- Retry policy: POST never double-fires on 5xx; PUT/DELETE retry; network errors retry for any method; empty-204 → `{}`.
- Header/URL construction (Bearer token, marketplace, Content-Language).
- Offline (faked `urlopen`), fixture-free so both `tests/run_all.py` and CI pytest run all of them.

## Verified
- `python tests/test_ebay_client.py` → 16/16 pass.
- Full `python -m pytest tests/ -q` → **249 passed** (7:50 local, incl. the CLIP gate CI skips).

## Not in this PR (remaining #30 items)
- `prep.md` / `draft.md` diets — blocked on seller-style merge.
- One-line-verdict tool convention, script consolidation, comp caching, docs archive, single-pass mode.
- CI: already existed (`.github/workflows/tests.yml`) — no work needed, contrary to the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)