### PR TITLE
In-hand voice as enforced rule, insurance reminder retired, and three live fixes

### DIFF
--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -1102,16 +1102,20 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
 
 
 def _insurance_notes(draft: Draft) -> list[str]:
-    """Remind to insure high-value items — only $100 is auto-included, and the
-    eBay API can't set insurance (it's bought at label time via ShipCover)."""
-    price = _to_decimal_str(draft.get("price"))
-    try:
-        if price and Decimal(price) > Decimal("100"):
-            return [f"insurance: price ${price} > $100 — only $100 ships included; "
-                    f"add ShipCover/added coverage when buying the label (Seller Hub -> "
-                    f"Get shipping label -> Additional liability coverage)."]
-    except InvalidOperation:
-        pass
+    """RETIRED 2026-08-26 — always returns no notes.
+
+    This used to fire on every listing over $100: only $100 of coverage is
+    auto-included and the API can't set insurance, so it reminded the operator
+    to add ShipCover at label time. The reminder was correct and useless — added
+    coverage is bought in the eBay UI when the label is bought, which the
+    operator already does as a matter of course, so the line was noise on every
+    high-value card. Turned off at the operator's request.
+
+    Kept as a no-op rather than deleted: both call sites (preflight and the
+    publish path) still ask for it, and a function that returns nothing is a
+    smaller change than unpicking those. To bring it back, restore the body —
+    the threshold was price > $100.
+    """
     return []
 
 
@@ -1153,7 +1157,7 @@ def preflight_listing(draft_path: Path, creds: Optional[EbayCredentials] = None,
     # Shipping policy selection (media vs ground) + validation
     _chosen, ship = _resolve_shipping_policy(draft, policies, creds)
     msgs.extend(ship)
-    # Insurance reminder for high-value items
+    # Insurance: retired, no-op — see _insurance_notes
     msgs.extend(_insurance_notes(draft))
     return msgs
 
@@ -1168,7 +1172,7 @@ def build_review_card(draft_path: Path,
     (card_text, card_path). Does NOT publish.
 
     It (1) ensures the item is recorded (SKU + DRAFTED ledger row),
-    (2) runs preflight (condition remap + shipping policy + insurance flag),
+    (2) runs preflight (condition remap + shipping policy),
     and (3) assembles the decision card deterministically from the draft,
     comps, ledger, and preflight — written to <shoot>/review_card.md.
     """
@@ -1178,7 +1182,7 @@ def build_review_card(draft_path: Path,
     shoot = draft_path.parent
 
     sku, _ = record_draft(draft_path)                  # ensure SKU + DRAFTED
-    pf = preflight_listing(draft_path, creds=creds)    # remap + shipping + insurance
+    pf = preflight_listing(draft_path, creds=creds)    # remap + shipping
     draft = parse_draft(draft_path)                    # re-read (condition may have changed)
 
     title = str(draft.get("title") or "")
@@ -1311,7 +1315,7 @@ def build_review_card(draft_path: Path,
         f"Condition: {cond}",
         f"Quantity:  {qty}   ·   Photos: {len(photos)} (hero: {hero})",
         f"Fulfillment: {fulfill}",
-        "Preflight (condition / shipping / insurance):",
+        "Preflight (condition / shipping):",
         *[f"  • {m}" for m in pf],
         "International (eBay International Shipping):",
         *intl_lines,

--- a/lib/list_edit_group.py
+++ b/lib/list_edit_group.py
@@ -208,6 +208,12 @@ def _variation_inventory_item(draft, var: dict, varies_by: str,
         pkg["dimensions"] = {"length": float(length), "width": float(width),
                              "height": float(depth), "unit": "INCH"}
     if pkg:
+        # packageType is REQUIRED for CALCULATED shipping. The group path only
+        # ever ran on free flat-rate policies (tubes, Magic Rose), so this was
+        # missing until the Flair NOS lot moved onto the BUYER-PAID calculated
+        # policy; without it publish fails 25002 / err:216314 "Please provide a
+        # valid Shipping Package type". Same helper the single-item path uses.
+        pkg["packageType"] = le._package_type(draft)
         item["packageWeightAndSize"] = pkg
     return item
 

--- a/prompts/condition-rubric.md
+++ b/prompts/condition-rubric.md
@@ -18,9 +18,11 @@ prevents it. Dig in.
 2. **Run the material checklist** for the item's dominant material(s).
 3. **Record each defect** with location + severity (minor / moderate /
    significant) + photo reference. No defect is too small to note.
-4. **State what you cannot assess** from the photos (function untested,
-   undersides not shown, interior not visible) — silence reads as a
-   claim of "fine".
+4. **Record what you cannot assess** from the photos (function untested,
+   undersides not shown, interior not visible) — silence in the internal
+   record reads as a claim of "fine". This wording is **internal only**
+   (identify.txt / investigate.txt); what reaches buyer copy is governed
+   by the can't-assess rule under `condition_description` below.
 5. **Map to one eBay grade** using the tie-break rule below.
 
 ## Material defect checklists
@@ -102,11 +104,18 @@ Order, each part only if it applies:
    the defects a buyer would reasonably fear for this material/grade
    (e.g. `No chips, cracks, or repairs.`). Skip clears that don't bear on
    the grade.
-3. **Can't-assess** — untested function, undersides/interior unseen,
-   smoke-free not verifiable from photos. One fragment.
+3. **Can't-assess — grade-relevant only, phrased in-hand.** Include ONLY
+   when it sets the grade (electronics/mechanical function): `Untested;
+   sold as-is.` Never the photo excuse ("not verifiable from photos"),
+   never an inventory of tests not run (shake/ring/odor checks). All
+   other can't-assess items stay in INVESTIGATE's "NOT defensible" list
+   and out of buyer copy — see the in-hand-voice rule in
+   [draft.md](draft.md).
 
 **Never** include: narrative ("removed from box only to photograph"),
 marketing adjectives, decorative description of the item itself (that's
-the title/specifics), or what's-included (that's the body's What's
-Included). If a clause doesn't disclose a defect, a grade-relevant clear,
+the title/specifics), what's-included (that's the body's What's
+Included), or camera-frame language ("visible in photos", "as-shown",
+"not verifiable from the photos") — the in-hand-voice rule in
+[draft.md](draft.md) bans it in every buyer-visible field. If a clause doesn't disclose a defect, a grade-relevant clear,
 or a limit of inspection, it does not belong in this field.

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -437,6 +437,38 @@ bodies. Two things do not follow it into our copy:
   INVESTIGATE established. Where I genuinely don't know, say that
   plainly and say what I did to check.
 
+**In-hand voice — never from behind the camera** (house rule, adopted
+2026-08-26). The listing speaks as a seller holding the item. Language
+phrased from the camera's point of view is banned in every buyer-visible
+field (title, body, `condition_description`, item specifics):
+
+- **camera framing** — "visible in the photos", "shown/pictured",
+  "as-shown", "photographed surfaces", "undersides not photographed";
+- **photo-limit confessions** — "not identifiable/verifiable from the
+  photos", "can't be assessed from the pictures";
+- **inspection-process narration** — enumerating tests not run ("not
+  shake-tested", "ring test not performed", "odor not verified").
+
+This is our internal evidence process leaking into the copy: it tells
+the buyer the seller never handled the item, and it manufactures doubt
+instead of preventing returns. **Rephrase rule: state the finding, never
+the method.** "No chips or cracks visible" → "No chips or cracks
+noted." "Knife handle seated tight in photos; not shake-tested" →
+"Knife handle sits tight." A photo-only observation ("UPC not shown in
+the photographed surfaces") is an internal note for `meta.notes` /
+NEEDS_REVIEW, never buyer copy.
+
+Untested status survives ONLY where it sets the grade (electronics /
+mechanical function, per condition-rubric): phrased plainly —
+"Untested; sold as-is." — with no photo excuse attached. Two things the
+rule does NOT touch: the internal record (IDENTIFY/INVESTIGATE still
+log every can't-assess — this rule governs only what reaches the
+buyer), and the standing close line "Please see the photos and read the
+description for full details" (it points the buyer at the photos as
+disclosure; it doesn't confess the inspection was photo-only). Defects
+themselves all still survive — the rule strips the camera frame off a
+disclosure, never the disclosure.
+
 Hard rules: never include a claim absent from INVESTIGATE's listing-safe
 / observable lists; never anything INVESTIGATE marked NOT defensible;
 never IDENTIFY `[BEST-CASE]` language; honor unit-type phrasing.
@@ -469,7 +501,9 @@ Satisfy by **rephrasing, never mid-word truncation:**
 Walk every `_field_constraints` entry against the populated value:
 length ≤ max_len (rephrase if not) · required present (else flag) ·
 numeric parses positive (else flag, empty) · lookup canonical (else
-substitute + log). Only then write draft.md. Re-read after write and
+substitute + log). Also scan every buyer-visible field for camera-frame
+language (the in-hand-voice rule above) and rephrase any hit to the
+finding. Only then write draft.md. Re-read after write and
 confirm every constrained field fits and `_field_constraints` was copied
 verbatim.
 

--- a/prompts/prep.md
+++ b/prompts/prep.md
@@ -128,21 +128,27 @@ and they are enforced in code:
   the edges and always leaves backdrop around the item. Too generous costs a
   second look. Too tight has already thrown pixels away, and nobody re-shoots.
 
-Present the result as a widget: every frame, the turn applied, the crop box on
-the frame, and the guessed ones flagged. Apply the pass, then show ONE card
-(`python tools/prep_card.py <shoot>`) of the revised frames, and ask a single
-question with two answers:
+Apply the pass, then gate on confidence, not on the operator (operator's
+call, 2026-08-27):
 
-- **approve** → `--approve-auto`, which signs off orientation AND crop together
-  and moves to colour;
-- **override** → open the interactive flow below, at `--stage orientation`.
+- **Every frame resolved, nothing guessed, every self-check clean** — the
+  normal case — run `--approve-auto` yourself, which signs off orientation AND
+  crop together, and move straight to colour. Show ONE card
+  (`python tools/prep_card.py <shoot>`) of the revised frames as a record of
+  what shipped, not as a question. The operator can still override anything
+  from the card, but the run does not stop to wait for it.
+- **Anything guessed or flagged** — a `guessed: true` frame, a mask the colour
+  stage cannot trust, a crop the pipeline refused — ask about THOSE frames
+  only, by name, and approve the rest. The one question is about the
+  exception, never "may I continue".
 
-Nothing about the gate changes. `--auto` approves nothing, `listing/` is still
-written only after the stages are signed off, and `--approve-auto` stamps the
-same per-stage digest a sheet approval does — so any later edit invalidates it
-the same way.
+Auto-approval never buys a lower bar. `--auto` still approves nothing by
+itself, `listing/` is still written only after the stages are signed off, and
+`--approve-auto` stamps the same per-stage digest a sheet approval does — so
+any later edit invalidates it the same way. What changed is who clicks it when
+the pipeline has nothing to ask.
 
-## The review is STAGED, and interactive. Always.
+## The interactive review is the EXCEPTION path — and it is STAGED
 
 This is where an override lands, and where a shoot goes whenever the auto pass
 is not good enough. Three corrections, in this order, and **you do not move on

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -24,8 +24,15 @@ This does the whole pre-review prep in one shot:
    the `DRAFTED` ledger row (so a finished draft is always registered before
    review).
 2. **Preflight** — auto-remaps the condition to one the category accepts,
-   picks the shipping policy (Media Mail vs ground), and flags insurance on
-   items > $100.
+   and picks the shipping policy (Media Mail vs ground).
+
+   **Insurance is NOT a preflight concern — never raise it.** Preflight used to
+   flag every listing over $100 to add ShipCover, because only $100 of coverage
+   is auto-included and the API cannot set insurance. The operator buys added
+   coverage in the eBay UI at label time as a matter of course, so the reminder
+   was noise on every high-value card. Retired 2026-08-26 (`_insurance_notes`
+   in [`../lib/list_edit.py`](../lib/list_edit.py) is a no-op). Do not
+   reintroduce it in the card, in chat, or in the closing summary.
 3. **Assembles the card** from the draft, comps, ledger, and preflight, and
    writes `review_card.md`.
 
@@ -34,7 +41,7 @@ Present that card to the user **verbatim** and STOP. It contains:
     ━━ REVIEW: <item> (sku … · ledger …) ━━
     Title [N/80] · Price · Best Offer · Condition · Quantity · Photos
     Fulfillment (Ship · service, OR LOCAL PICKUP only — confirm pickup items)
-    Preflight (condition · shipping · insurance)
+    Preflight (condition · shipping)
     Comps (open to verify) — each with a URL
     Condition detail (every flagged defect, verbatim — never softened)
     ⚠ Needs review / manual intervention (NEEDS_REVIEW.md lines)
@@ -82,6 +89,16 @@ run `--record` first, then assemble the same fields by hand from `draft.md`
 **One item at a time.** In a multi-item shoot, run `--review` per item,
 present its card, take the decision, then the next. Only batch-publish if
 the user says "approve all".
+
+**Copy check — in-hand voice.** Before presenting the card, scan the
+draft's buyer-visible fields (title, description, condition_description,
+item specifics) for camera-frame language: "visible in the photos",
+"shown/pictured", "as-shown", "not identifiable/verifiable from the
+photos", or tests-not-run narration ("not shake-tested", "odor not
+verified"). Any hit is a copy defect, not a judgment call: fix it via
+DRAFT (rephrase to the finding, per draft.md's in-hand-voice rule), then
+re-run `--review`. The standing "Please see the photos…" close line is
+exempt. Grade-setting "Untested; sold as-is." is exempt.
 
 ## The gate (HARD — this is where the run stops)
 

--- a/specializations/silverplate.md
+++ b/specializations/silverplate.md
@@ -103,6 +103,16 @@ different companies. Read the mark exactly.
 - **Star + eagle flanking "Wm. Rogers"** = a *decorative pseudo-hallmark* imitating British/coin-
   silver stamps — **no legal/assay meaning**, do not read it as sterling or as a date.
 - **The pattern name is often printed on the box/chest** if NOS — easiest ID of all.
+- **A SEALED poly sleeve does NOT hide the mark — shoot it before you declare the pattern
+  unverifiable.** 1847 Rogers stamps the pattern name in script right of the `I S` boxes, and on a
+  raking-light macro it reads straight THROUGH the sleeve (proven 2026-08-25 on
+  `flair-child-fork-spoon-NOS-set/ZZ250012`: "1847 ROGERS BROS. [I][S] Flair"). A listing that says
+  "the backstamps cannot be assessed while sealed" is usually a listing where nobody tried. Getting
+  it also converts a hedged pattern guess into a provable claim, which is a selling point in a
+  market where nearly every sealed listing has to hedge.
+- **Sleeve creasing is NOT an identity signal.** Floppy poly re-creases every time a piece is set
+  down, so the "same" piece photographed three times looks like three different pieces. Do not count
+  inventory from sleeve appearance — count it in hand. (Cost me a wrong 3-pairs read, same day.)
 - Cross-check the handle-front design against **Replacements.com** (the pattern-ID bible) or
   silvercollection.it before committing a pattern name.
 
@@ -118,13 +128,13 @@ complete sets). Intro years from silvercollection.it:
 | **Daffodil** | 1950 | large daffodil blossom at handle top | beloved MCM pattern (disc. 1973) |
 | **Remembrance** | 1948 | traditional floral, symmetrical | "ever-popular" traditional |
 | **Heritage** | 1953 | ornate scrolled/beaded border | dressy, sought |
-| **Flair** | 1956 | slim, single flower spray, mid-century clean | very common but liked |
+| **Flair** | 1956 | **completely PLAIN** slim tapered handle — a bare swelled tip with a soft crimped edge and NO floral element at all | very common but liked. **ID trap:** "Flair" sounds floral and this row used to say "single flower spray" — it does not have one. A 1847 Rogers handle with an applied flower is NOT Flair; check Magic Rose / Springtime / Leilani / Daffodil first. (Corrected 2026-08-24 against dealer reference photos after a lot was mis-catalogued as Flair.) |
 | **Adoration** | 1930 | (Wm Rogers & Son line) rose/floral | one of the few Wm Rogers & Son patterns with a following |
 | **Marquise** | 1933 | geometric Deco | Deco collectors |
 | **Reflection** | 1959 | plain modern, tapered | MCM/minimal demand |
 | **Springtime** | 1957 | floral spray | MCM |
 | **Leilani** | 1961 | tropical/leaf | MCM niche |
-| **Magic Rose** | 1963 | rose | niche |
+| **Magic Rose** | 1963 | a single applied **open rose** on a diagonal stem, one leaf trailing back down the handle + a leaf/bud spraying forward past the bloom, on an otherwise plain softly-swelled tip | disc. 1969. Called "niche" here, but the live market is deep — 120+ active listings, singles and full services, and the **serving pieces carry it** (gravy ladle asks $13–19 vs $5–9 for place pieces) |
 
 Other IS-umbrella demand patterns to recognize: **Holmes & Edwards** *Danish Princess*, *Spring
 Garden*, *May Queen*; **Community** *Coronation*, *Milady*, *Evening Star*, *South Seas*, *White

--- a/tools/sales_report.py
+++ b/tools/sales_report.py
@@ -262,10 +262,14 @@ def gather(days: int) -> dict:
                if c.get("campaignStatus") == "RUNNING"}
     out["live_count"] = len(live_ids)
     out["live_with_ad"] = len(live_ids & set(ad_by_listing))
+    # A cost-per-sale ad carries no `adStatus` at all — the field is CPC-only.
+    # Requiring "ACTIVE" therefore reported 0 of 141 promoted on the very day a
+    # rules-based CPS campaign filled itself with 130 ads. An ad in a RUNNING
+    # campaign counts unless it says otherwise.
     out["live_with_running_ad"] = len(
         {lid for lid, a in ad_by_listing.items()
          if lid in live_ids and a["campaignId"] in running
-         and a.get("adStatus") == "ACTIVE"})
+         and a.get("adStatus") in (None, "", "ACTIVE")})
     out["running_campaigns"] = len(running)
     out["ad_status_mix"] = Counter(a.get("adStatus") or "?" for a in ads_doc["ads"])
     # ---- the store as it stands, not just what sold -------------------------


### PR DESCRIPTION
## What this lands

The working tree that accumulated across the 2026-08-24 → 08-26 sessions, split into six commits:

- **feat(draft): in-hand voice** — the house rule behind the 73-listing sweep, now written into `draft.md`: camera-frame language ("visible in the photos", "as-shown", tests-not-run narration) is banned in every buyer-visible field; state the finding, never the method. `condition-rubric.md` gets the matching can't-assess phrasing ("Untested; sold as-is." survives only where it sets the grade).
- **feat(review): copy check + insurance retirement** — REVIEW scans buyer copy for camera voice before presenting the card, and the >$100 ShipCover reminder is retired to a documented no-op (`_insurance_notes`): coverage is bought in the eBay UI at label time as a matter of course, so the line was noise on every high-value card.
- **fix(ebay): `packageType` on group variations** — required once a group listing runs on buyer-paid calculated shipping; without it publish fails 25002 / err 216314. Found live on the Flair NOS lot.
- **fix(silverplate): Flair is plain** — the pattern table said Flair had a flower spray; it has no floral element at all, and that misID priced a lot 38% low. Magic Rose row rewritten with real market depth; sealed-sleeve lessons added (backstamps read through poly under raking light; sleeve creasing is not an identity signal).
- **fix(report): CPS ads have no `adStatus`** — requiring ACTIVE reported 0 of 141 promoted the day a cost-per-sale campaign filled itself with 130 ads.
- **feat(prep): confidence-gated self-approval (#36)** — when every frame is resolved, nothing guessed, and every self-check clean, PREP runs `--approve-auto` itself and shows the card as a record, not a question. Quality gates unchanged.

## Notes

- The working tree also carried the #33 per-frame-flag fix; it is already on main and is not duplicated here.
- The six untracked `tools/*.py` one-offs stay uncommitted on purpose — they are #30's consolidation material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)