### PR TITLE
v4 foundation: the refactor plan + the two biggest prompt diets

### DIFF
--- a/docs/V4_PLAN.md
+++ b/docs/V4_PLAN.md
@@ -20,7 +20,8 @@ only to AGREE?
 
 - [x] `prep.md` — 629→340 + `reference/prep-notes.md` (190); the two
       near-duplicate review-page sections merged into one
-- [ ] `draft.md` (543)
+- [x] `draft.md` — 543→402 + `reference/draft-notes.md` (111); the
+      superseded old-chain procedure moved wholesale to the notes
 - [ ] `identify.md` (364)
 - [ ] `list_edit_chrome.md` (276)
 - [ ] `_shared.md` (208)

--- a/docs/V4_PLAN.md
+++ b/docs/V4_PLAN.md
@@ -1,0 +1,73 @@
+# v4 — the refactor plan
+
+v3 made the pipeline headless (prompts/ + lib/ at root). v4 makes it **cheap
+and quiet**: skinny prompts, terse tools, one CLI, fewer questions, and a
+session observer that keeps it improving. The scope is the open Idea issues —
+#30 (token/output diet) is the structural core, #36 (self-optimizing sessions)
+is the feedback loop, #23 (PREP categories), #31 (web front-end) and #32
+(pack-and-ship) build on the result.
+
+Each phase is a PR-sized unit. Update the checkboxes as work lands.
+
+## Phase 1 — prompt diet (#30, highest leverage)
+
+Every stage prompt becomes a rules-only checklist; rationale, history and
+evidence move to `prompts/reference/<stage>-notes.md`, read only when a rule
+is disputed. Precedent: `price.md` 636→315 with `reference/price-notes.md`
+(landed on main, #34). **No rule is dropped, no rationale is deleted — it
+relocates.** The test for each paragraph: does an agent need this to ACT, or
+only to AGREE?
+
+- [x] `prep.md` — 629→340 + `reference/prep-notes.md` (190); the two
+      near-duplicate review-page sections merged into one
+- [ ] `draft.md` (543)
+- [ ] `identify.md` (364)
+- [ ] `list_edit_chrome.md` (276)
+- [ ] `_shared.md` (208)
+- [ ] `curate.md` (186)
+- [ ] `promote.md` (159)
+- [ ] `review.md` / `investigate.md` / `condition-rubric.md` (already short —
+      audit only, diet if a page of rationale hides in them)
+
+## Phase 2 — terse tool output (#30)
+
+Convention: a tool prints `OK n/m, k flagged → <file>.json` and writes detail
+to the file; detail is read only when flagged. Apply to the noisiest first:
+`lib/photo_prep/prep.py`, `lib/list_edit.py`, `tools/sales_report.py`,
+`tools/ledger_reconcile.py`, `tools/live_audit.py`. Schema-check the JSON in
+tests so "read only when flagged" can be trusted.
+
+## Phase 3 — one CLI, shared plumbing (#30)
+
+- [ ] Single entry point (`python -m lib.cli <subcommand>`) with shared
+      config + eBay client bootstrap.
+- [ ] Fold in the six untracked keepers: `ledger_reconcile`, `live_audit`,
+      `mpn_apply`, `pick_list`, `policy_sweep`, `price_audit` (they stay
+      uncommitted until they land here — see PR #37 notes).
+- [ ] Merge the duplicated offer/publish logic between `list_edit.py` (2,199
+      lines) and `list_edit_group.py`.
+- [ ] Root hygiene: ledger/sales backups → `backups/` (gitignored), one-off
+      review-card HTML + scratch images → `docs/archive/`, session logs out
+      of `docs/`.
+
+## Phase 4 — fewer round-trips
+
+- [ ] On-disk cache for comp runs and eBay reads, keyed query+date, `--fresh`
+      bypass.
+- [ ] Single-pass mode for routine items: PREP→IDENTIFY→PRICE→DRAFT in one
+      run, ONE review card at the end, conversation reserved for flagged
+      exceptions. Builds on PREP's confidence gate (#36, landed in PR #37).
+
+## Phase 5 — the observer (#36)
+
+- [ ] `tools/session_observer.py`: parse session transcripts (timestamps +
+      token usage are already in the JSONL), compute per-stage wall time,
+      token attribution, interaction hot spots, repeats.
+- [ ] Friction report → auto-filed `Idea:` issue, deduped against open ones.
+
+## Ground rules
+
+Honesty rules, condition disclosure, approval digests and the review gate on
+publish do not move in any phase. A diet that changes behavior is a bug: for
+Phase 1, the before/after prompt must produce the same decisions on the same
+inputs — when in doubt, the line is a rule and stays.

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -1,4 +1,4 @@
-# DRAFT — v3, Function 5
+# DRAFT — v4, Function 5
 
 Obeys [`_shared.md`](_shared.md). Read it first.
 
@@ -8,109 +8,33 @@ A pure template-fill transform — no new identification, investigation, or
 pricing. Read the prior phases' files, render the template, validate
 against its constraints, write one self-contained local file. **Local
 file only — no eBay calls, no publishing** (firewall, per _shared).
+Rationale, history and the measurements behind the rules:
+[reference/draft-notes.md](reference/draft-notes.md).
 
 ## Photos come from PREP — DRAFT does not touch them up
 
-Photo preparation is its own phase now: **[PREP](prep.md)**, run after IDENTIFY.
-It handles orientation, crop, backdrop and the subject pass in one pass, writes
-`<shoot-dir>/listing/`, and stops at a HARD approval gate.
-
-**DRAFT's job here is only to point `photos:` at the prepped files:**
+Photo preparation is its own phase: **[PREP](prep.md)**, run after IDENTIFY.
+It writes `<shoot-dir>/listing/` and stops at a HARD approval gate. DRAFT's
+job is only to point `photos:` at the prepped files:
 
     python -m lib.photo_prep.prep <shoot-dir> --repoint-draft --apply-repoint
 
-That maps each existing entry to its prepped counterpart **in the same order** —
-entry one is the eBay gallery image and the list is often not lexicographic.
+That maps each existing entry to its prepped counterpart **in the same
+order** — entry one is the eBay gallery image and the list is often not
+lexicographic.
 
-If PREP has not been run, stop and run it; do not fall back to the old tools.
-`upload_photos_to_eps` enforces this in code, so an unprepped or unapproved
-shoot cannot publish regardless of what this prompt says.
+If PREP has not been run, stop and run it; do not fall back to the old tools
+(one-off exceptions in the notes). `upload_photos_to_eps` enforces this in
+code, so an unprepped or unapproved shoot cannot publish regardless of what
+this prompt says.
 
-<details>
-<summary>The old hand-chained sequence (superseded — kept for one-off use)</summary>
-
-The steps below ran as a chain: `strip_exif` → `even_background` →
-`trim_whitespace` → `center_crop`, each writing a subdirectory. **Do not run
-them as a chain any more.** Four subdirectories that all look plausible, plus a
-lexicographic photo picker at the end, is where 66 sideways photos hid until
-buyers complained. PREP replaces the whole sequence with one output directory
-and a manifest recording what was done to each frame.
-
-The individual tools still work for a quick one-off, and `orient.py`'s manifest
-is read *and written* by PREP so a rotation recorded in either is the call in
-both. What must not happen is running both on one shoot and then guessing which
-directory the draft points at.
-
-> ⛔ **The orientation test is CONTENT, not metadata.** "Would a buyer see this
-> the right way up?" is the only question that matters, and it cannot be answered
-> from EXIF. A clean metadata pass is necessary and nowhere near sufficient: a
-> phone held at an angle, a book laid on its side, a box shot end-on all produce
-> files that are correct by their EXIF and wrong on the page. Buyers complained
-> about exactly this, and it was declared fixed twice on the strength of the
-> metadata alone. **Never call photos good without looking at them, and never at
-> thumbnail size** — a whole batch was passed off small tiles with every frame
-> still rotated. See step 1b.
-
-Run the sequence (skip a step when it doesn't apply):
-
-1. **EXIF / orientation** — always. Bakes any real Orientation tag into the
-   pixels (`exif_transpose`), then strips metadata, so a viewer needs no tag to
-   get it right.
-       python -m lib.photo_prep.strip_exif <shoot-dir>            # -> <shoot-dir>/no-exif/
-       python -m lib.photo_prep.strip_exif <shoot-dir> --force    # after fixing a bug: stale
-                                                                 # outputs are NEWER than their
-                                                                 # sources and are skipped otherwise
-
-1b. **Orientation review — ALWAYS, and a HUMAN rules on it.** Step 1 only fixes
-   photos whose camera told the truth. For the rest:
-   - Build a numbered contact sheet of the SHIPPED files (`no-exif/`, opened with
-     NO transpose), frame numbers matching this draft's `photos:` order.
-   - Any frame that isn't obviously right: render it at **all four rotations side
-     by side** and pick by eye. Text baseline is the strongest cue (which way
-     would you tilt your head to read it), then how the object naturally sits.
-   - Record the call — never rotate a shipped file in place:
-         python -m lib.photo_prep.orient <shoot-dir> --set "1=180,2=ccw,3=cw"
-     It writes `<shoot-dir>/orientation.json` (degrees CW) and REBUILDS
-     `no-exif/` from the source every time, so a wrong call cannot stack and a
-     later strip_exif cannot silently revert a human's decision.
-   - **Show the user the sheet and get their ruling BEFORE anything publishes.**
-     They are looking at the real listings; you are not.
-   - On a flat lay with objects at odds, no rotation makes everything upright.
-     Pick the hero and SAY which secondary item stays inverted — that is a
-     re-shoot issue, not a rotation one. Don't claim the frame is perfect.
-2. **Backdrop cleanup — only for near-white/seamless backdrops** (NOT dark-felt
-   shots; the corner-sampling logic is tuned for light backgrounds). Evens
-   lighting/shadow, then trims the border to the subject.
-       python -m lib.photo_prep.even_background <dir>            # -> uniform backdrop
-       python -m lib.photo_prep.trim_whitespace <dir>           # -> <dir>/trimmed/
-3. **Center-crop — always.** Centers the item on its focal point at an
-   eBay-friendly aspect (square 1:1 default). Finds the subject by
-   background-contrast (works on dark felt AND light box interiors) and unions
-   ALL foreground pieces so a pair/set stays whole.
-       python -m lib.photo_prep.center_crop <dir> --check        # per-photo verdict + reason
-       python -m lib.photo_prep.center_crop <dir> --apply        # recenter in place (backs up to .orig/)
-   `--apply` overwrites in place so DRAFT's lexicographic photo picker uses the
-   centered files with no other change; default (no `--apply`) writes to
-   `cropped/`. Tunables: `--aspect 4:5`/`orig`, `--pad 0.12`, `--threshold` (flag
-   cutoff, default 6%). Writes a `crop_review.jpg` before|after contact sheet.
-   The tool REFUSES a crop it can't make safely (subject fills the frame, nothing
-   detected, detector locked onto a logo/fragment, or the crop would cut the
-   item): it prints `SKIPPED <reason>`, passes the original through untouched,
-   and labels that row on the review sheet. Expect a lot of skips on macro-heavy
-   shoots — that's the tool working. `--force` crops anyway; don't, unattended.
-
-Chaining: each tool reads a dir and writes a subdir — point the next step at the
-previous output. See [[feedback_center_crop_before_draft]].
-
-</details>
-
-**Check the photos before drafting (per [[feedback_crop_check_first]] ethos):**
-eyeball `<shoot-dir>/.prep/prep_review.jpg`. PREP self-skips the known misfires
-and prints the reason on each row, but that is a backstop, not a substitute — a
-crop can be merely ugly rather than unsafe, and a look can be wrong for the item
-without any rule catching it. Never draft on a bad pass: re-run PREP, `--pick`
-the other look, or record a different rotation. The approval that PREP's gate
-wants is the user's, on that sheet.
+**Check the photos before drafting:** eyeball
+`<shoot-dir>/.prep/prep_review.jpg`. PREP self-skips the known misfires and
+prints the reason on each row, but that is a backstop — a crop can be merely
+ugly rather than unsafe, and a look can be wrong for the item without any
+rule catching it. Never draft on a bad pass: re-run PREP, `--pick` the other
+look, or record a different rotation. The approval PREP's gate wants is the
+user's, on that sheet.
 
 ## Inputs
 
@@ -136,28 +60,20 @@ DRAFT never invents to fill gaps — missing inputs become flagged gaps.
 
 ## Style guide (optional overlay — OFF unless the run turns it on)
 
-A **style guide** under [`../styleguides/`](../styleguides/README.md) is a study
-of how one good seller lists — title slot order and budgets, body skeleton,
-voice. It is **off by default**. Load one only when the run names it ("use the
-patinaelements style guide") or a batch config sets `style_guide: <slug>`; then
-read `../styleguides/<slug>.md` and apply its **DRAFT — titles** and
-**DRAFT — description voice** sections while composing.
+A **style guide** under [`../styleguides/`](../styleguides/README.md) is a
+study of how one good seller lists. **Off by default.** Load one only when
+the run names it or a batch config sets `style_guide: <slug>`; then apply its
+**DRAFT — titles** and **DRAFT — description voice** sections while
+composing.
 
-It changes *how we say it*, never *what we may claim*. Every rule above and
-below still binds: INVESTIGATE remains the sole source of claims, no
-`[BEST-CASE]` language reaches copy, defects survive any trim, expected age
-gets one neutral clause, PII stays redacted (and disclosed), and the field
-constraints hold. **On any conflict, the house rule wins** — drop the guide's
-pattern, note it in `meta.notes`, and move on. Never reproduce a studied
-seller's title strings or sentences; the guide carries technique, not text.
-
-If a guide is loaded, say so in `meta.notes` (`style_guide: <slug>`) so the
-review card shows which listings were drafted under an overlay.
-
-**The patinaelements guide is no longer an overlay** — its title pattern and
-body skeleton were adopted as house style on 2026-08-24 and are written into
-the two sections below, claim bar intact. The overlay mechanism stays for the
-*next* seller we study.
+It changes *how we say it*, never *what we may claim*: INVESTIGATE remains
+the sole source of claims, no `[BEST-CASE]` language reaches copy, defects
+survive any trim, expected age gets one neutral clause, PII stays redacted
+(and disclosed), and the field constraints hold. **On any conflict, the house
+rule wins** — drop the guide's pattern, note it in `meta.notes`, move on.
+Never reproduce a studied seller's title strings or sentences; a guide
+carries technique, not text. If a guide is loaded, say so in `meta.notes`
+(`style_guide: <slug>`).
 
 ## Source-of-truth mapping
 
@@ -183,13 +99,14 @@ repeat a claim INVESTIGATE confirmed.
 **item_specifics:** from INVESTIGATE's "Item specifics" section ONLY. If
 INVESTIGATE listed it, copy; else `""` — do NOT fall back to IDENTIFY.
 Standard fields ≤65, `upc` ≤20. Extra specifics → `item_specifics.extra`.
-**Category-REQUIRED aspects must still be emitted** even if INVESTIGATE didn't
-itemize them and even when unbranded — eBay rejects the publish otherwise (errorId
-25002 "item specific <X> is missing"). A loaded specialization names its category's
-required aspects in its Output hooks (e.g. jewelry rings require `Metal` +
-`Metal Purity` + `Ring Size`); emit those into `item_specifics.extra` from
-INVESTIGATE/IDENTIFY. When unsure which a category requires, prefer including the
-obvious ones over a failed publish.
+**Category-REQUIRED aspects must still be emitted** even if INVESTIGATE
+didn't itemize them and even when unbranded — eBay rejects the publish
+otherwise (errorId 25002 "item specific <X> is missing"). A loaded
+specialization names its category's required aspects in its Output hooks
+(e.g. jewelry rings require `Metal` + `Metal Purity` + `Ring Size`); emit
+those into `item_specifics.extra` from INVESTIGATE/IDENTIFY. When unsure
+which a category requires, prefer including the obvious ones over a failed
+publish.
 
 **pricing:** `format` FIXED_PRICE (AUCTION only if price.txt says) ·
 `price` = working price as string, ≤13 · `cost_of_goods` null ·
@@ -200,94 +117,71 @@ list price sits ABOVE the supported price, so there's headroom to negotiate
 down to it.
 
 - Compare the list `price` to PRICE's **Recommended** tier (from price.txt).
-- **If `price` > Recommended** (listing in-between Recommended and Push-high,
-  or at/above Push-high): `best_offer.enabled` **true** ·
+- **If `price` > Recommended**: `best_offer.enabled` **true** ·
   `best_offer.auto_decline_amount` = **the Recommended tier price**, rounded
-  to the nearest whole dollar, as a string — auto-decline anything below the
-  supported price. (Fallback if price.txt has no Recommended tier: 85% of
-  list, nearest dollar.)
+  to the nearest whole dollar, as a string. (Fallback if price.txt has no
+  Recommended tier: 85% of list, nearest dollar.)
 - **If `price` ≤ Recommended**: `best_offer.enabled` **false**, both amounts
-  null — you're already at or below the supported price, so don't invite
-  offers.
+  null — don't invite offers below the supported price.
 - `best_offer.auto_accept_amount` is **always null** — never auto-accept;
   the user reviews and accepts offers manually.
 - Log the gate decision + computed auto-decline in `meta.notes`.
 
 **Net-floor check (MANDATORY — the floor is a price we AGREE to, not a
-formality).** An auto-decline figure is a standing offer to sell at that number,
-so before writing it, compute what we'd actually keep if a buyer hit it exactly:
+formality).** An auto-decline figure is a standing offer to sell at that
+number. Before writing it, compute what we'd actually keep if a buyer hit it
+exactly:
 
     net_at_floor = floor − fee(floor) − our_postage
 
 using PRICE's **measured fee band** (16–18% depending on size — see
 [price.md](price.md); it is NOT 13%) and the REAL postage for this item
-(everything now ships Ground Advantage on the single fulfillment policy — the
-account's Media Mail policy was deleted 2026-08-25, so do NOT price a book at the
-media rate; magazines and anything with ads were never Media Mail eligible
-anyway, per DMM 173.4.2). If `net_at_floor` is implausibly
-thin for the handling — packing, a trip to the mailbox, and the return risk —
-**raise the floor until it isn't**, and say so in `meta.notes`.
-
-This exists because it was gotten wrong: two magazine lots went live with floors
-set from the Recommended tier under the old 13% fee assumption, and at those
-floors an accepted offer netted **$13.46 and $9.67** on heavy Ground Advantage
-parcels. Both were raised at the REPORT phase (2026-08-15). The failure mode is
-specific — a low floor looks generous and costs nothing until someone takes it.
-
-Postage weighs most on cheap heavy things, so the check bites hardest exactly
-where the old rule was loosest: sub-$50 lots of paper.
+(everything ships Ground Advantage on the single fulfillment policy — never
+price a book at the media rate; ad-carrying paper was never Media Mail
+eligible, per DMM 173.4.2). If `net_at_floor` is implausibly thin for the
+handling — packing, a trip to the mailbox, and the return risk — **raise the
+floor until it isn't**, and say so in `meta.notes`. The check bites hardest
+on cheap heavy things: sub-$50 lots of paper.
 
 **shipping:** weight/dims from IDENTIFY (round up); `free_shipping` true →
 `domestic_shipping_type` FREE_FLAT_RATE; `primary_service` per Service
 map; `handling_time_days` 1; `item_location_zip` blank. **Set
 `fulfillment_mode` per the Local-pickup gate below** — default `SHIP`.
 
-**Local-pickup gate (SOFT — suggest, never assume).** Some items are
-awkward or unsafe to parcel-ship (heavy, oversized, or fragile like stained
-glass). For these we flag local pickup in the **description**, and the offer
-still lists on the single fulfillment policy — the account's local-pickup-only
-policy was deleted 2026-08-25, so `list_edit.py` falls back to the default ground
-policy and prints a warning. That means a `LOCAL_PICKUP` draft is a
-*disclosure*, not a shipping configuration: the listing still shows parcel
-shipping to buyers. Say so at REVIEW. Decide `fulfillment_mode`:
+**Local-pickup gate (SOFT — suggest, never assume).** A `LOCAL_PICKUP` draft
+is a *disclosure*, not a shipping configuration: the account's
+local-pickup-only policy was deleted 2026-08-25, so the offer still lists on
+the single fulfillment policy (with a warning from `list_edit.py`) and shows
+parcel shipping to buyers. Say so at REVIEW. Decide `fulfillment_mode`:
 
-- **Default `SHIP`.** Most items ship normally — leave `fulfillment_mode:
-  SHIP` and fill the shipping fields as usual.
-- **Set `LOCAL_PICKUP` only when the user has indicated it** — either they
-  said so for this item ("local only", "pickup only", "too fragile to ship"),
-  or you asked and they confirmed. The user usually says so up front.
-- **When to ASK (and you must ask before assuming):** if IDENTIFY's **Ship
-  risk** is `suggest-pickup` (weight > 25 lb or any side > 24 in), OR the item
-  is clearly fragile (stained/blown glass, thin porcelain), surface the
-  suggestion: *"This looks <reason> — risky to ship. List as local pickup
-  (freight by quote), or ship normally?"* **Attended:** ask and honor the
-  answer. **Headless (no one to ask):** keep `SHIP` (the safe non-blocking
-  default), and append a NEEDS_REVIEW line suggesting local pickup so it's
-  raised again at REVIEW. Never silently flip an item to pickup-only.
-- **When `LOCAL_PICKUP`:** set `fulfillment_mode: LOCAL_PICKUP`,
+- **Default `SHIP`.**
+- **Set `LOCAL_PICKUP` only when the user has indicated it** — they said so
+  for this item ("local only", "too fragile to ship"), or you asked and they
+  confirmed.
+- **When to ASK (and you must ask before assuming):** IDENTIFY's **Ship
+  risk** is `suggest-pickup` (weight > 25 lb or any side > 24 in), OR the
+  item is clearly fragile (stained/blown glass, thin porcelain): *"This
+  looks <reason> — risky to ship. List as local pickup (freight by quote),
+  or ship normally?"* **Attended:** ask and honor the answer. **Headless:**
+  keep `SHIP` (the safe non-blocking default) and append a NEEDS_REVIEW line
+  so it's raised again at REVIEW. Never silently flip an item to
+  pickup-only.
+- **When `LOCAL_PICKUP`:** `fulfillment_mode: LOCAL_PICKUP`,
   `free_shipping: false`, `domestic_shipping_type` blank, `primary_service`
-  blank (no parcel service); still record weight/dims (useful for a freight
-  quote). Set `local_pickup.location_hint` from the seller's city/region if
-  known. Add a short closing line to the description body: *"Local pickup only
-  — <location_hint>. Not local? Message me for a freight quote."* Log the
-  decision (+ trigger) in `meta.notes`.
+  blank; still record weight/dims (useful for a freight quote).
+  `local_pickup.location_hint` from the seller's city/region if known. Add a
+  short closing line to the body: *"Local pickup only — <location_hint>. Not
+  local? Message me for a freight quote."* Log the decision (+ trigger) in
+  `meta.notes`.
 
 **Carrier: there is no carrier choice.** Every item ships on the one
 fulfillment policy, `296458692014` ("Free USPS Ground + eBay International
 Shipping", free calculated USPS Ground Advantage, 1 day handling). Do not
 propose a carrier switch, do not estimate a rival carrier's cost, and do not
-override the policy at LIST time.
-
-The FedEx vs USPS carrier-check gate that used to live here was removed on
-2026-08-25: the FedEx policy it named (`292460878014`, "FedEx SmartPost / Ground
-Economy") had been deleted from the eBay account and returned 404, so following
-the gate produced an offer that could not be published. See
-docs/top-rated-plus.md.
-
-Weight and dimensions are still worth recording — they drive the calculated rate
-the buyer sees, and a freight quote if an item is too big for parcel. If an item
-genuinely cannot go USPS (oversize / >70 lb), say so in `meta.notes` and append a
-NEEDS_REVIEW line rather than selecting a different policy.
+override the policy at LIST time. Weight and dimensions are still worth
+recording — they drive the calculated rate and a freight quote. If an item
+genuinely cannot go USPS (oversize / >70 lb), say so in `meta.notes` and
+append a NEEDS_REVIEW line rather than selecting a different policy.
 
 **photos:** image files in shoot dir, lexicographic (first = hero). If
 INVESTIGATE references photos by number, honor that order.
@@ -316,126 +210,96 @@ quote) — also a strong local-pickup candidate (gate above).
 
 ## The house title pattern
 
-Measured, not guessed: 245 active listings from a seller worth matching,
-and the pattern held in every category sampled — jewelry, collectibles,
-glass, antiques, clothing (see
-[`../styleguides/_studies/patinaelements.md`](../styleguides/_studies/patinaelements.md)).
-Adopted as house style 2026-08-24.
+Adopted as house style 2026-08-24, measured across a studied seller's 245
+active listings (numbers in the notes).
 
-**Slot order** — era → object/maker → material → distinguishing detail →
-measurement → unit phrase. Era leads (their mean era slot is 0.4, and
-97% of titles carry an era word); material sits mid-title around slot 6.
-
-**Fill the field.** Target 75–80 characters. Their median is 78 and 89%
-run ≥75. Stop only when the next true keyword will not fit — never
-because the title "reads finished" at 55.
-
-**Budget ~2 descriptors** (their mean is 1.8, max 4). Past that it reads
-as keyword soup, and every adjective spent is a searchable noun lost.
-
-**Measurement earns a slot** where size is a buying decision — 56% of
-their antiques titles carry one, 37% of glass, 0% of clothing. Include
-it when we have a measured number, not an estimate.
-
-**Casing:** sentence/title case, with ALL-CAPS reserved for one or two
-tokens that genuinely carry weight (a maker, a model). Whole-title caps
-is shouting, not emphasis. **Separators:** prefer `/` for alternatives,
-`-` sparingly; no pipes, no bullets, no decorative characters.
-
-**The lead slot goes to a condition or scarcity word when one is
-earned**, ahead of the era word — `MINT`, `NOS`, `RARE`, `SCARCE`,
-`FINE`. The studied seller leads this way constantly (their mean
-condition slot is 0.2) and it is the strongest thing in the field: it is
-the first word a scrolling buyer reads. Earn it like this:
-
-- `MINT` / `NOS` / `EXCELLENT` — from the condition grade INVESTIGATE
-  already assigned via [condition-rubric.md](condition-rubric.md).
-  The rubric decides the word; the title just carries it. Grade to the
-  top of the supported band, per house practice — a clean piece is Mint.
-- `RARE` / `SCARCE` / `HTF` — only where INVESTIGATE found actual
-  scarcity evidence (a low production figure, a short production window,
-  a thin comp field after a real hunt). "I haven't seen another" is not
-  evidence, and neither is a high asking price.
-- `FINE` — quality of make, when the piece supports it.
-
-No word is earned → **the era word leads instead**, and that is a normal
-outcome, not a failure. The rest of the slots work the same way: era,
-maker, and material enter the title only where INVESTIGATE supports
-them, and an empty slot is correct when the evidence is not there. We
-lead as hard as the evidence allows and not one word harder.
+- **Slot order** — era → object/maker → material → distinguishing detail →
+  measurement → unit phrase. Era leads; material sits mid-title.
+- **Fill the field.** Target 75–80 characters. Stop only when the next true
+  keyword will not fit — never because the title "reads finished" at 55.
+- **Budget ~2 descriptors** (max 4). Past that it reads as keyword soup, and
+  every adjective spent is a searchable noun lost.
+- **Measurement earns a slot** where size is a buying decision (antiques,
+  glass — not clothing). Include it when we have a measured number, not an
+  estimate.
+- **Casing:** sentence/title case; ALL-CAPS reserved for one or two tokens
+  that genuinely carry weight (a maker, a model). **Separators:** prefer `/`
+  for alternatives, `-` sparingly; no pipes, no bullets, no decorative
+  characters.
+- **The lead slot goes to a condition or scarcity word when one is earned**,
+  ahead of the era word — it is the first word a scrolling buyer reads.
+  Earn it like this:
+  - `MINT` / `NOS` / `EXCELLENT` — from the condition grade INVESTIGATE
+    assigned via [condition-rubric.md](condition-rubric.md). The rubric
+    decides the word; the title just carries it. Grade to the top of the
+    supported band — a clean piece is Mint.
+  - `RARE` / `SCARCE` / `HTF` — only where INVESTIGATE found actual scarcity
+    evidence (a low production figure, a short production window, a thin
+    comp field after a real hunt). "I haven't seen another" is not evidence,
+    and neither is a high asking price.
+  - `FINE` — quality of make, when the piece supports it.
+- No word is earned → **the era word leads instead**, and that is a normal
+  outcome, not a failure. Era, maker and material enter the title only where
+  INVESTIGATE supports them; an empty slot is correct when the evidence is
+  not there. We lead as hard as the evidence allows and not one word harder.
 
 ## Markdown body (description)
 
-Compose from INVESTIGATE's claim set only, in this **fixed section
-order**. The skeleton is house style as of 2026-08-24 — it is the spine
-the studied seller uses on 100% of their bodies, and a body missing a
-section reads as a thinner listing:
+Compose from INVESTIGATE's claim set only, in this **fixed section order**
+(house skeleton as of 2026-08-24 — a body missing a section reads as a
+thinner listing):
 
-- **Opener** — ONE sentence, ~20 words, that names the item in full:
-  era, maker, material, object. It is the title expanded into a
-  sentence, and it is the same claim set as the title, so it needs no
-  new evidence. Written in first person (see Voice below).
-- **The look-at-this line** — one sentence on why it is worth a look:
-  the feature that makes it, how it displays, what it does. The studied
-  seller does this on half their listings and it is what stops a scroll.
-  Enthusiasm is allowed here; **claims are not smuggled in with it**.
-  "This displays beautifully" is a matter of taste and always fine;
-  "this is a rare piece" is a scarcity claim and needs the same evidence
-  the title's `RARE` needs.
+- **Opener** — ONE sentence, ~20 words, naming the item in full: era,
+  maker, material, object. The title expanded into a sentence — same claim
+  set, no new evidence. First person (see Voice).
+- **The look-at-this line** — one sentence on why it is worth a look: the
+  feature that makes it, how it displays, what it does. Enthusiasm is
+  allowed here; **claims are not smuggled in with it**. "This displays
+  beautifully" is taste and always fine; "this is a rare piece" is a
+  scarcity claim and needs the same evidence the title's `RARE` needs.
 - **The cross-sell line** — "This is one of several … I'm listing this
-  week, so please take a look at my other listings." Include it **only
-  when it is true**: there are sibling items from the same estate or lot
-  actually going up. One-off item → drop the line rather than invent a
-  batch.
+  week, so please take a look at my other listings." Include it **only when
+  it is true**. One-off item → drop the line rather than invent a batch.
 - **What's Included** — bullets from observable components; unit-type
   vocabulary.
-- **Size** — the measured dimensions, plus weight where it matters to
-  the buyer. **Required whenever we have a measurement.** If nothing was
+- **Size** — measured dimensions, plus weight where it matters to the
+  buyer. **Required whenever we have a measurement.** If nothing was
   measured, say so plainly rather than dropping the section.
 - **Condition** — factual, minimal. Bullets enumerating EVERY defect
-  INVESTIGATE flagged (no minimizing), each as `<location>: <defect>`.
-  At most one short context line for expected vintage wear; no warm
-  framing sentence, no marketing. Defects always survive any trim.
-  Close the section with the photos line — "Please see the photos and
-  read the description for full details" — which the studied seller
-  carries on 100% of listings. It sets the expectation that the photos
-  are part of the disclosure; it never substitutes for naming a defect
-  in words.
-- **Markings** — maker's mark, signature, hallmark, stamp, or label:
-  what it says and where it is, keyed to the photo that shows it.
-  **Required.** When there is none, `No maker's mark found.` is the
-  correct content — absence is information a buyer wants, and it is also
-  the honest alternative to implying attribution we cannot defend.
+  INVESTIGATE flagged (no minimizing), each as `<location>: <defect>`. At
+  most one short context line for expected vintage wear; no warm framing,
+  no marketing. Defects always survive any trim. Close the section with the
+  photos line — "Please see the photos and read the description for full
+  details" — it sets the expectation that the photos are part of the
+  disclosure; it never substitutes for naming a defect in words.
+- **Markings** — maker's mark, signature, hallmark, stamp, or label: what
+  it says and where it is, keyed to the photo that shows it. **Required.**
+  When there is none, `No maker's mark found.` is the correct content —
+  absence is information, and the honest alternative to implying
+  attribution we cannot defend.
 - **About this item** — 1–2 sentence collector hook from INVESTIGATE's
   listing-approach.
 - **The close** — the standing block, same on every listing, from
-  `store.closing_block` in [`../config.yaml`](../config.yaml): the
-  questions line, the terms line, the sign-off. It is boilerplate on
-  purpose — a buyer reads it once and it answers the questions that
-  otherwise arrive as messages. Render it verbatim from config; **do not
-  compose it per listing** and do not add claims to it. If a line in
-  that block ever stops being true, the fix is config, not a listing.
-  When `store.display_name` is set, the sign-off names the store; when
-  it is empty, the unnamed thank-you ships — never invent a brand name.
+  `store.closing_block` in [`../config.yaml`](../config.yaml). Boilerplate
+  on purpose. Render it verbatim; **do not compose it per listing**, do not
+  add claims to it. If a line stops being true, the fix is config, not a
+  listing. When `store.display_name` is set, the sign-off names the store;
+  when empty, the unnamed thank-you ships — never invent a brand name.
 
-**Length:** aim ~130–180 words (their median body is 133 across 245
-listings; ours carries the same spine plus the opener and close). Short
-paragraphs, ~20 words per sentence. A body under ~100 words is usually a
-section left empty — check which one before shipping it.
+**Length:** aim ~130–180 words. Short paragraphs, ~20 words per sentence. A
+body under ~100 words is usually a section left empty — check which one
+before shipping it.
 
-**Voice: first person, ours.** Write as the seller — "I picked this up
-from a local estate", "I haven't tested it". It reads as a person, and
-that is the point: the studied seller is in first person on 100% of
-bodies. Two things do not follow it into our copy:
+**Voice: first person, ours.** Write as the seller — "I picked this up from
+a local estate", "I haven't tested it". Two things do not follow it into our
+copy:
 
-- **Sentence case, never an all-caps body.** Caps is shouting, it is
-  harder to read on a phone, and it flattens the emphasis we do want.
+- **Sentence case, never an all-caps body.** Caps is shouting, harder to
+  read on a phone, and flattens the emphasis we do want.
 - **First person is not a licence to speculate.** "I think this might be
-  Georgian" is exactly the guess the claim bar exists to stop — first
-  person makes a claim sound softer without making it any more
-  supported. What I say in my own voice still has to be something
-  INVESTIGATE established. Where I genuinely don't know, say that
-  plainly and say what I did to check.
+  Georgian" is exactly the guess the claim bar exists to stop. What I say in
+  my own voice still has to be something INVESTIGATE established. Where I
+  genuinely don't know, say that plainly and say what I did to check.
 
 **In-hand voice — never from behind the camera** (house rule, adopted
 2026-08-26). The listing speaks as a seller holding the item. Language
@@ -449,29 +313,29 @@ field (title, body, `condition_description`, item specifics):
 - **inspection-process narration** — enumerating tests not run ("not
   shake-tested", "ring test not performed", "odor not verified").
 
-This is our internal evidence process leaking into the copy: it tells
-the buyer the seller never handled the item, and it manufactures doubt
-instead of preventing returns. **Rephrase rule: state the finding, never
-the method.** "No chips or cracks visible" → "No chips or cracks
-noted." "Knife handle seated tight in photos; not shake-tested" →
-"Knife handle sits tight." A photo-only observation ("UPC not shown in
-the photographed surfaces") is an internal note for `meta.notes` /
-NEEDS_REVIEW, never buyer copy.
+This is our internal evidence process leaking into the copy: it tells the
+buyer the seller never handled the item, and it manufactures doubt instead
+of preventing returns. **Rephrase rule: state the finding, never the
+method.** "No chips or cracks visible" → "No chips or cracks noted." "Knife
+handle seated tight in photos; not shake-tested" → "Knife handle sits
+tight." A photo-only observation ("UPC not shown in the photographed
+surfaces") is an internal note for `meta.notes` / NEEDS_REVIEW, never buyer
+copy.
 
 Untested status survives ONLY where it sets the grade (electronics /
-mechanical function, per condition-rubric): phrased plainly —
-"Untested; sold as-is." — with no photo excuse attached. Two things the
-rule does NOT touch: the internal record (IDENTIFY/INVESTIGATE still
-log every can't-assess — this rule governs only what reaches the
-buyer), and the standing close line "Please see the photos and read the
-description for full details" (it points the buyer at the photos as
-disclosure; it doesn't confess the inspection was photo-only). Defects
-themselves all still survive — the rule strips the camera frame off a
-disclosure, never the disclosure.
+mechanical function, per condition-rubric): phrased plainly — "Untested;
+sold as-is." — with no photo excuse attached. Two things the rule does NOT
+touch: the internal record (IDENTIFY/INVESTIGATE still log every
+can't-assess — this rule governs only what reaches the buyer), and the
+standing close line "Please see the photos and read the description for full
+details" (it points the buyer at the photos as disclosure; it doesn't
+confess the inspection was photo-only). Defects themselves all still
+survive — the rule strips the camera frame off a disclosure, never the
+disclosure.
 
-Hard rules: never include a claim absent from INVESTIGATE's listing-safe
-/ observable lists; never anything INVESTIGATE marked NOT defensible;
-never IDENTIFY `[BEST-CASE]` language; honor unit-type phrasing.
+Hard rules: never include a claim absent from INVESTIGATE's listing-safe /
+observable lists; never anything INVESTIGATE marked NOT defensible; never
+IDENTIFY `[BEST-CASE]` language; honor unit-type phrasing.
 
 ## Constraints — enforce before write (the hardest rule)
 
@@ -503,9 +367,8 @@ length ≤ max_len (rephrase if not) · required present (else flag) ·
 numeric parses positive (else flag, empty) · lookup canonical (else
 substitute + log). Also scan every buyer-visible field for camera-frame
 language (the in-hand-voice rule above) and rephrase any hit to the
-finding. Only then write draft.md. Re-read after write and
-confirm every constrained field fits and `_field_constraints` was copied
-verbatim.
+finding. Only then write draft.md. Re-read after write and confirm every
+constrained field fits and `_field_constraints` was copied verbatim.
 
 ## meta.notes (DRAFT NOTES)
 
@@ -516,23 +379,19 @@ substitution. These stay local — never pushed to eBay.
 
 ## Register the item (SKU + ledger record)
 
-**Whenever you finish writing `draft.md` — and again after any later edit to
-it — register the item:**
+**Whenever you finish writing `draft.md` — and again after any later edit
+to it — register the item:**
 
     python lib/list_edit.py --record <shoot-dir>
 
 This computes the item's **SKU** (a deterministic 8-hex hash of title +
 folder — no eBay call, no credentials), stamps it into the draft's
-`meta.ebay_inventory_sku`, and creates/refreshes the item's row in the
-listings ledger with status **DRAFTED**. It's idempotent — once the SKU is
-stamped it's reused, so an edit just refreshes the row's title/price and
-never duplicates it. The same row is later updated in place to
-SYNCED → PUBLISHED → ENDED/DELETED.
-
-This guarantees the record exists from draft time, **before REVIEW**.
-Belt-and-suspenders: `--review` (and `--sync`) also call `--record`
-internally, so a missed run is recovered; if you can't run a shell here, the
-record is created at the next step that can.
+`meta.ebay_inventory_sku`, and creates/refreshes the item's ledger row with
+status **DRAFTED**. Idempotent — once the SKU is stamped it's reused, so an
+edit refreshes the row and never duplicates it. The same row is later
+updated in place to SYNCED → PUBLISHED → ENDED/DELETED. This guarantees the
+record exists from draft time, **before REVIEW**; `--review` and `--sync`
+also call `--record` internally, so a missed run is recovered.
 
 ## Closing
 

--- a/prompts/prep.md
+++ b/prompts/prep.md
@@ -1,4 +1,4 @@
-# PREP — v3, Function 2.5 (photo preparation)
+# PREP — v4, Function 2.5 (photo preparation)
 
 Obeys [`_shared.md`](_shared.md). Read it first.
 
@@ -8,495 +8,256 @@ Obeys [`_shared.md`](_shared.md). Read it first.
 
 Turn a shoot's raw frames into listing-ready photos: upright, cropped to the
 item, backdrop softened, foreground sharpened. Runs **after IDENTIFY, before
-INVESTIGATE/DRAFT**.
-
-INVESTIGATE keeps reading the **originals** — condition evidence must never come
-from a processed file. Only DRAFT reads `listing/`.
-
----
+INVESTIGATE/DRAFT**. INVESTIGATE keeps reading the **originals** — condition
+evidence never comes from a processed file. Only DRAFT reads `listing/`.
+Rationale, history and the measurements behind every rule:
+[reference/prep-notes.md](reference/prep-notes.md).
 
 ## Style guide (optional overlay — OFF unless the run turns it on)
 
-A **style guide** under [`../styleguides/`](../styleguides/README.md) carries a
-studied seller's photo conventions: photo count target, backdrop lightness and
-neutrality, framing/subject fill, colour cast. **Off by default.** Load one only
-when the run names it or a batch config sets `style_guide: <slug>`, then read
-that guide's **PREP — photography** section.
+- Guides live under [`../styleguides/`](../styleguides/README.md). Load one
+  only when the run names it or a batch config sets `style_guide: <slug>`,
+  then read that guide's **PREP — photography** section.
+- Advisory only, and it lands on the review card, not in the stage contract:
+  a guide may tune backdrop/framing/count taste; it cannot add a stage,
+  override a look, or justify a drained frame. The stages (orientation →
+  crop → colour), look defaults, `--category` handling and the printed-media
+  rules are unchanged.
+- Note the loaded guide on the review card (`style_guide: <slug>`).
 
-It is **advisory**, and it lands on the review card, not in the stage contract:
-the four approved stages (orientation → unskew → crop → colour), the look
-defaults, `--category` handling, and the "printed media takes no crop" rule are
-unchanged. A guide can say "keep the backdrop light and neutral, crop tight"; it
-cannot add a stage, override a look, or justify a drained frame. Note the loaded
-guide on the review card (`style_guide: <slug>`) so the reviewer knows which
-conventions were in play.
+## Frame count — house target 10
 
-**The patinaelements guide is no longer an overlay** — its conventions were
-adopted as house style on 2026-08-24 and are written into the frame-count rule
-below. The overlay mechanism stays for the *next* seller we study.
+- Count frames BEFORE PREP runs. Under target → say so on the review card
+  (`frames: 6 (house target 10)`) and name the missing shots: the
+  marked/signed detail, the underside, each disclosed defect, a scale
+  reference. That list is the reshoot request; it is not a reason to hold the
+  listing.
+- PREP never invents frames. Eight good frames beat twelve padded ones.
+- Marble photo-protocol shoots keep their own spec — that is a per-item
+  agreement, not a count target.
 
----
-
-## Frame count — the house target
-
-**Ten frames per listing**, and count them before PREP runs, not after.
-Measured across 245 active listings of a seller worth matching: median 10
-photos, 38% at 12 or more, effectively none at the 24 cap
-([study](../styleguides/_studies/patinaelements.md)). Eight good frames beat
-twelve padded ones, but a three-frame listing is a thin listing, and the fix
-is a reshoot, not processing.
-
-PREP does not invent frames. When a shoot comes in under target, **say so on
-the review card** — `frames: 6 (house target 10)` — and name the shots that
-are missing: the marked/signed detail, the underside, each disclosed defect,
-a scale reference. That list is the reshoot request; it is not a reason to
-hold the listing.
-
-The photo-protocol conventions for marbles stay as they are — that spec is a
-per-item agreement, not a count target.
-
----
-
-## The hero is a MONTAGE — decided per listing
-
-The gallery frame can carry two or three views composed into one image: the
-object whole, plus the detail that sells it — the maker's mark, the piece
-open, the box it came in. A buyer scrolling a search page sees one thumbnail,
-and one thumbnail can say more than one thing.
+## The hero MAY be a montage — decided per listing
 
     python -m lib.photo_prep.hero_montage propose <shoot>
     python -m lib.photo_prep.hero_montage apply   <shoot> --style m2 --repoint
 
-**There is no default style, and no default to montage at all.** `propose`
-renders BOTH candidates side by side over a numbered strip of every frame, and
-the operator picks: **montage 1** (main + one supporting view — inset when
-that view is a detail, split panels when it is a different state or object),
-**montage 2** (main + two thumbnails down the quietest corner), or **neither**,
-which ships the clean frame and leaves the details in slots 2 onward. The
-studied seller montages roughly 18% of their listings, not all of them; a
-single clear object often needs no help.
-
-Frame choice is a guess and gets reviewed. The picker takes the main view from
-listing order — never reordering, that is the operator's decision — and
-chooses companions for DISTINCTNESS: each has to be unlike the main view AND
-unlike the companions already chosen. That rule exists because scoring against
-the main view alone put two photographs of the same presentation box in the
-same hero, twice: each was a fine answer to "unlike the macro", and together
-they said one thing twice. If nothing left is distinct enough, it says so and
-offers the two-frame hero only. Override with `--frames 1,6,3` — the numbers
-are the strip.
-
-It also checks the main frame against PREP's subject detector and says so when
-the object runs off the edge of the picture, naming the frames that show it
-whole.
-
-**The honesty rule this tool cannot enforce:** a montage must never imply the
-buyer gets more than one item. Panels show one listing's contents, and two
-panels that read as two objects for sale is a misleading gallery image no
-matter how good it looks. When in doubt, thumbnails rather than equal panels —
-a thumbnail reads as a detail, equal panels read as an inventory.
-
-**Known risk, accepted deliberately:** eBay's picture standards discourage
-added borders and composited artwork on the gallery image. The studied seller
-runs montages at scale on live listings, which is the evidence that it is
-tolerated in practice, but it is tolerance and not a guarantee. If eBay ever
-pulls a gallery image for it, the fix is to ship the clean frame as the hero
-and move the montage to slot two — nothing else in the pipeline changes.
-
----
+- **No default style, and no default to montage at all.** `propose` renders
+  both candidates over a numbered strip of every frame; the operator picks:
+  **montage 1** (main + one supporting view — inset for a detail, split
+  panels for a different state or object), **montage 2** (main + two
+  thumbnails down the quietest corner), or **neither** (clean frame as hero,
+  details in slots 2 onward). A single clear object often needs no help.
+- The picker takes the main view from listing order — never reordering, that
+  is the operator's decision — and chooses companions for DISTINCTNESS: each
+  unlike the main view AND unlike the companions already chosen. If nothing
+  left is distinct enough it says so and offers the two-frame hero only.
+  Override with `--frames 1,6,3` — the numbers are the strip.
+- It warns when the main frame's subject runs off the edge of the picture,
+  naming the frames that show it whole.
+- **Honesty rule the tool cannot enforce:** a montage must never imply the
+  buyer gets more than one item. When in doubt, thumbnails rather than equal
+  panels — a thumbnail reads as a detail, equal panels read as an inventory.
+- eBay's picture standards discourage composited gallery images; running them
+  is a deliberate, revocable risk. If eBay ever pulls one: clean frame to
+  hero, montage to slot two, nothing else changes.
 
 ## The run OPENS with a best attempt, made without asking
 
     python -m lib.photo_prep.prep <shoot> --auto
 
 One pass, no questions: every frame turned the way PREP reads it, every crop
-planned, nothing approved and nothing rendered. Then the operator looks ONCE at
-what it did and either takes it or opens the stages.
+planned, nothing approved and nothing rendered. Two protections are enforced
+in code:
 
-Why it is allowed to guess. The staged review below is the point of PREP, and it
-also spends the operator's attention on frames where the answer was never in
-doubt. Deciding first and asking second costs nothing as long as two things hold,
-and they are enforced in code:
+- **A guess is labelled a guess.** A frame the resolver cannot read takes the
+  best signal it has (the OSD proposal, else 0) and records `guessed: true`.
+  Report guessed frames by name, every time — a guess presented as a
+  resolution is the one way this pass can hurt.
+- **The crop is deliberately loose.** `DEFAULT_PAD` 0.28 of the item's box,
+  `MIN_FRAME_KEPT` 0.55 floor: a crop trims edges and always leaves backdrop.
 
-- **A guess is labelled a guess.** A frame the resolver cannot read would
-  normally become an ASK and stop the run. Here it takes the best signal it has
-  (the OSD proposal, else 0) and records `guessed: true`. Report those frames by
-  name, every time — they are exactly the ones worth a human look, and a guess
-  presented as a resolution is the one way this pass can hurt.
-- **The crop is deliberately loose.** `DEFAULT_PAD` is 0.28 of the item's own
-  box, and `MIN_FRAME_KEPT` (0.55) is a floor under the whole box: a crop trims
-  the edges and always leaves backdrop around the item. Too generous costs a
-  second look. Too tight has already thrown pixels away, and nobody re-shoots.
-
-Apply the pass, then gate on confidence, not on the operator (operator's
+Apply the pass, then **gate on confidence, not on the operator** (operator's
 call, 2026-08-27):
 
 - **Every frame resolved, nothing guessed, every self-check clean** — the
-  normal case — run `--approve-auto` yourself, which signs off orientation AND
-  crop together, and move straight to colour. Show ONE card
+  normal case — run `--approve-auto` yourself (signs off orientation AND crop
+  together) and move straight to colour. Show ONE card
   (`python tools/prep_card.py <shoot>`) of the revised frames as a record of
-  what shipped, not as a question. The operator can still override anything
-  from the card, but the run does not stop to wait for it.
-- **Anything guessed or flagged** — a `guessed: true` frame, a mask the colour
-  stage cannot trust, a crop the pipeline refused — ask about THOSE frames
-  only, by name, and approve the rest. The one question is about the
+  what shipped, not as a question; the run does not stop to wait.
+- **Anything guessed or flagged** — a `guessed: true` frame, a mask the
+  colour stage cannot trust, a crop the pipeline refused — ask about THOSE
+  frames only, by name, and approve the rest. The one question is about the
   exception, never "may I continue".
 
-Auto-approval never buys a lower bar. `--auto` still approves nothing by
-itself, `listing/` is still written only after the stages are signed off, and
-`--approve-auto` stamps the same per-stage digest a sheet approval does — so
-any later edit invalidates it the same way. What changed is who clicks it when
-the pipeline has nothing to ask.
+Auto-approval never buys a lower bar: `--auto` approves nothing by itself,
+`listing/` is still written only after sign-off, and `--approve-auto` stamps
+the same per-stage digest a sheet approval does — any later edit invalidates
+it the same way.
 
-## The interactive review is the EXCEPTION path — and it is STAGED
+## The interactive review — the exception path, STAGED
 
-This is where an override lands, and where a shoot goes whenever the auto pass
-is not good enough. Three corrections, in this order, and **you do not move on
-until the operator says the current one is right**:
+Where an override lands, and where a shoot goes when the auto pass is not
+good enough. Three corrections, in dependency order, and you do not move on
+until the operator says the current one is right:
 
     1. ORIENTATION  ->  2. CROP  ->  3. COLOUR / touch-up
 
-This ordering is not a preference, it is a dependency. A crop is only meaningful
-once the frame is the right way up. A colour judgement is only meaningful on the
-final framing. Shown together, a bad crop and a bad rotation look the same on
-the page and neither can be answered.
-
-**There used to be an UNSKEW stage between orientation and crop**, warping a
-rectangular item so its edges met the picture's. It was removed in 2026-08 on
-the operator's call: it cost a quad fit and a full-frame resample on every
-frame, it damaged more photos than it saved — a quad landing on a mat, a mount
-or a soft shadow squares up the wrong rectangle — and two degrees of tilt is not
-something a buyer sees in a thumbnail. Nothing plans one now. A shoot that was
-squared before it went still REPLAYS its recorded warp, so re-running PREP on a
-live shoot returns the pixels a buyer is already looking at.
+A crop is only meaningful once the frame is upright; a colour judgement only
+on the final framing. (UNSKEW was removed 2026-08; nothing plans one, but a
+previously squared shoot REPLAYS its recorded warp, so re-running PREP on a
+live shoot returns the pixels a buyer is already looking at.)
 
 ## Orientation is DECIDED, not asked — above 95% confidence
 
-Orientation is the one stage where the answer is usually in the picture, and it
-is not a good use of the operator's attention. So the model decides it:
-
     python tools/prep_orient_review.py <shoot>   # -> .prep/orient_review_N.jpg
 
-A row per frame, all four turns side by side, big enough to read printed body
-copy, current call ruled green, with the OSD reading printed for reference.
-**Read it, decide, apply with `--set-rotate`, and only surface the frames that
-fall below the bar.** Do not build a clickable picker for this stage and do not
-ask the operator to rule on frames you can read.
+Read the sheet (a row per frame, all four turns, OSD reading printed for
+reference), decide, apply with `--set-rotate`, and surface only the frames
+below the bar. Do not build a clickable picker for this stage, and never ask
+the operator to rule on frames you can read.
 
-**What clears 95%** — a positive, legible signal:
+**Clears 95%** — a positive, legible signal:
 
-- printed text whose baseline you can read (a masthead, body copy, a caption);
-- a human figure, which in a fashion or catalog frame is the strongest cue there
-  is: head up, garment hanging down;
-- an object with an unambiguous upright (a locomotive on its wheels);
-- **and** agreement with the rest of the shoot where the frames are alike — as a
-  *prompt to look again*, never as the answer. This used to read "six spreads
-  photographed in one session cannot correctly differ by 90°", and that is
-  false: on `paul-fredrick` the cover was shot portrait-wise and the spreads
-  were laid on the bedspread turned 90°, so the subject half genuinely differed
-  within one session. The camera half is shared across a session; the way the
-  item was laid down is not. Treating disagreement as proof of error is what
-  made a correct OSD reading look wrong (see `docs/osd-audit-2026-08-21.md`).
+- printed text whose baseline you can read;
+- a human figure (head up, garment hanging down) — the strongest cue in a
+  fashion or catalog frame;
+- an object with an unambiguous upright;
+- **and** agreement with like frames in the shoot — as a *prompt to look
+  again*, never as the answer: the camera half is shared across a session,
+  the way the item was laid down is not.
 
-**What does NOT clear it**, and goes to the operator with the sheet:
+**Does NOT clear** (→ operator, with the sheet): "looks more natural" with
+nothing legible to point at; a frame whose two halves disagree (say which cue
+you followed and why); a round or flat item with no defined upright; anything
+resting on OSD alone.
 
-- "it looks more natural this way" with nothing legible to point at;
-- a frame whose two halves disagree — a masthead upright on one page and a model
-  upright on the other. Say which cue you followed and why;
-- a round or flat item with no defined upright;
-- anything resting on OSD alone. **OSD is reference, not evidence.** Measured
-  across 73 frames where a human look was recorded beside the reading, OSD
-  agreed with the operator **49%** of the time at the old confidence floor —
-  a coin toss. The floor is now 4.0, where it agrees 84% of the time and
-  answers 42% of frames; below that it reports no answer and the frame becomes
-  an ASK. Regenerate the numbers with `python tools/osd_audit.py --bands`.
+**OSD is reference, not evidence.** Confidence floor 4.0; below it OSD
+reports no answer and the frame becomes an ASK (regenerate the bands with
+`python tools/osd_audit.py --bands`). A reading above the floor is STILL
+reference: high orientation confidence with weak script confidence means
+tesseract is confident about marks it does not recognise as language, and on
+flat printed media OSD can be confidently wrong — the orientation gate is
+what catches it.
 
-  Note what this does NOT license: a reading that clears 4.0 is still
-  reference. 84% is not 100%, and the one frame that shipped sideways on
-  `paul-fredrick` read confidence 12.29 — well clear of any bar — on a script
-  confidence of 0.6. High orientation confidence with weak script confidence
-  means tesseract is confident about marks it does not recognise as language.
+State the confidence per frame and name the cue. A number without a cue is
+not a judgement.
 
-State the confidence per frame when you report, and name the cue. A number
-without a cue is not a judgement.
+**Orientation is first — nothing else is measured yet.** `--check` resolves
+which way is up and stops; it does NOT plan crop or colour, which would
+otherwise be measured against a rotation nobody confirmed.
+`--approve-stage orientation` then runs `plan_geometry()` itself against the
+just-approved rotations; planning refuses outright while orientation is
+unapproved.
 
-**Orientation is first, and that means nothing else is measured yet.**
-`--check` reads EXIF, segments, runs the text detector and resolves which way is
-up — and stops there. It does NOT plan the crop or the colour reading, because
-each of those describes the geometry it was computed on: measure them against a
-rotation nobody has confirmed, and a later turn silently invalidates both. Six catalog spreads shipped exactly that way, with crops
-planned at 0° while the manifest ended up saying 270°.
+## The Frame Check page — the locked review format
 
-`--approve-stage orientation` then runs `plan_geometry()` itself, against the
-rotations just approved, so the operator never has to remember a second command.
-Planning refuses outright while orientation is unapproved. It costs one extra
-decode per frame; it buys the guarantee that no downstream number was ever
-computed against a rotation that later changed.
-
-Each stage shows **a card per photo with a thumbnail for every option at that
-stage, side by side**, current choice ruled green. The operator is picking from
-pictures, never reading a description of a picture.
-
-**Present it as the Frame Check page, every time — orientation, crop AND
-colour.** This is the settled format. Do not hand over a JPEG contact sheet, do
-not describe the frames in prose, and do not invent a different layout for any
-stage: all three use the same page, the same card, the same controls.
+Every stage — orientation, crop AND colour — and every modified image is
+shown the same way: same page, same card, same controls. Never a JPEG contact
+sheet, never prose in place of a picture, never a per-stage improvisation.
 
     python tools/prep_sheet_html.py <shoot>      # -> <shoot>/.prep/review.html
 
-then publish that file as an artifact and give the user the link. Republish the
-SAME file path after every change so the link never moves.
+Publish that file as an artifact and link it; republish the SAME path after
+every change so the link never moves. Pair it with a one-click accept in chat
+so the operator never copies a command by hand. (The JPEG builders —
+`--stage NAME` → `.prep/stage_N_*.jpg` — remain the fallback when no page can
+be published.)
 
-What the page must have, on every stage:
-
-| | |
-|---|---|
-| **A card per frame** | one picture per card, big enough to judge |
-| **Every option side by side** | as clickable thumbnails, current one ruled green |
-| **An override on every card** | including frames the pipeline refused — a card you cannot argue with is not a review. A refused crop still offers *force a crop* |
-| **A free-text box on every card** | the options only cover the overrides we thought of; "the smokestack is clipped" has to have somewhere to go. Typed notes ride along with the command |
-| **An Accept button per stage** | says plainly that it sends the stage as shown, with any changes and notes attached |
-| **Click any picture to open it full size** | the thumbnail is enough to make the call, the detail is what the call rests on |
-| **The exact command, copyable** | the page cannot reach the CLI; a fake Apply button would be worse than admitting that |
-
-**The page must work with JavaScript switched off.** This is the rule that cost
-the most to learn. Selection is native radio inputs, the picture shown is a CSS
-`:has()` rule, the tabs are a radio group, the full-size preview is `:target`.
-Script is layered on top for one job — assembling the command — and the page is
-fully usable when it never runs. Two versions built the DOM in JS and routed
-every click through a handler; both rendered perfectly and neither responded to
-a single click in the viewer the operator actually uses. Script-dependent UI
-fails as a page that looks finished and does nothing.
-
-Rules that follow from getting it wrong, in order of how much they cost:
-
-1. **No inline `onclick`, and no JS-built DOM.** Render the markup from Python.
-2. **Never assume a key event landed on an element** — it can land on the
-   document, which has no `closest()`, and the handler dies silently.
-3. **Never render a lone option as a button.** One option is not a choice; it
-   reads as broken. Give it a real alternative or no button row at all.
-4. **Write each image's bytes once**, as a CSS custom property on the card, and
-   paint the thumbnail, the option chip and the full-size preview from it. Three
-   copies took a fourteen-frame shoot to 15 MB against a 16 MB ceiling.
-5. **Anything that looks clickable must be clickable**; anything that is not
-   gets no affordance.
-0. **Nothing may depend on a modern selector, a URL or a script.** Three
-   mechanisms have been tried and abandoned, each of which worked perfectly in a
-   normal tab and was dead in the frame the operator reads these pages in: a
-   JS-built DOM (script never ran), `:target` for the previews and the Accept
-   panel (a URL fragment never lands in a sandboxed frame), and `:has()` for
-   selection, tabs and chips (a 2022 selector — where it is missing the page
-   draws perfectly and answers nothing). Every piece of state is a native input
-   at the TOP of its container and everything it drives is a following sibling
-   reached by `~`, which has worked since CSS2. A control whose input is nested
-   inside the thing it styles cannot work — that is how the Accept button
-   shipped inert. Held by `tests/test_prep_sheet_html.py`.
-6. **Never hand-list the options in CSS.** The rule that decides which picture a
-   card shows matches on the option's **index**, generated up to `MAX_OPTS` — not
-   on its value. An earlier version spelled the values out (`"0"`, `"90"`, `"on"`,
-   `"off"`, `"studio"`, `"punch"`), so the day the colour stage grew `half`,
-   `tenth` and `crisp`, picking any of the three matched no rule: the card went
-   blank and the full-size preview opened empty, on the stage the operator uses
-   most. A stage must be able to add an option without anyone remembering to edit
-   a stylesheet. Held by `tests/test_prep_sheet_html.py`, which fails if the rules
-   go back to being hand-listed or a stage outgrows the generated range.
-
-**Verify the page in a browser before handing it over** — every option on every
-card, checking that the picture changes in BOTH the card and the full-size
-preview. Both bugs above rendered perfectly and did nothing; neither is visible
-in the markup, and neither would have shipped if one pass had actually clicked
-through the options. `tests/test_prep_sheet_html.py` covers the generator; the
-click-through covers the page.
-
-The JPEG builders still exist (`--stage NAME` writes `.prep/stage_N_*.jpg`) and
-are the fallback when no page can be published.
-
-## SHOWING A MODIFIED IMAGE — the locked template
-
-Every time PREP changes a picture, the operator sees it this way. No
-exceptions, no per-stage improvisation, and never a prose description in place
-of the picture.
-
-**The rule: never show a result without what it came from.** A cropped frame
-alone is unreviewable — the question is not "is this a good picture", it is
-"was the right thing removed". The same holds for a rotation and a colour pass.
-
-    BEFORE            →   AFTER              →   why, in the operator's words
-    (what it was)         (what will ship)       ("would cut 10% off the page")
+**Never show a result without what it came from.** The question is "was the
+right thing removed", never "is this a good picture":
 
 | Stage | Before | After | Options offered |
 |---|---|---|---|
-| orientation | the frame as the camera gave it | at the chosen turn | all four turns |
+| orientation | as the camera gave it | at the chosen turn | all four turns |
 | crop | the full frame | the crop result | cropped / as shot / force a crop |
 | colour | as shot | each rendered look | as shot + every look |
 
-Requirements, all of them load-bearing:
+The page must have, on every stage — all load-bearing:
 
 1. **A card per frame**, one picture per card, big enough to judge.
-2. **Every option side by side as a thumbnail**, current choice ruled green.
-3. **Click any picture to open it full size**; arrow keys step frame to frame.
-4. **An override on every card**, including frames the pipeline refused. A card
-   you cannot argue with is not a review. A refused crop still offers *force a
-   crop*, and says it cannot be previewed.
-5. **A free-text box on every card.** The options only cover the overrides we
-   thought of; "the smokestack is clipped" needs somewhere to go.
-6. **The reason, per frame, in words** — "no studio backdrop (luma 192)", "would
-   cut 10% off the subject". A refusal without a reason reads as a failure.
-7. **An Accept button per stage**, stating that it sends the stage as shown.
-8. **The exact command, copyable**, and generated in an IDEMPOTENT form
-   (`--set-rotate`, not `--rotate`) — see the rules below.
+2. **Every option side by side as thumbnails**, current choice ruled green —
+   the operator picks from pictures, never a description of a picture.
+3. **Click any picture to open it full size**; arrow keys step frame to
+   frame.
+4. **An override on every card**, including frames the pipeline refused — a
+   card you cannot argue with is not a review. A refused crop still offers
+   *force a crop*, and says it cannot be previewed.
+5. **A free-text box on every card** — "the smokestack is clipped" needs
+   somewhere to go; typed notes ride along with the command.
+6. **The reason, per frame, in words** ("no studio backdrop (luma 192)"). A
+   refusal without a reason reads as a failure.
+7. **An Accept button per stage**, stating it sends the stage as shown.
+8. **The exact command, copyable, in IDEMPOTENT form** (`--set-rotate`, never
+   `--rotate` — a relative command moves the frame again on every paste).
 
-Build it with:
+**The page must work with JavaScript OFF, in a sandboxed frame, on old CSS.**
+Held by `tests/test_prep_sheet_html.py`:
 
-    python tools/prep_sheet_html.py <shoot>      # -> <shoot>/.prep/review.html
+1. No inline `onclick`, no JS-built DOM — render the markup from Python.
+   Script does ONE job (assembling the command); the page is fully usable
+   when it never runs.
+2. Nothing may depend on a modern selector, a URL or a script — no `:has()`,
+   no `:target`. Every piece of state is a native input at the TOP of its
+   container, driving following siblings via `~`. A control whose input is
+   nested inside the thing it styles cannot work.
+3. Selector rules match the option's **index**, generated up to `MAX_OPTS` —
+   never hand-listed values. A stage must be able to add an option without
+   anyone editing a stylesheet.
+4. Write each image's bytes ONCE, as a CSS custom property on the card, and
+   paint thumbnail, option chip and preview from it.
+5. Never assume a key event landed on an element — it can land on the
+   document, which has no `closest()`.
+6. Never render a lone option as a button; anything that looks clickable must
+   be clickable, and anything that is not gets no affordance.
 
-publish that file as an artifact, link it, and republish the SAME path after
-every change so the link never moves. Pair it with a one-click accept in chat
-so the operator never copies a command by hand.
-
-**The page must work with JavaScript switched off.** Selection is native radio
-inputs, the shown picture is a CSS `:has()` rule, tabs are a radio group, the
-preview is `:target`. Script does one job — assembling the command — and the
-page is fully usable when it never runs. Two versions built the DOM in JS and
-routed every click through a handler; both rendered perfectly and neither
-responded to a single click in the viewer the operator actually uses.
-
-Rules learned by breaking them, in order of what they cost:
-
-1. **No inline `onclick`, and no JS-built DOM.** Render the markup from Python.
-2. **A generated command must be idempotent.** `--rotate` is relative to what
-   the sheet shows; a page that emits it as if it were absolute moves the frame
-   again on every paste. Use `--set-rotate`.
-3. **Never assume a key event landed on an element** — it can land on the
-   document, which has no `closest()`, and the handler dies silently.
-4. **Never render a lone option as a button.** One option is not a choice.
-5. **Write each image's bytes once**, as a CSS custom property on the card.
-   Three copies took a fourteen-frame shoot to 15 MB against a 16 MB ceiling.
-6. **Anything that looks clickable must be clickable**; anything that is not
-   gets no affordance.
-
-The JPEG builders (`--stage NAME`) remain as the fallback when no page can be
-published.
-
----
-
-## What the audit found, and what it changed
-
-An audit of 819 already-published frames (`tools/prep_saturation_audit.py`, then
-`tools/prep_saturation_verify.py` against the subject mask) found item colour
-destroyed on **14 frames across 10 shoots**, 9 of them live. Worth keeping in
-mind because every one had the same shape:
-
-- the correction was behaving **correctly on a wrong premise**. Segmentation
-  handed part of the item to the backdrop, and the backdrop pass neutralised it,
-  which is exactly what it is told to do to cloth;
-- the tell is **mask coverage**: 43–70% on flat printed catalog covers, 5–9% on
-  thin silver on a light ground. Those two subjects are the weakness;
-- the first-pass sweep flagged 39 shoots, but **54 of 76 frames were the
-  correction working** — a backdrop cast being removed. Measure inside the mask
-  before calling anything damage.
-
-Mitigations now in the code: `_protect_objects` tests chroma as well as luma
-(`CHROMA_OBJECT_MIN`, measured — cloth reaches 24, paint starts at 54), `crisp`
-is the default for new items, and `asshot` exists for when a shoot's mask cannot
-be trusted at all.
-
-**Open defect — OSD can be confidently wrong.** On paul-fredrick the detector
-read subject 270 on five frames at confidence up to 12.2 with recognised script,
-all corroborating each other, and all wrong: the pages ship at 270 applied, not
-0. The one frame it could not read is the one the operator kept correcting by
-hand, and they were right every time. "High confidence, corroborated" is exactly
-the state in which a headless run would ship these unreviewed. Do not trust OSD
-alone on flat printed media; the orientation gate is what catches it.
+**Verify the page in a browser before handing it over** — every option on
+every card, checking the picture changes in BOTH the card and the full-size
+preview. The costliest bugs rendered perfectly and did nothing.
 
 ## The looks
 
-Both render every time; the operator picks. They differ only in how hard they
+All render for comparison; the operator picks. They differ in how hard they
 push, never in what they may touch.
 
 | Preset | Backdrop | Item |
 |---|---|---|
-| `half` | studio at half strength — every move halved | half the pop and sharpen |
+| `half` | studio with every move halved (`k=0.5`) | half the pop and sharpen |
 | `studio` | neutralised to true black/white, fuzz blurred | sharpened |
 | `punch` | same | stronger contrast and colour |
 
-`half` is not a fourth set of numbers to keep in step. It is studio with `k=0.5`,
-the same multiplier the rail guard already backs off with, so it halves the
-white-balance gain, the backdrop curve, the neutralise, the blur, the pop and
-the sharpen together. Reach for it when a look reads washed out: the wash comes
-from the correction, so less correction is less wash.
+Reach for `half` when a look reads washed out: the wash comes from the
+correction, so less correction is less wash.
 
-### Printed media takes NO crop, either.
+**Defaults:**
 
-**On books, magazines, catalogs and mailers, force `--crop <every frame>=off`.**
+- **`crisp` for any NEW item, whatever the backdrop** — the only look that
+  cannot misrepresent the goods: full-strength backdrop cleanup, item colour
+  exactly as the camera recorded it.
+- **An item ALREADY LIVE keeps the look it was published under.** Change one
+  on purpose with `--pick`, never in bulk — re-rendering silently changes
+  pictures a buyer may have seen.
+- Backdrop-led defaults for existing shoots: `punch` on dark or navy cloth,
+  `studio` on a light sweep. The default decides what is SHOWN at the gate,
+  never what publishes.
 
-Same cause as the colour rule, a different stage. The crop stage looks for the
-highest-contrast object in the frame; on an open catalog that object is the
-photograph PRINTED IN THE LAYOUT, not the catalog. So it crops the merchandise
-away and keeps the picture of it.
+## Printed media — books, magazines, catalogs, mailers
 
-Measured on live listings before the fix: `j-crew/3` shipped cropped to a
-printed boot with the J.CREW masthead — the thing that identifies the listing —
-outside the frame; `mark-shale-business-casual` to a printed chair, keeping 24%
-of the original; `brother-tree` into the body text at 18.9%; and the
-`fall-and-winter-1980` mailer to a bare black bar, because the crop locked onto
-the redaction rectangle over the address. Of 56 cropped media frames the median
-kept 75% and the tail ran to 19%.
-
-There is no crop worth making here. The object of the listing is the whole page,
-edges included: a buyer judging a catalog is judging its cover wear, its corners
-and its squareness, all of which live exactly where a tight crop cuts. Set crop
-off for the class rather than trying to teach the detector what a catalog is.
-
-Order matters when re-rendering: set the crop off BEFORE `--apply`. A crop
-change invalidates the renders, so doing it afterwards renders every frame
-twice.
-
-### Printed media renders `asshot`. No exceptions from the default path.
-
-**Books, magazines, catalogs, mailers — any shoot whose subject is printed paper
-— default to `asshot` (k=0), not to `studio`.**
-
-The correction cannot be trusted on this class, and the reason is structural
-rather than a tuning miss. A catalog is photographed open on a light sweep, so
-the printed page IS a large light field with ink on it: the segmenter hands that
-page to the backdrop, and the backdrop pass then does exactly what it is told to
-do to a backdrop — neutralise it toward paper white. White balance has nothing
-reliable to lock onto either, because the page's own ink is the dominant colour
-and glossy stock throws the sweep's cast straight back into the lens.
-
-Measured on `more-mags-444/fall-and-winter-1980`, on renders that were already
-live: saturation against source-selected pixels fell 51.8% on the hero, 60.9%
-and 61.3% on two interior spreads, and 94.0% on the mailer. The damage scales
-linearly with `k` — studio -39.4%, half -19.2%, tenth -3.5%, asshot -0.2% —
-which is the signature of the backdrop pass eating the subject, not of a bad
-curve. Re-running under the chroma guard did not change those numbers.
-
-`tenth` is the compromise if a genuine cast has to come off. `asshot` is the
-default because the failure is silent: a drained catalog spread still looks like
-a catalog spread, and nothing in the pipeline flags it.
-
-**Default: `crisp` for any NEW item, whatever the backdrop.** It is the only
-look that cannot misrepresent the goods — full-strength backdrop cleanup, the
-item's colour left exactly as the camera recorded it. An item ALREADY LIVE keeps
-the look it was published under; re-rendering it into a different one silently
-changes pictures a buyer may already have seen. Change one on purpose with
-`--pick`, never in bulk.
-
-The older backdrop-led defaults still apply to existing shoots:
-**`punch` on a dark or navy cloth, `studio` on a light sweep.** A
-deepened backdrop gives the item something to separate against, so the extra
-push pays off; on a white sweep the same push has nothing to separate from and
-reads as over-processed. `--pick` overrides. The default decides what is SHOWN
-at the gate, never what publishes.
-
----
+- **NO crop: force `--crop <every frame>=off`.** The crop detector locks onto
+  the photograph PRINTED in the layout and crops the merchandise away. The
+  object of the listing is the whole page, edges included — cover wear,
+  corners and squareness live exactly where a tight crop cuts. Set crop off
+  BEFORE `--apply`; a crop change afterwards invalidates the renders and
+  renders every frame twice.
+- **Colour: `asshot` (k=0), no exceptions from the default path.** The
+  segmenter hands the printed page to the backdrop pass, which neutralises it
+  toward paper white; the damage scales linearly with `k` and the failure is
+  silent — a drained spread still looks like a spread. `tenth` is the
+  compromise when a genuine cast has to come off.
+- **Orientation: prefer the OSD read over the vision estimate** when the two
+  disagree — text is the one thing on a page with an unambiguous upright, and
+  the corroboration rule guards OSD's known false positive.
 
 ## Categories — say what the goods ARE, once
-
-Most of PREP's flags are not preferences. They are statements about what is in
-front of the camera, and they have the same answer every time for a given kind
-of goods. `--category` carries the whole set:
 
 ```bash
 python -m lib.photo_prep.prep <shoot> --category printed --check
@@ -507,40 +268,17 @@ python -m lib.photo_prep.prep <shoot> --category printed --check
 | `default` | `auto` — both detectors, arbitrated on agreement | all six, for comparison |
 | `printed` | `paper` — LAB decides; u2net kept as a second opinion | `asshot` only |
 
-**Why `printed` needs its own detector.** On a catalog the salient object is the
-picture PRINTED ON the item, so u2net cuts out the cover model and returns a
-mask that is a strict sub-region of the paper. The containment test cannot catch
-that — a box wholly inside the paper's box scores 1.0. LAB has no such
-confusion: paper against a sweep is the figure/ground split it measures.
-
-**Why it renders one look.** The section above already says printed media ships
-`asshot`, always. Rendering the other five produces images nobody opens, at
-~25s a frame each. Measured on five 12 MP catalog frames, same decisions and
-the same gates: **8m10s under `default` → 45.6s under `printed`, 10.7×**. Per
-frame, once u2net is loaded, that is ~94s → ~5.1s.
-
-Two of those seconds came back from `asshot` itself: at `k=0` every term in the
-colour correction is multiplied by zero and the result discarded, so the loop is
-now skipped outright rather than computed and thrown away (26s → 3.9s a frame).
-The pixels and the full colour report are asserted identical to the old path.
-
-`looks` narrows what is RENDERED, never what is picked. The operator still
-chooses at the colour stage and `--pick` still overrides. A one-look category
-says *the comparison is not live for this kind of item* — not *this look is
-approved*.
-
-**The category persists in the manifest**, so a later `--check` or `--apply`
-that does not repeat the flag gets the same answer. Changing it drops the
-crop/colour sign-offs, because every box downstream of the detector was
-measured against the old one. `--subject auto|paper` remains available as the
-escape hatch for a shoot its category gets wrong, and outranks it.
-
-Categories live in `lib/photo_prep/categories.py`. Adding one is data, not code
-— but keep it grounded: every field should trace to something observed on a real
-shoot. A category invented from taste is a policy change wearing a config file,
-and it reaches hundreds of frames before anyone notices it was a guess.
-
----
+- `looks` narrows what is RENDERED, never what is picked. A one-look category
+  says *the comparison is not live for this kind of item*, not *this look is
+  approved*. `--pick` still overrides.
+- The category persists in the manifest, so a later `--check`/`--apply` that
+  omits the flag gets the same answer. Changing it drops the crop/colour
+  sign-offs — every box downstream of the detector was measured against the
+  old one. `--subject auto|paper` is the per-shoot escape hatch and outranks
+  it.
+- Categories are data (`lib/photo_prep/categories.py`), but every field must
+  trace to something observed on a real shoot. A category invented from taste
+  is a policy change wearing a config file.
 
 ## What it will not do
 
@@ -548,19 +286,17 @@ The line is between **the studio** and **the goods**. Re-toning, neutralising
 and blurring the backdrop are fair game. On the item itself: white balance,
 exposure, contrast and sharpening only.
 
-**No denoise, no smoothing, no blemish removal, ever.** Those are what soften
-scratches and even out tarnish, and a listing photo that disagrees with its own
-condition disclosure is worse than a flat one. Sharpening earns its place by
-cutting the other way — it makes fine wear *more* legible.
+**No denoise, no smoothing, no blemish removal, ever.** Those soften
+scratches and even out tarnish, and a listing photo that disagrees with its
+own condition disclosure is worse than a flat one. Sharpening earns its place
+by cutting the other way — it makes fine wear *more* legible.
 
-Automatic refusals, all reported per frame on the sheet:
+Automatic refusals, each reported per frame on the sheet:
 
-- **No studio backdrop** → no crop, no backdrop move. A macro of a maker's mark
-  or a serial stamp has the item's own surface behind it; lifting aged tan paper
-  toward white is cosmetically nicer and a misrepresentation.
-- **A large object in the backdrop** → protected from neutralising and blurring.
-  A ruler laid alongside for scale falls outside the subject mask and is *not*
-  cloth; blurring it destroys measurement evidence.
+- **No studio backdrop** → no crop, no backdrop move (a mark macro's
+  "backdrop" is the item's own surface; lifting it is misrepresentation).
+- **A large object in the backdrop** → protected from neutralising and
+  blurring (a scale ruler is measurement evidence).
 - **Mask failure** (subject under 2% of frame) → every backdrop operation off.
 - **Detectors disagree** on where the item is → no crop.
 - **The item would be cut**, or the crop lands under 1400px → no crop.
@@ -568,62 +304,37 @@ Automatic refusals, all reported per frame on the sheet:
 The colour pass also measures its own output: no correction may push an item
 pixel to pure black or white that was not already there.
 
----
+**When a frame looks damaged, measure INSIDE the subject mask before calling
+it damage** — most flagged frames are the correction correctly removing a
+backdrop cast. Low mask coverage (flat printed covers; thin silver on a light
+ground) is the tell that segmentation handed item to backdrop.
 
 ## Orientation: what is trusted
 
-Two independent rotations, composed:
+Two independent rotations, composed: **camera** (the EXIF Orientation tag —
+objective, always applied) and **subject** (how the item was laid in the
+frame — no metadata knows this).
 
-- **Camera** — the EXIF Orientation tag. Objective, always applied.
-- **Subject** — how the item was laid in the frame. **No metadata knows this.**
+The subject half comes from OSD **corroborated by another like frame in the
+same shoot**, or from a recorded look, or it goes to ASK. Nothing infers
+"probably upright" from an aspect ratio; a round item is resolved by someone
+looking once and confirming `0`. Recorded rotations mirror into
+`<shoot>/orientation.json`, shared with
+[`lib/photo_prep/orient.py`](../lib/photo_prep/orient.py) — a call made in
+either tool is the call in both.
 
-The subject half comes from page-orientation detection (objective, but only when
-**corroborated by another frame in the same shoot** — measured false positives
-include a textless macro read as text at higher confidence than a real magazine
-cover), or from a recorded look, or it goes to ASK.
+## The old chain
 
-On printed media, prefer the page-orientation (OSD) read over the vision
-estimate when the two disagree. Text is the one thing on a catalog page that has
-an unambiguous upright, and the corroboration rule already guards OSD's known
-false positive. Measured on `fall-and-winter-1980`: the three frames resolved
-`exif+osd` all landed upright, while two of the three resolved `exif+vision`
-shipped rotated 90 degrees with the models on their sides and the body text
-running vertically — and none of them were flagged ASK, so the pipeline was
-confidently wrong rather than uncertain.
-
-Nothing infers "probably upright" from an aspect ratio. A round item with no
-defined upright is resolved the same way as everything else: someone looks once
-and confirms `0`.
-
-Recorded rotations mirror into `<shoot>/orientation.json`, the same file
-[`lib/photo_prep/orient.py`](../lib/photo_prep/orient.py) writes, so a call made
-in either tool is the call in both.
-
----
-
-## What replaced what
-
-| Old step | Now |
-|---|---|
-| `strip_exif` | PREP bakes EXIF internally; `no-exif/` is legacy output |
-| `even_background`, `trim_whitespace` | PREP's backdrop pass (mask-driven, works on dark felt too) |
-| `center_crop` | PREP's crop (its safety guards are reused, not reimplemented) |
-| `orient.py --set` | still works; PREP reads AND writes its manifest |
-| DRAFT step 1/1b/2/3 | this prompt |
-
-`strip_exif` and `orient.py` remain useful on their own for a quick one-off.
-What must not happen is running the old chain *and* PREP on one shoot and then
-guessing which directory the draft points at — that ambiguity is what the single
-`listing/` output and the code-level gate exist to remove.
-
----
+`strip_exif` and `orient.py` remain useful for a quick one-off; PREP subsumes
+the rest (mapping in the notes). Never run the old chain AND PREP on one
+shoot — the single `listing/` output and the code-level gate exist to remove
+exactly that ambiguity.
 
 ## Gate contract
 
-PREP is a **HARD gate** and stops the run, including headless, until the user
-approves. It is enforced in code as well as here: `upload_photos_to_eps` refuses
-photos that are not prepped and approved, so an unapproved shoot cannot reach
-eBay even if this prompt is ignored. Approval goes stale automatically if a
-source or an output changes — what was approved must be what is uploaded.
-
-Flip it to soft only when the user says so.
+PREP is a **HARD gate** and stops the run, including headless, until
+approval. Enforced in code: `upload_photos_to_eps` refuses photos that are
+not prepped and approved, so an unapproved shoot cannot reach eBay even if
+this prompt is ignored. Approval goes stale automatically when a source or an
+output changes — what was approved must be what is uploaded. Flip to soft
+only when the user says so.

--- a/prompts/reference/draft-notes.md
+++ b/prompts/reference/draft-notes.md
@@ -1,0 +1,111 @@
+# DRAFT — rationale, history, and evidence
+
+Companion to [prompts/draft.md](../draft.md). The prompt holds the rules;
+this file holds *why* they exist, plus the superseded procedures kept for
+one-off use. Read this only when a rule is disputed or being changed — never
+as part of a routine DRAFT run.
+
+## The house pattern: where the numbers come from
+
+Title pattern and body skeleton were measured across 245 active listings of
+a studied seller ([study](../../styleguides/_studies/patinaelements.md)) and
+adopted as house style 2026-08-24, claim bar intact. The patinaelements
+guide stopped being an overlay at that point; the overlay mechanism stays
+for the *next* seller we study. The evidence behind each title rule:
+
+- **Era leads:** their mean era slot is 0.4, and 97% of titles carry an era
+  word; material sits mid-title around slot 6.
+- **Fill the field:** their median title is 78 characters and 89% run ≥75.
+- **~2 descriptors:** their mean is 1.8, max seen 4.
+- **Measurement earns a slot:** 56% of their antiques titles carry one, 37%
+  of glass, 0% of clothing — size is a buying decision in some categories
+  and noise in others.
+- **Condition/scarcity lead:** their mean condition slot is 0.2 — when a
+  word is earned, it goes first.
+
+Body skeleton: the spine appears on 100% of their bodies; the
+look-at-this line on about half; the "Please see the photos" close on 100%;
+first person on 100%. Their median body is 133 words across 245 listings —
+ours carries the same spine plus the opener and close, hence the 130–180
+target.
+
+## Net-floor check: the two lots that paid for it
+
+Two magazine lots went live with auto-decline floors set from the
+Recommended tier under the old 13% fee assumption. At those floors an
+accepted offer netted **$13.46 and $9.67** on heavy Ground Advantage
+parcels; both were raised at the REPORT phase (2026-08-15). The failure mode
+is specific — a low floor looks generous and costs nothing until someone
+takes it. Postage weighs most on cheap heavy things, so the check bites
+hardest exactly where the old rule was loosest: sub-$50 lots of paper.
+
+## Carrier: why there is no choice
+
+The FedEx-vs-USPS carrier-check gate that used to live in the shipping
+section was removed 2026-08-25: the FedEx policy it named (`292460878014`,
+"FedEx SmartPost / Ground Economy") had been deleted from the eBay account
+and returned 404, so following the gate produced an offer that could not be
+published. Every item now ships on the single fulfillment policy; the
+account's Media Mail and local-pickup-only policies were deleted the same
+week. See docs/top-rated-plus.md.
+
+## The old hand-chained photo sequence (superseded — kept for one-off use)
+
+The chain was `strip_exif` → `even_background` → `trim_whitespace` →
+`center_crop`, each writing a subdirectory. **Do not run it as a chain any
+more.** Four subdirectories that all look plausible, plus a lexicographic
+photo picker at the end, is where 66 sideways photos hid until buyers
+complained. PREP replaces the sequence with one output directory and a
+manifest recording what was done to each frame. The individual tools still
+work for a quick one-off, and `orient.py`'s manifest is read *and written*
+by PREP, so a rotation recorded in either is the call in both. What must not
+happen is running both on one shoot and then guessing which directory the
+draft points at.
+
+> ⛔ **The orientation test is CONTENT, not metadata.** "Would a buyer see
+> this the right way up?" cannot be answered from EXIF: a phone held at an
+> angle, a book laid on its side, a box shot end-on all produce files that
+> are correct by their EXIF and wrong on the page. Buyers complained about
+> exactly this, and it was declared fixed twice on the strength of the
+> metadata alone. Never call photos good without looking at them, and never
+> at thumbnail size — a whole batch was passed off small tiles with every
+> frame still rotated.
+
+The steps, when a one-off genuinely needs them:
+
+1. **EXIF / orientation** — bakes any real Orientation tag into the pixels
+   (`exif_transpose`), then strips metadata.
+       python -m lib.photo_prep.strip_exif <shoot-dir>            # -> no-exif/
+       python -m lib.photo_prep.strip_exif <shoot-dir> --force    # stale outputs are
+                                                                  # newer than sources
+                                                                  # and skipped otherwise
+1b. **Orientation review — a HUMAN rules on it.** Build a numbered contact
+   sheet of the SHIPPED files (opened with NO transpose), numbers matching
+   `photos:` order. Any frame not obviously right: render all four rotations
+   side by side, pick by eye (text baseline first, then how the object
+   naturally sits). Record the call — never rotate a shipped file in place:
+       python -m lib.photo_prep.orient <shoot-dir> --set "1=180,2=ccw,3=cw"
+   It writes `orientation.json` (degrees CW) and REBUILDS `no-exif/` from
+   source every time, so a wrong call cannot stack and a later strip_exif
+   cannot silently revert a human's decision. Show the user the sheet and
+   get their ruling BEFORE anything publishes. On a flat lay with objects at
+   odds, no rotation makes everything upright: pick the hero and SAY which
+   secondary item stays inverted — a re-shoot issue, not a rotation one.
+2. **Backdrop cleanup — only near-white/seamless backdrops** (NOT dark
+   felt; the corner-sampling is tuned for light grounds).
+       python -m lib.photo_prep.even_background <dir>
+       python -m lib.photo_prep.trim_whitespace <dir>             # -> trimmed/
+3. **Center-crop.** Centers the item at an eBay-friendly aspect (square 1:1
+   default), finds the subject by background-contrast, unions ALL
+   foreground pieces so a pair/set stays whole.
+       python -m lib.photo_prep.center_crop <dir> --check         # verdict + reason
+       python -m lib.photo_prep.center_crop <dir> --apply         # in place (backs up
+                                                                  # to .orig/)
+   Tunables: `--aspect 4:5`/`orig`, `--pad 0.12`, `--threshold` (default
+   6%). Writes `crop_review.jpg`. The tool REFUSES a crop it can't make
+   safely and prints `SKIPPED <reason>` — expect many skips on macro-heavy
+   shoots; that's the tool working. `--force` crops anyway; don't,
+   unattended.
+
+Chaining: each tool reads a dir and writes a subdir — point the next step at
+the previous output.

--- a/prompts/reference/prep-notes.md
+++ b/prompts/reference/prep-notes.md
@@ -1,0 +1,187 @@
+# PREP — rationale, history, and evidence
+
+Companion to [prompts/prep.md](../prep.md). The prompt holds the rules; this
+file holds *why* they exist, so the prompt stays a checklist. Read this only
+when a rule is disputed or being changed — never as part of a routine PREP
+run.
+
+## Frame count: where "10" comes from
+
+Measured across 245 active listings of a seller worth matching
+([study](../../styleguides/_studies/patinaelements.md)): median 10 photos,
+38% at 12 or more, effectively none at the 24 cap. The patinaelements
+conventions were adopted as house style on 2026-08-24, which is why that
+guide is no longer an overlay; the overlay mechanism stays for the *next*
+seller we study.
+
+## Montage: the distinctness rule and the accepted risk
+
+The studied seller montages roughly 18% of their listings, not all of them —
+hence "no default to montage". The distinctness rule (companions unlike the
+main view AND unlike each other) exists because scoring against the main view
+alone put two photographs of the same presentation box in the same hero,
+twice: each was a fine answer to "unlike the macro", and together they said
+one thing twice.
+
+The eBay picture-standards risk is accepted deliberately: the studied seller
+runs montages at scale on live listings, which is evidence it is tolerated in
+practice — tolerance, not a guarantee.
+
+## Why the auto pass may guess
+
+The staged review is the point of PREP, but it also spends the operator's
+attention on frames where the answer was never in doubt. Deciding first and
+asking second costs nothing as long as a guess is labelled a guess and the
+crop is loose enough that "too generous" only costs a second look — "too
+tight" has already thrown pixels away, and nobody re-shoots.
+
+## Why the gate moved to confidence (2026-08-27)
+
+Operator's call, part of the self-optimizing-sessions program (GH #36): an
+approval that is always "yes" is pure friction. The per-step accept became a
+confidence gate — self-approve when everything is resolved and clean, ask
+only about named exceptions. Nothing about the quality bars moved; what
+changed is who clicks approve when the pipeline has nothing to ask.
+
+## UNSKEW: why it was removed (2026-08)
+
+It warped a rectangular item so its edges met the picture's. Removed on the
+operator's call: it cost a quad fit and a full-frame resample on every frame,
+and it damaged more photos than it saved — a quad landing on a mat, a mount
+or a soft shadow squares up the wrong rectangle — while two degrees of tilt
+is not something a buyer sees in a thumbnail. The REPLAY rule (a previously
+squared shoot re-applies its recorded warp) exists so re-running PREP on a
+live shoot returns the pixels a buyer is already looking at.
+
+## Orientation: the measurements behind the rules
+
+**The OSD floor (4.0).** Measured across 73 frames with a recorded human look
+beside the reading: at the old confidence floor OSD agreed with the operator
+**49%** of the time — a coin toss. At 4.0 it agrees 84% and still answers 42%
+of frames. Regenerate with `python tools/osd_audit.py --bands`
+(`docs/osd-audit-2026-08-21.md`).
+
+**Why 84% is still "reference, not evidence."** The one frame that shipped
+sideways on `paul-fredrick` read confidence 12.29 — well clear of any bar —
+on a script confidence of 0.6: tesseract confident about marks it did not
+recognise as language. On the same shoot the detector read subject 270 on
+five frames at confidence up to 12.2, with recognised script, all
+corroborating each other, and all wrong — "high confidence, corroborated" is
+exactly the state in which a headless run ships mistakes unreviewed. The
+orientation gate is what catches it.
+
+**Why OSD needs corroboration at all.** Measured false positives include a
+textless macro read as text at higher confidence than a real magazine cover —
+which is why an uncorroborated OSD read goes to ASK instead of resolving.
+
+**Why session agreement is a prompt, not an answer.** The rule used to read
+"six spreads photographed in one session cannot correctly differ by 90°", and
+that is false: on `paul-fredrick` the cover was shot portrait-wise and the
+spreads were laid on the bedspread turned 90°. The camera half is shared
+across a session; the way the item was laid down is not. Treating
+disagreement as proof of error made a correct OSD reading look wrong.
+
+**Why OSD beats the vision estimate on printed media.** Measured on
+`fall-and-winter-1980`: the three frames resolved `exif+osd` all landed
+upright; two of the three resolved `exif+vision` shipped rotated 90° — models
+on their sides, body text running vertically — and none were flagged ASK. The
+pipeline was confidently wrong rather than uncertain.
+
+**Why nothing is planned before orientation approval.** Crop and colour
+describe the geometry they were computed on. Six catalog spreads shipped with
+crops planned at 0° while the manifest ended up saying 270° — hence `--check`
+stops after orientation, and `plan_geometry()` runs only against approved
+rotations.
+
+## The Frame Check page: rules learned by breaking them
+
+Every constraint in the prompt's page-contract list was paid for:
+
+- **JS-off / no modern selectors.** Two versions built the DOM in JS and
+  routed every click through a handler; both rendered perfectly and neither
+  responded to a single click in the sandboxed frame the operator actually
+  reads these pages in. Three mechanisms were tried and abandoned — a
+  JS-built DOM (script never ran), `:target` previews (a URL fragment never
+  lands in a sandboxed frame), `:has()` selection (a 2022 selector — where
+  missing, the page draws perfectly and answers nothing). Native inputs
+  driving `~` siblings has worked since CSS2. The Accept button once shipped
+  inert because its input was nested inside the element it styled.
+- **Index-matched selector rules.** An earlier version hand-listed option
+  values (`"0"`, `"90"`, `"studio"`, …) in CSS; the day the colour stage grew
+  `half`, `tenth` and `crisp`, picking any of the three matched no rule — the
+  card went blank and the preview opened empty, on the stage the operator
+  uses most. `tests/test_prep_sheet_html.py` fails if the rules go back to
+  being hand-listed or a stage outgrows `MAX_OPTS`.
+- **One copy of each image's bytes.** Three copies took a fourteen-frame
+  shoot to 15 MB against the 16 MB artifact ceiling.
+- **Idempotent commands.** `--rotate` is relative to what the sheet shows; a
+  page emitting it as if absolute moved the frame again on every paste —
+  hence `--set-rotate`.
+- **Click-through verification.** Both of the worst bugs rendered perfectly
+  and did nothing; neither was visible in the markup. The generator test
+  covers the generator; only clicking covers the page.
+
+## The saturation audit (2026-08-19): why "measure inside the mask"
+
+An audit of 819 already-published frames (`tools/prep_saturation_audit.py`,
+then `tools/prep_saturation_verify.py` against the subject mask) found item
+colour destroyed on 14 frames across 10 shoots, 9 live. Every one had the
+same shape: the correction behaving **correctly on a wrong premise** —
+segmentation handed part of the item to the backdrop, and the backdrop pass
+neutralised it, exactly as it is told to do to cloth. The tell is mask
+coverage: 43–70% on flat printed catalog covers, 5–9% on thin silver on a
+light ground. The first-pass sweep flagged 39 shoots, but 54 of 76 flagged
+frames were the correction *working* (a backdrop cast being removed) — hence:
+measure inside the mask before calling anything damage.
+
+Mitigations now in code: `_protect_objects` tests chroma as well as luma
+(`CHROMA_OBJECT_MIN`, measured — cloth reaches 24, paint starts at 54),
+`crisp` is the default for new items, `asshot` exists for a shoot whose mask
+cannot be trusted at all.
+
+## Printed media: the measurements
+
+**Crop.** Before the rule, of 56 cropped media frames the median kept 75% of
+the frame and the tail ran to 19%: `j-crew/3` shipped cropped to a printed
+boot with the J.CREW masthead outside the frame; `mark-shale-business-casual`
+to a printed chair (24% kept); `brother-tree` into body text (18.9%); the
+`fall-and-winter-1980` mailer to a bare black bar — the crop locked onto the
+redaction rectangle over the address.
+
+**Colour.** On `more-mags-444/fall-and-winter-1980`, live renders: saturation
+against source-selected pixels fell 51.8% on the hero, 60.9% and 61.3% on two
+spreads, 94.0% on the mailer. Damage scales linearly with `k` — studio
+−39.4%, half −19.2%, tenth −3.5%, asshot −0.2% — the signature of the
+backdrop pass eating the subject, not of a bad curve. Re-running under the
+chroma guard did not change the numbers. The failure is silent (a drained
+spread still looks like a spread), which is why `asshot` is the default
+rather than a warning.
+
+**Why `printed` has its own detector.** On a catalog the salient object is
+the picture printed ON the item, so u2net cuts out the cover model and
+returns a mask that is a strict sub-region of the paper — and the containment
+test cannot catch it (a box wholly inside the paper's box scores 1.0). LAB
+has no such confusion: paper against a sweep is exactly the figure/ground
+split it measures.
+
+**The speed numbers.** Rendering five looks nobody opens costs ~25s a frame.
+Measured on five 12 MP catalog frames, same decisions, same gates: 8m10s
+under `default` → 45.6s under `printed` (10.7×); per frame, once u2net is
+loaded, ~94s → ~5.1s. Two of those seconds came from `asshot` itself: at
+`k=0` every correction term was being computed, multiplied by zero and
+discarded; the loop is now skipped (26s → 3.9s a frame), with pixels and the
+colour report asserted identical to the old path.
+
+## What replaced what (the old chain)
+
+| Old step | Now |
+|---|---|
+| `strip_exif` | PREP bakes EXIF internally; `no-exif/` is legacy output |
+| `even_background`, `trim_whitespace` | PREP's backdrop pass (mask-driven, works on dark felt too) |
+| `center_crop` | PREP's crop (its safety guards are reused, not reimplemented) |
+| `orient.py --set` | still works; PREP reads AND writes its manifest |
+| DRAFT step 1/1b/2/3 | the PREP prompt |
+
+The prohibition on running the old chain and PREP on one shoot exists because
+the resulting ambiguity — which directory does the draft point at? — is what
+the single `listing/` output was built to remove.


### PR DESCRIPTION
Re-files #38, which GitHub auto-closed when #37's branch was deleted out from under it. Same content, now against main.

- **`docs/V4_PLAN.md`** — the phased v4 plan: #30 (diet, terse tools, one CLI) as the structural core, #36 (session observer) as the feedback loop, #23/#31/#32 building on the result. Ground rules: honesty gates never move; a diet that changes behavior is a bug.
- **`prep.md`: 629 → 340** + `reference/prep-notes.md` (190) — the two near-duplicate review-page sections merged into one page contract.
- **`draft.md`: 543 → 402** + `reference/draft-notes.md` (111) — the superseded old-chain block moved wholesale to the notes.

Same split `price.md` got in #34: rules stay in the prompt, the *why* moves to reference notes read only when a rule is disputed. Verified: both test runners green; the `--repoint-draft` wiring assertion preserved; diets cross-checked section-by-section with three near-losses caught and restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)