### PR TITLE
v4 phase 1 complete: every stage prompt dieted or audited to rules-only

### DIFF
--- a/docs/V4_PLAN.md
+++ b/docs/V4_PLAN.md
@@ -22,13 +22,21 @@ only to AGREE?
       near-duplicate review-page sections merged into one
 - [x] `draft.md` — 543→402 + `reference/draft-notes.md` (111); the
       superseded old-chain procedure moved wholesale to the notes
-- [ ] `identify.md` (364)
-- [ ] `list_edit_chrome.md` (276)
-- [ ] `_shared.md` (208)
-- [ ] `curate.md` (186)
-- [ ] `promote.md` (159)
-- [ ] `review.md` / `investigate.md` / `condition-rubric.md` (already short —
-      audit only, diet if a page of rationale hides in them)
+- [x] `identify.md` — 364→326 + `reference/identify-notes.md` (46); mostly
+      rules already, so the cut is prose compression
+- [x] `list_edit_chrome.md` — 276→222 + `reference/list-edit-chrome-notes.md`
+      (52); incident histories (hen run, 2026-06-07 photo findings) moved;
+      status corrected from "deprecated when API lands" to "fallback for
+      categories the API can't publish"
+- [x] `_shared.md` — 208→201; near-pure contract, light trim only
+- [x] `curate.md` — audited, already rules-only; header bump
+- [x] `promote.md` — 159→158, two small trims; header bump
+- [x] `review.md` / `investigate.md` / `condition-rubric.md` — audited,
+      already rules-only; header bumps
+
+Phase 1 result: the per-stage prompt set totals ~2,500 lines of rules (was
+~3,300 mixed), with ~490 lines of rationale parked in `prompts/reference/`
+loaded only on dispute.
 
 ## Phase 2 — terse tool output (#30)
 

--- a/prompts/_shared.md
+++ b/prompts/_shared.md
@@ -1,8 +1,7 @@
-# _shared — rules every v3 phase obeys
+# _shared — rules every phase obeys (v4)
 
-Single source for the rules that used to be copy-pasted into all five
-phase prompts. Each phase prompt references this file instead of
-restating it. Read this once per run; the phase prompts assume it.
+Single source for the cross-phase rules. Read this once per run; the
+phase prompts assume it.
 
 ---
 
@@ -29,10 +28,9 @@ all three of:
 
 1. its **thumbnail image, EMBEDDED as a base64 `data:` URI** — download the
    comp's `thumbnail` (`i.ebayimg.com/...`) yourself, resize small, and inline
-   it. **Do NOT use `<img src="https://i.ebayimg.com/...">`** — the widget /
-   artifact sandbox CSP blocks ALL remote image hosts, so a remote `src` renders
-   as a BROKEN image (this is the #1 failure the user has hit — do not repeat
-   it). Only self-contained `data:image/jpeg;base64,...` sources render.
+   it. **Never `<img src="https://i.ebayimg.com/...">`** — the widget /
+   artifact sandbox CSP blocks ALL remote image hosts and renders a BROKEN
+   image. Only self-contained `data:image/jpeg;base64,...` sources render.
 2. a **clickable link to the actual eBay listing** (`<a href>` to the comp's
    real `https://www.ebay.com/itm/<id>` URL) so the user can open and verify it
    themselves; and
@@ -44,21 +42,16 @@ all three of:
   large payload; OR
 - inline the same self-contained HTML into the visualize `show_widget` tool.
 
-Generate the HTML with a small script straight from the saved comp JSON (it has
-`thumbnail` + `url` per comp) — fetch+resize+base64 each thumbnail, and use each
-comp's REAL `url` (never hand-write an item id / thumbnail — a fabricated link
-defeats the whole point). Never present comps as a text-only list, a plain
-markdown table, or with remote `<img src>` — the user has explicitly required
-seeing real thumbnails and clicking through to verify each listing. A
-price/number without its embedded thumbnail AND clickable listing is not an
-acceptable way to show a comp. The text `price.txt` / `comps.csv` artifacts are
-still written as specified in PRICE; this rule governs the CHAT layer, in every
-phase, on top of them.
+Generate the HTML with a small script straight from the saved comp JSON (it
+has `thumbnail` + `url` per comp) — fetch+resize+base64 each thumbnail, and
+use each comp's REAL `url` (never hand-write an item id / thumbnail). Never
+present comps as a text-only list, a plain markdown table, or with remote
+`<img src>`. A price without its embedded thumbnail AND clickable listing is
+not an acceptable way to show a comp. The `price.txt` / `comps.csv` artifacts
+are still written as specified in PRICE; this rule governs the CHAT layer, in
+every phase, on top of them.
 
 ## Confidence (commit, don't hedge)
-
-The old prompts manufactured doubt — 5-scenario brackets, "effectively
-excluded" entries, best→worst ladders. v3 commits.
 
 - **State the single best-supported call.** Make it; don't narrate the
   alternatives you rejected.

--- a/prompts/curate.md
+++ b/prompts/curate.md
@@ -1,4 +1,4 @@
-# CURATE — v3, Function 3
+# CURATE — v4, Function 3
 
 Obeys [`_shared.md`](_shared.md). Read it first.
 

--- a/prompts/identify.md
+++ b/prompts/identify.md
@@ -1,4 +1,4 @@
-# IDENTIFY — v3, Function 1
+# IDENTIFY — v4, Function 1
 
 Obeys [`_shared.md`](_shared.md) (style, confidence, fresh-investigation,
 unit_type, char limits, persistence, gate contract). Read it first.
@@ -7,19 +7,18 @@ unit_type, char limits, persistence, gate contract). Read it first.
 
 Enumerate the distinct items across a shoot's photos and write one
 structured record each. Speculative-upward: surface best-case identity so
-the user can see upside, with the verification path attached.
+the user can see upside, with the verification path attached. Rationale +
+history: [reference/identify-notes.md](reference/identify-notes.md).
 
 ## Photo intake (read the decisive set, not every frame)
 
-Full-res photos are the biggest token cost in a shoot, so read the frames that
-decide the record — not every angle. A single-item shoot is usually decided by
-4–6: the **hero / full-form** shot, the **underside / backstamp / mark** shot(s),
-**1–2 detail** shots (condition, a distinguishing feature), and any **ruler /
-scale** frame. Skip near-duplicate angles — they add cost, not evidence.
-Coverage still wins where it matters: on wide/group shoots read enough to
-enumerate every item, and never skip a frame that shows a mark you must read
-(see "Hunt every mark"). Glance at the filename list to pick; fully read only
-what you need.
+Full-res photos are the biggest token cost in a shoot. A single-item shoot
+is usually decided by 4–6 frames: the **hero/full-form** shot, the
+**underside/backstamp/mark** shot(s), **1–2 detail** shots, any
+**ruler/scale** frame. Skip near-duplicate angles. Coverage still wins where
+it matters: on wide/group shoots read enough to enumerate every item, and
+never skip a frame that shows a mark you must read (see "Hunt every mark").
+Glance at the filename list to pick; fully read only what you need.
 
 ## Shoot mode
 
@@ -58,225 +57,189 @@ Marker discipline (per _shared confidence rule):
 
 Lead with the upside, and make the downgrade EARN it. Where a specialization
 provides a **Good / Better / Best** ladder (e.g. marbles), present all three
-live tiers on the item instead of collapsing to one verdict:
+live tiers instead of collapsing to one verdict:
 
-- **GOOD** — an *optimistic* floor (what it is even if nothing special confirms);
-  never "filler" by default.
-- **BETTER** — the named-maker / upgraded read, with the cue that supports it.
-- **BEST** — the trophy read if the tells align; stays `[BEST-CASE]` + verify,
-  but is STATED, not buried.
+- **GOOD** — an *optimistic* floor; never "filler" by default.
+- **BETTER** — the named-maker / upgraded read, with the cue supporting it.
+- **BEST** — the trophy read if the tells align; stays `[BEST-CASE]` +
+  verify, but is STATED, not buried.
 
-Grade to the TOP of the supported band — a clean surface in adequate photos is
-the top grade, not a hedged "pending". Damage must be *visible* to cost grade.
+Grade to the TOP of the supported band — a clean surface in adequate photos
+is the top grade, not a hedged "pending". Damage must be *visible* to cost
+grade.
 
-When you genuinely cannot tell which tier the item lands on AND it swings value,
-do **not** silently pick the low one. **Poll the user with the SPECIFIC
-discriminating question(s)** the specialization names — in an *interactive* run
-this is a stop-and-ask (same gate as the maker-mark stop below); in a *headless*
-run it degrades to the SOFT path (log them to `needs_followup_photo` +
-`NEEDS_REVIEW.md`). Ask only for what the photos can't answer — settle from the
-photos everything you can read yourself; never offload an expert read (pattern,
-seam, ribbons-vs-patch) onto the user.
+When you genuinely cannot tell which tier AND it swings value, do **not**
+silently pick the low one. **Poll the user with the SPECIFIC discriminating
+question(s)** the specialization names — interactive: a stop-and-ask (same
+gate as the maker-mark stop below); headless: degrade to the SOFT path
+(`needs_followup_photo` + `NEEDS_REVIEW.md`). Ask only what the photos can't
+answer — settle everything you can read yourself; never offload an expert
+read (pattern, seam, ribbons-vs-patch) onto the user.
 
 ## Category specializations (load expert knowledge on a match)
 
-Some categories have a dedicated **specialization module** — a self-contained
-expert field guide under [`../specializations/`](../specializations/). After you
-form an item's first-pass Category, check the registry table in
-[`../specializations/README.md`](../specializations/README.md): match the item's
-category / material / keywords against each module's **Triggers**. On a hit, the
-item is *in specialization* — **read that module file and apply it** before
-settling this item's fields.
-
-A loaded module gives you, for that item: the maker/type taxonomy and visual
-tells, the named high-value types to watch for, the category's own condition
-vocabulary, the authentication/fake tests, and a coarse **value tier**. Use it
-to:
+After forming an item's first-pass Category, check the registry table in
+[`../specializations/README.md`](../specializations/README.md): match the
+item against each module's **Triggers**. On a hit, **read that module and
+apply it** before settling the item's fields. A loaded module supplies the
+maker/type taxonomy and tells, the named high-value types, the category's
+condition vocabulary, the authentication tests, and a **value tier**:
 
 - settle Brand / Type / Era / Condition with specialist precision;
-- record the module's **value tier** in Distinguishing marks (so PRICE/CURATE
-  know which items deserve the exact-comp hunt vs which are filler);
-- set `needs_followup_photo` to the SPECIFIC inspection shot the module names
-  (e.g. a pontil/seam macro) when the confident call needs an inspection the
-  photos don't show.
+- record the module's **value tier** in Distinguishing marks (so
+  PRICE/CURATE know which items deserve the exact-comp hunt);
+- set `needs_followup_photo` to the SPECIFIC inspection shot the module
+  names when the confident call needs a shot the photos don't show.
 
 A specialization **refines, never overrides** the honesty rules and the
-maker-attribution discipline below: still no inventing, still `[BEST-CASE]` +
-scenario bracket for value-swing inferences, still the maker-mark gate. If no
-module's triggers match, proceed with the general pass as normal.
+maker-attribution discipline below. No trigger match → general pass as
+normal.
 
-> ⛔ **Crop gate (marbles, bulk/group).** Before identifying a multi-marble shoot,
-> generate per-marble crops + the numbered contact sheet
-> (`tools/marble_triage.py <dir> --crops-only --expect N`), **show the user the
-> contact sheet, and STOP** — begin IDENTIFY only on their go-ahead. HARD
-> interactive stop; headless degrades to self-verify-count + log to
+> ⛔ **Crop gate (marbles, bulk/group).** Before identifying a multi-marble
+> shoot, generate per-marble crops + the numbered contact sheet
+> (`tools/marble_triage.py <dir> --crops-only --expect N`), **show the user
+> the contact sheet, and STOP** — begin IDENTIFY only on their go-ahead.
+> HARD interactive stop; headless degrades to self-verify-count + log to
 > `NEEDS_REVIEW.md`. See the ⛔ CROP GATE block in
 > [`../specializations/marbles.md`](../specializations/marbles.md).
 
-> 🚫 **CLIP/forum-index DISABLED for IDENTIFY (marbles).** The forum CLIP index and
-> every tool that queries it are turned OFF for IDENTIFY — `lib/marble_index.py`,
-> `verify_batch` / `marble_triage` / `marble_matches` / `marble_colormatch` /
-> `marble_refset` — and the forum expert-answer text is not used to set the maker.
-> Do **not** run any of them during IDENTIFY: not for the maker/type, not as an
-> escalation, not as a colour-match "lead," not for corroboration. They proved
-> ineffective (CLIP = 224px, matches colour not seams) and are kept but dormant.
-> The maker/type comes from **photos + the module's tells ALONE**, staying
-> firmly-named or `Unknown`/`[BEST-CASE]`. Human reference-panel triangulation and
-> WebFetch of reference photos remain allowed. Run the CLIP/forum tools ONLY when
-> the user EXPLICITLY asks, as a separate colour-lead step outside the record. Full
-> rule: the 🚫 block in
-> [`../specializations/marbles.md`](../specializations/marbles.md). In-specialization
-> marbles only; other categories unchanged.
+> 🚫 **CLIP/forum-index DISABLED for IDENTIFY (marbles).** The forum CLIP
+> index and every tool that queries it are OFF for IDENTIFY —
+> `lib/marble_index.py`, `verify_batch` / `marble_triage` /
+> `marble_matches` / `marble_colormatch` / `marble_refset` — and the forum
+> expert-answer text is not used to set the maker. Not for the maker/type,
+> not as an escalation, not as a colour-match "lead," not for
+> corroboration. The maker/type comes from **photos + the module's tells
+> ALONE**, staying firmly-named or `Unknown`/`[BEST-CASE]`. Human
+> reference-panel triangulation and WebFetch of reference photos remain
+> allowed. Run the CLIP/forum tools ONLY when the user EXPLICITLY asks, as
+> a separate step outside the record. Full rule: the 🚫 block in
+> [`../specializations/marbles.md`](../specializations/marbles.md).
+> In-specialization marbles only; other categories unchanged.
 
 ## Maker / brand attribution (work it HARD — high leverage)
 
 Brand is the single highest-leverage field: a confirmed maker changes the
-PRICE tier, lets PRICE hunt an EXACT maker+pattern comp, sharpens the title
-SEO, and informs authenticity. So `Unknown` is a LAST RESORT after a real
-attribution attempt — never a lazy default. Run this pass on every item before
-settling Brand:
+PRICE tier, enables the EXACT maker+pattern comp hunt, sharpens title SEO,
+and informs authenticity. `Unknown` is a LAST RESORT after a real
+attribution attempt. Run this pass on every item before settling Brand:
 
-**Stop-and-ask gate (mark-likely categories, interactive runs).** Some
-categories almost always carry a maker's mark that swings value hard. These are
-the **gate categories** — the editable list that arms the stop-and-ask (grow it
-as you learn; "for now" it is):
+**Stop-and-ask gate (mark-likely categories, interactive runs).** The gate
+categories — an editable list; grow it as you learn:
 
-- **Jewelry** — incl. gemstone & costume pieces (maker / karat / assay / stone
-  marks, usually on the clasp, gallery, or inner band).
-- **Precious metals** — silver/sterling, gold, platinum (holloware, flatware,
-  plate; hallmarks, assay/karat marks, EPNS/EP, maker roundels + pattern
-  numbers).
-- **Glass** — anything made of glass (art, pressed, cut, studio; pontil,
-  acid-etched, or sticker marks).
+- **Jewelry** — incl. gemstone & costume (maker / karat / assay / stone
+  marks; clasp, gallery, inner band).
+- **Precious metals** — silver/sterling, gold, platinum (hallmarks,
+  assay/karat marks, EPNS/EP, maker roundels + pattern numbers).
+- **Glass** — art, pressed, cut, studio (pontil, acid-etched, or sticker
+  marks).
 - **Pottery / ceramics / porcelain** — backstamps, impressed/painted marks,
   pattern names/numbers, country-of-origin wording.
 
-When an item is in a gate category AND a mark is **plausibly present but you
-cannot decisively read it from the photos** (illegible, obscured, or on a
-surface this shoot doesn't show), **STOP and ask the user to read the
-inside/underside marking before you spend on searches/Lens or settle Brand.**
-The user is holding the piece; their close-read of the mark beats any web or
-Lens guess and is the cheapest path to a confirmed maker. Ask specifically —
-name the surface and what to look for ("Can you read the mark on the base of the
-silver pot? Any lion/letters, 'STERLING'/'EPNS', or a number?"). Resume the pass
-below with whatever they report; only if they decline or genuinely can't read it
-do you fall through to research → Lens → (last resort) Unknown.
+When an item is in a gate category AND a mark is **plausibly present but
+not decisively readable from the photos**, **STOP and ask the user to read
+the inside/underside marking before you spend on searches/Lens or settle
+Brand.** The user is holding the piece; their close-read beats any web or
+Lens guess. Ask specifically — name the surface and what to look for ("Can
+you read the mark on the base of the silver pot? Any lion/letters,
+'STERLING'/'EPNS', or a number?"). Resume with whatever they report; only
+if they decline or can't read it fall through to research → Lens → (last
+resort) Unknown.
 
-**Exception (skip the stop).** A gate category is a *default* to stop, not an
-absolute. If THIS specific piece is plainly mass-produced / unmarked / low-value
-such that a maker's mark is genuinely unlikely AND a maker wouldn't move
-value or SEO — a plain modern drinking glass, a generic unmarked terracotta pot,
-a strand of costume beads — you MAY proceed without asking. Log the carve-out in
-one line (`exception: <why a mark is unlikely here>`) so the skip is auditable.
-When genuinely in doubt, stop and ask: a missed mark is the most expensive thing
-to leave on the table.
+**Exception (skip the stop).** A gate category is a *default* to stop, not
+an absolute. If THIS piece is plainly mass-produced / unmarked / low-value
+such that a mark is genuinely unlikely AND a maker wouldn't move value or
+SEO — a plain modern drinking glass, a generic unmarked terracotta pot —
+you MAY proceed without asking. Log the carve-out in one line
+(`exception: <why a mark is unlikely here>`). In doubt → stop and ask: a
+missed mark is the most expensive thing to leave on the table.
 
-This is a HARD stop in an **interactive** run. In a **headless** run (no user to
-ask) it degrades to the SOFT path: set `needs_followup_photo: yes` naming the
-exact macro shot, log the question to `NEEDS_REVIEW.md`, and proceed with the
-attribution pass below.
+HARD stop in an **interactive** run. **Headless** degrades to the SOFT
+path: `needs_followup_photo: yes` naming the exact macro shot, log the
+question to `NEEDS_REVIEW.md`, proceed with the pass below.
 
-1. **Hunt every mark.** Scan ALL surfaces for any mark — base/underside, foot
-   rim, back, lid underside, inside rim, handle/spout joins, seams, stickers/
-   labels. A mark, stamp, signature, hallmark, trademark, pattern/model number,
-   size code, or registry mark MUST be addressed (read it, decode it, or state
-   it is present-but-illegible). Never silently skip a visible mark.
+1. **Hunt every mark.** Scan ALL surfaces — base/underside, foot rim, back,
+   lid underside, inside rim, handle/spout joins, seams, stickers/labels.
+   Any mark, stamp, signature, hallmark, trademark, pattern/model number,
+   size code, or registry mark MUST be addressed (read it, decode it, or
+   state present-but-illegible). Never silently skip a visible mark.
 2. **Decode it by type.**
-   - **Silver/metal:** distinguish GENUINE assay hallmarks (e.g. lion passant =
-     English sterling, town + date letters) from a MAKER's mark, from EPNS / EP
-     / "quadruple plate" / "silver on copper" plate marks, from pattern + size
-     numbers, and from purely DECORATIVE pseudo-hallmarks. Each tells you
-     something: assay → solid silver + origin/date; trademark roundel + pattern
-     number → a specific plate maker (often catalog-matchable).
-   - **Ceramics/porcelain/pottery:** backstamp, impressed mark, painted mark,
-     pattern name/number; country-of-origin wording dates it ("England" vs
-     "Made in England", post-1891 "country" rule, "Occupied Japan", etc.).
+   - **Silver/metal:** distinguish GENUINE assay hallmarks (lion passant =
+     English sterling, town + date letters) from a MAKER's mark, from
+     EPNS / EP / "quadruple plate" / "silver on copper" plate marks, from
+     pattern + size numbers, and from DECORATIVE pseudo-hallmarks. Assay →
+     solid silver + origin/date; trademark roundel + pattern number → a
+     specific plate maker (often catalog-matchable).
+   - **Ceramics/porcelain/pottery:** backstamp, impressed mark, painted
+     mark, pattern name/number; country-of-origin wording dates it
+     ("England" vs "Made in England", post-1891 rule, "Occupied Japan").
    - **Other:** logos, model numbers, union/care labels, date codes.
-3. **Research the mark.** Use reference knowledge and web search to MATCH a
-   partial or stylized mark to a maker (silver-mark encyclopedias, pottery-mark
-   references, pattern-number catalogs). A pattern/size number plus a trademark
-   shape is often enough to name the maker even when the legend is worn.
-4. **Commit at the right confidence.** If research yields a likely maker, write
-   `Brand: <maker> [BEST-CASE]` + a Scenario bracket + the exact resolution
-   step (the macro shot or test that would confirm). Only a legible, matched
-   mark earns a maker WITHOUT `[BEST-CASE]`. A genuinely markless piece, or a
-   purely decorative fantasy pseudo-hallmark with no maker name, is honestly
-   `Unknown` — say which it is. Reach `Unknown`/`Unbranded` only AFTER you have
-   genuinely worked at least two SPECIFIC maker candidates — name each, then rule
-   it out against an observable — never as a first-pass shrug. Note the
-   candidates you considered and why each failed so the rejection is auditable.
+3. **Research the mark.** Reference knowledge + web search to MATCH a
+   partial or stylized mark to a maker (silver-mark encyclopedias,
+   pottery-mark references, pattern-number catalogs). A pattern/size number
+   plus a trademark shape often names the maker even when the legend is
+   worn.
+4. **Commit at the right confidence.** Research yields a likely maker →
+   `Brand: <maker> [BEST-CASE]` + Scenario bracket + the exact resolution
+   step. Only a legible, matched mark earns a maker WITHOUT `[BEST-CASE]`.
+   A genuinely markless piece, or a fantasy pseudo-hallmark with no maker
+   name, is honestly `Unknown` — say which it is. Reach
+   `Unknown`/`Unbranded` only AFTER genuinely working at least two SPECIFIC
+   maker candidates — name each, rule it out against an observable — never
+   as a first-pass shrug. Note the candidates and why each failed.
 
-**Honesty guard (unchanged, non-negotiable):** trying harder is NOT license to
-invent. Do not promote a guess to a stated maker, and do not read a maker into
-fantasy/pseudo marks to inflate value. The bar for a named maker is a real,
-decodable signal; the bar for `[BEST-CASE]` is a mark whose style/elements
-genuinely point to one. When the mark is present but you cannot resolve it, set
-`needs_followup_photo: yes` with the SPECIFIC shot (a raking-light macro of the
-mark) and note the downstream value impact — an unread mark is the most
-expensive thing to leave on the table.
+**Honesty guard (non-negotiable):** trying harder is NOT license to invent.
+Never promote a guess to a stated maker; never read a maker into
+fantasy/pseudo marks. The bar for a named maker is a real, decodable
+signal; for `[BEST-CASE]`, a mark whose style/elements genuinely point to
+one. A present-but-unresolvable mark → `needs_followup_photo: yes` with the
+SPECIFIC shot (raking-light macro) and the downstream value impact.
 
-5. **Visual second opinion (Google Lens) — for markless or can't-place pieces.**
-   When the maker is unresolved (markless, OR a mark you couldn't read) AND the
-   piece is plausibly collectible/branded, get an independent read before
-   settling Brand. Lens does TWO jobs, so **choose the photo(s) by goal — never
-   default to the wide hero shot:**
+5. **Visual second opinion (Google Lens) — markless or can't-place
+   pieces.** When the maker is unresolved AND the piece is plausibly
+   collectible/branded, get an independent read before settling Brand.
+   Choose the photo(s) by goal — never default to the wide hero:
    - **Design match** → the clearest **full-form** shot (in focus, minimal
-     background). Finds the same-shaped piece across the web.
-   - **Mark match** → if step 1 found a **mark / stamp / signature / label**
-     (usually on the **underside or back**), send that **close-up too**: Lens
-     OCR can *read* a maker name off it, which beats any look-alike. A wide hero
-     shot is useless for this — the underside is the decisive photo.
-     **Caveat (verified):** Lens OCR reads **printed/painted** marks (paper
-     labels, painted backstamps, ink) — it routinely **can't read low-contrast
-     EMBOSSED METAL stamps** (silver/pewter/buckles/jewelry; it returns "No
-     results"). For a pressed-metal stamp, **your own step-1 close-read is the
-     authority** — don't wait on Lens, and don't read its empty result as "no
-     mark". (lens_id flags this: verdict says "rely on your own close-read".)
+     background).
+   - **Mark match** → if step 1 found a mark (usually underside/back), send
+     that **close-up too**: Lens OCR can *read* a maker name off it.
+     **Caveat (verified):** OCR reads **printed/painted** marks; it
+     routinely **can't read low-contrast EMBOSSED METAL stamps** (returns
+     "No results"). For a pressed-metal stamp, **your own step-1 close-read
+     is the authority** — don't read Lens's empty result as "no mark".
 
-   You examined every photo in this pass, so YOU pick — deliberately, by reason.
-   **Cap at 2–3 images, each earning its place:** the full-form shot (design),
-   the mark/underside close-up (OCR — only if a mark exists), and at most one
-   more ONLY for a genuinely distinctive feature (a unique finial, a signature
-   panel). Never dump all the photos or pick at random — near-duplicate angles
-   add cost and noise, not signal, and a wrong crop (a blurry edge, heavy
-   background) can mislead Lens. `lib/lens_id.py` takes those images in one run
-   (~pennies each):
+   **Cap at 2–3 images, each earning its place:** full-form (design), mark
+   close-up (OCR — only if a readable mark exists), at most one more for a
+   genuinely distinctive feature. Never dump all photos — near-duplicates
+   add cost and noise, and a bad crop can mislead Lens.
 
-       # "what is this?" — markless / metal-marked piece, design + AI mode, NO OCR (cheaper):
+       # markless / metal-marked — design + AI mode, NO OCR (cheaper):
        python lib/lens_id.py <shoot-dir>/<full-view>.jpg --no-ocr
-       # mark present AND printed/painted (readable) — add the mark close-up + OCR:
+       # readable printed/painted mark — add the close-up + OCR:
        python lib/lens_id.py <shoot-dir>/<full-view>.jpg <shoot-dir>/<mark-shot>.jpg
 
-   The CORE is always a **"what is this?"** read (visual match + AI mode) off the
-   full-form shot — it does NOT need a mark. **OCR is an add-on:** include it
-   (default) only when you're sending a **readable printed/painted** mark; use
-   **`--no-ocr`** otherwise (markless pieces, or an embossed metal stamp where
-   OCR returns nothing) for a cheaper mark-free pass. OCR failing never blocks
-   the "what is this?" result.
+   The CORE is always the **"what is this?"** read off the full-form shot —
+   it needs no mark. OCR is an add-on for readable marks only; OCR failing
+   never blocks the design result. The tool prints a **verdict + maker
+   tally + any mark/OCR read**. Weigh it — never obey it:
+   - **`MARK READ (OCR): <Maker>`** → strongest signal. Confirm the reading
+     against the photo, then `Brand: <Maker>` (a verified read mark is
+     evidence — no `[BEST-CASE]`).
+   - **`leans <Maker>`** (recurs across matches AND fits what you see) →
+     `Brand: <Maker> [BEST-CASE]` + bracket, note "Lens-corroborated".
+   - **`split across makers` / `widely-copied`** → stay
+     `Unbranded`/`Unknown`; the names are later keywords, NOT a claim. The
+     common, honest result — never promote a stray mention. Lens is
+     evidence about the *design*, not proof of *this* piece's maker.
+   - Record `Lens cross-check: <verdict>` on the item and reconcile with
+     your own call in one line (agree / conflict / refined).
 
-   It hosts each photo at a temp public URL, runs the Lens actor, and prints a
-   **verdict + a maker tally across distinct visual matches + any mark/OCR read**.
-   Weigh it — never obey it:
-   - **`MARK READ (OCR): <Maker>`** → strongest signal: Lens read a maker name
-     off the mark. Confirm the reading is legible/correct on the photo, then
-     write `Brand: <Maker>` (a confirmed read mark is real evidence, not a guess
-     — no `[BEST-CASE]` needed once you verify it).
-   - **`leans <Maker>`** (recurs across several matches AND fits what you see) →
-     `Brand: <Maker> [BEST-CASE]` + scenario bracket, note "Lens-corroborated".
-   - **`split across makers` / `no single maker — widely-copied`** → stay
-     `Unbranded`/`Unknown`; the names are later keywords, NOT a claim. This is
-     the common, honest result — do NOT promote a single stray Lens mention into
-     an attribution (the same failure as inventing a maker from a fantasy mark).
-     Lens is evidence about the *design*, not proof of *this* piece's maker.
-   - Record a `Lens cross-check: <verdict>` line on the item and reconcile it
-     with your own visual call in one line (agree / conflict / refined).
-
-   **Gate (cost + privacy):** RUN only when attribution is genuinely uncertain
-   AND would move value/SEO. SKIP for legibly-marked items, obvious low-value
-   commodities, and lots of generics — it sends the photo to Google via a
-   temporary public host (auto-expiring) and spends ~$0.02–0.05 of Apify credit.
-   Needs direct egress (tmpfiles + api.apify.com); in a blocked sandbox, run with
-   egress on, or host via the lib and drive the actor through the Apify MCP.
+   **Gate (cost + privacy):** RUN only when attribution is genuinely
+   uncertain AND would move value/SEO. SKIP for legibly-marked items,
+   obvious commodities, lots of generics — it sends the photo to Google via
+   a temp public host (auto-expiring) and spends ~$0.02–0.05 of Apify
+   credit. Needs direct egress (tmpfiles + api.apify.com); in a blocked
+   sandbox, host via the lib and drive the actor through the Apify MCP.
 
 ## Output format
 
@@ -297,10 +260,10 @@ Then one block per item, `--- Item <N> ---`, fields in this order:
 - **Quantity** — integer. 1 for single, 2 for pair, piece count for
   set/lot, copy count for duplicate.
 - **Category** — general bucket (bike, magazine, chess set). Uncapped.
-- **Brand** — run the maker-attribution pass above FIRST. Legible/matched mark
-  → write the maker; mark whose style points to a likely maker → `value
-  [BEST-CASE]` + bracket; genuinely markless or fantasy-marked → `Unknown`
-  (last resort, after the pass). ≤65.
+- **Brand** — run the maker-attribution pass FIRST. Legible/matched mark →
+  the maker; style points to a likely maker → `value [BEST-CASE]` +
+  bracket; genuinely markless or fantasy-marked → `Unknown` (last resort).
+  ≤65.
 - **Type** — specific descriptor. Same marker convention. ≤65.
 - **Era** — date/range. `[ASSUMPTION]` if inferred from styling. ≤65.
 - **Collectability** — collectable / vintage / antique / modern /
@@ -315,14 +278,13 @@ Then one block per item, `--- Item <N> ---`, fields in this order:
 - **Estimated dimensions** — item size (not packed). Box `~L×W×H in`;
   cylinder `~dia×h in`; furniture `~W×D×H in`; flat `~L×W in`; irregular
   free-text w/ key measurements. Range when unsure.
-- **Ship risk** — `none` or `suggest-pickup`. Set `suggest-pickup` when the
-  item is awkward/unsafe to parcel-ship: estimated weight **> 25 lb** OR any
-  estimated dimension **> 24 in (2 ft)** on a side. Add a short reason
-  (`too heavy ~40 lb` / `> 2 ft long (38 in)`). This is only a *signal* for
-  DRAFT's local-pickup suggestion — IDENTIFY never decides fulfillment. If you
-  can't estimate weight/dims, leave `none` and rely on `needs_followup_photo`.
-  (Fragility the user names is honored at DRAFT too, but the auto-trigger here
-  is purely weight/size.)
+- **Ship risk** — `none` or `suggest-pickup`. Set `suggest-pickup` when
+  estimated weight **> 25 lb** OR any dimension **> 24 in** on a side, with
+  a short reason (`too heavy ~40 lb`). Only a *signal* for DRAFT's
+  local-pickup suggestion — IDENTIFY never decides fulfillment. Can't
+  estimate → leave `none` and rely on `needs_followup_photo`. (Fragility
+  the user names is honored at DRAFT; the auto-trigger here is purely
+  weight/size.)
 - **Distinguishing marks** — free-text, uncapped catch-all: cover text,
   dated copyright, photographer credit, model number, materials, the rich
   context that does NOT fit the capped fields above.
@@ -339,13 +301,13 @@ Then one block per item, `--- Item <N> ---`, fields in this order:
 
 ## Grouping (informs questions; never auto-groups)
 
-Default every record to `single`. When photos suggest a grouping,
-surface a question in "Needs user confirmation" AND append it to
-NEEDS_REVIEW.md — then keep going. Patterns worth surfacing: functional
-unit (chess board+pieces), mounted/cased/framed (lean toward `set`),
-matched pair (2 identical), matched set (3+ identical), provisional group
-(alike but not cleanly enumerable → set `needs_followup_photo: yes`),
-identical duplicates (N copies). Different brands never merge.
+Default every record to `single`. When photos suggest a grouping, surface a
+question in "Needs user confirmation" AND append it to NEEDS_REVIEW.md —
+then keep going. Patterns worth surfacing: functional unit (chess
+board+pieces), mounted/cased/framed (lean toward `set`), matched pair (2
+identical), matched set (3+ identical), provisional group (alike but not
+cleanly enumerable → `needs_followup_photo: yes`), identical duplicates (N
+copies). Different brands never merge.
 
 When the user later confirms, re-run or update the affected records in
 place with the new `unit_type` + `quantity`.

--- a/prompts/investigate.md
+++ b/prompts/investigate.md
@@ -1,4 +1,4 @@
-# INVESTIGATE — v3, Function 4
+# INVESTIGATE — v4, Function 4
 
 Obeys [`_shared.md`](_shared.md). Read it first.
 

--- a/prompts/list_edit_chrome.md
+++ b/prompts/list_edit_chrome.md
@@ -1,75 +1,73 @@
-# LIST / EDIT (Chrome stand-in) — v3, Function 6 — INTERIM
+# LIST / EDIT (Chrome stand-in) — v4, Function 6 — INTERIM
 
 Obeys [`_shared.md`](_shared.md). Read it first.
 
 Pushes an approved `draft.md` into an eBay **DRAFT** listing by driving the
-seller UI with the Claude-in-Chrome MCP. **Fallback only** — use it when
-the eBay Sell API path (`lib/list_edit.py`) isn't set up. The API path is
-primary because it can also publish LIVE post-approval; this stand-in is
-draft-only by design (see below).
+seller UI with the Claude-in-Chrome MCP. **Fallback only** — the eBay Sell
+API path (`lib/list_edit.py`) is primary; use this when the API path isn't
+available or can't handle the category. Incident history + evidence:
+[reference/list-edit-chrome-notes.md](reference/list-edit-chrome-notes.md).
 
-**Listing management is API-only.** Querying, withdrawing, and deleting
-listings (`list_edit.py --offers` / `--withdraw-offer` / `--delete-offer` /
-`--delete-item`) is done through the Sell API, not this UI stand-in — see
-[RUN.md](../RUN.md) "Managing live listings".
+**Listing management is API-only.** Querying, withdrawing, deleting
+(`list_edit.py --offers` / `--withdraw-offer` / `--delete-offer` /
+`--delete-item`) go through the Sell API — see [RUN.md](../RUN.md)
+"Managing live listings".
 
-**Reached via the REVIEW gate.** RUN.md's pipeline runs DRAFT → REVIEW.
-This path runs only after a human approves the review card, one item at a
-time.
+**Reached via the REVIEW gate.** Runs only after a human approves the
+review card, one item at a time.
 
 ================================================================
 THIS STAND-IN IS DRAFT-ONLY (publish via the API path)
 ================================================================
 Terminal action here is **"Save for later" / "Save as draft"** — nothing
-else. Going LIVE is not done through this UI stand-in: the browser is
-granted read-tier OS automation and the publish controls are unreliable
-to drive safely, so live publishing is reserved for the API path
-(`list_edit.py --list <dir> --confirm`, run after the REVIEW approval).
-So even with an approved card, this path stops at a saved draft; if the
-user wants it live, hand off to the API command. The firewall against
-*automatic* publishing still holds (see `_shared.md`).
+else. The browser is granted read-tier OS automation and the publish
+controls are unreliable to drive safely, so going LIVE is reserved for the
+API path (`list_edit.py --list <dir> --confirm`, after REVIEW approval).
+An approved card still stops at a saved draft here; hand off to the API
+command for live. The firewall against *automatic* publishing holds (see
+`_shared.md`).
 
 ## Preconditions (STOP if unmet)
 
 1. `<shoot-dir>/draft.md` exists and passed DRAFT validation — required
    fields present (`title`, `quantity`, `price`, `item_specifics.type`),
-   all caps satisfied. If `meta.notes` flags required-field gaps, STOP.
+   all caps satisfied. `meta.notes` flags required-field gaps → STOP.
 2. The user is signed into eBay in the connected Chrome browser. (Loading
    `https://www.ebay.com/sl/prelist/suggest` without a login redirect
    confirms it.)
 3. `list_connected_browsers` returns a browser; `select_browser` it.
 
-## Reliability rules (learned the hard way — follow these)
+## Reliability rules
 
-This eBay form is dynamic and auto-scrolls. The defaults below prevent
-the failure modes from the first live run.
+The eBay form is dynamic and auto-scrolls; these defaults prevent the
+known failure modes:
 
 - **JS DOM state is ground truth; screenshots lag and mislead.** Verify
-  every field with `javascript_tool` reads, not screenshots. A screenshot
-  may show a modal that JS confirms is closed — trust JS.
+  every field with `javascript_tool` reads. A screenshot may show a modal
+  JS confirms is closed — trust JS.
 - **Click via JS label-matching, not pixel coordinates.** Coordinate
-  clicks land wrong after the form re-scrolls. Find elements by
-  `aria-label` / `textContent` and call `.click()` / set value in JS.
-  Reserve `find`+ref clicks for when JS matching is ambiguous.
-- **Never create variations.** A stray click can open eBay's "Create
-  your variations" editor and add Color/MPN options. This item is a
-  single listing. If that editor appears, Cancel → confirm Yes, and
-  verify `document.body.textContent` no longer contains "Create your
-  variations" before continuing.
-- **Plain `<input>`/`<textarea>` fields take the React value-setter.** But
-  **controlled save-models ignore untrusted (JS) input** — the rich-text
+  clicks land wrong after a re-scroll. Find elements by `aria-label` /
+  `textContent` and `.click()` / set value in JS. Reserve `find`+ref
+  clicks for when JS matching is ambiguous.
+- **Never create variations.** A stray click can open "Create your
+  variations" and add Color/MPN options. If that editor appears: Cancel →
+  confirm Yes → verify `document.body.textContent` no longer contains
+  "Create your variations" before continuing.
+- **Trusted input rule (the #1 failure class).** Plain
+  `<input>`/`<textarea>` fields take the React value-setter below. But
+  **controlled save-models ignore untrusted (JS) input**: the rich-text
   description and tag-select item-specifics commit ONLY on TRUSTED
-  keystrokes. Enter those by **typing with the Chrome MCP `computer`
-  `type`/`key`** (CDP keystrokes are `isTrusted`), not by setting `.value`
-  or `execCommand`. JS injection updates the visible DOM but not the
-  save-state, so it silently fails to persist (see Description RTE below).
+  keystrokes (`isTrusted === true`). Enter those by **typing with the
+  Chrome MCP `computer` `type`/`key`** (CDP keystrokes are trusted) — JS
+  `setVal`, `innerHTML`, dispatched events and `execCommand` change what
+  you SEE but never reach the save-state, so the draft saves blank no
+  matter how often you re-apply.
 - **Verify after every fill** via JS before moving on.
 - **Never save until the save-state has settled and verified.** eBay syncs
-  fields (especially the rich-text description) to its save-state on a
-  debounce; saving too soon persists a draft with missing fields. Always
-  run the settle-and-verify gate (workflow step 8) and the post-save
-  reload check (step 10) before reporting success. This is the single most
-  common cause of "missing fields" — treat it as a hard gate, not a nicety.
+  fields (especially the description) on a debounce; saving too soon
+  persists a draft with missing fields. Always run the settle-and-verify
+  gate (step 8) and the post-save reload check (step 10) — a hard gate,
+  not a nicety.
 
 ### JS patterns
 
@@ -79,139 +77,102 @@ const setVal=(el,val)=>{const p=el.tagName==='TEXTAREA'?HTMLTextAreaElement.prot
 Object.getOwnPropertyDescriptor(p,'value').set.call(el,val);
 el.dispatchEvent(new Event('input',{bubbles:true}));el.dispatchEvent(new Event('change',{bubbles:true}));};
 ```
-Description RTE — the iframe `se-rte-frame__summary` holds a
+
+Description RTE: the iframe `se-rte-frame__summary` holds a
 `[contenteditable]` editor; `textarea[aria-label="Description"]` is its
-read-only save-state mirror.
-
-**Why the description goes missing (the #1 recurring failure) — two
-compounding root causes:**
-
-1. **Untrusted events are ignored by the save-model.** The editor commits
-   to eBay's save-state ONLY on TRUSTED input (`isTrusted === true`). JS
-   `setVal`, `innerHTML`, dispatched `Event`s, and `execCommand` are all
-   UNTRUSTED — they change what you SEE in the editor but never reach the
-   save-state, so the draft saves blank no matter how many times you
-   re-apply them. This is the real cause; the debounce below just hides it.
-2. **Debounced sync.** Even valid (trusted) input flushes to the mirror on
-   a debounce (a few hundred ms after blur), so an immediate save races it.
-
-**Reliable fix — TYPE the description with the Chrome MCP keyboard
-(trusted input).** The Chrome MCP `computer` `type`/`key` actions dispatch
-real CDP keystrokes (`isTrusted === true`), which the save-model honors —
-unlike any JS injection.
-
+read-only save-state mirror. JS does ONLY focus + clear:
 ```js
-// JS does ONLY focus + clear (not content insertion):
 const ed=document.getElementById('se-rte-frame__summary')
   .contentDocument.querySelector('[contenteditable="true"]');
-ed.focus(); document.execCommand?.('selectAll'); // select existing
+ed.focus(); document.execCommand?.('selectAll');
 ```
-Then, with the editor focused:
-- `computer` action `key` "Delete" (clear any selected cloned text), then
-- `computer` action `type` with the description **plain text**; send
-  paragraph breaks with `key` "Enter" (formatting like bold/bullets is
-  lost — plain prose is fine and is what persists).
-- Blur, **wait ~1.5–2s** for the debounce, then verify
-  `textarea[aria-label="Description"]`.value.length > 0. If still 0,
-  re-focus and re-type (up to 3×).
-
-`execCommand('insertHTML')` + dispatched blur is a LAST-RESORT fallback
-only; if the verify gate shows the mirror still empty (it usually will,
-because the events are untrusted), switch to trusted typing above. The
-same trusted-input rule explains why item-specifics tag-selects need real
-typing + Enter (via `form_input`/`computer`), not a JS value set.
+Then, editor focused: `computer` `key` "Delete" (clear selection), then
+`computer` `type` with the description **plain text**, paragraph breaks
+via `key` "Enter" (rich formatting is lost; plain prose is what persists).
+Blur, **wait ~1.5–2s** for the debounce, verify
+`textarea[aria-label="Description"]`.value.length > 0; re-focus and
+re-type up to 3×. `execCommand('insertHTML')` + dispatched blur is a
+LAST-RESORT fallback only — its events are untrusted and the mirror
+usually stays empty. Item-specifics tag-selects likewise need real typing
++ Enter (`form_input`/`computer`), not a JS value set.
 
 ## Path selection (from price.txt)
 
-- **Path A — Sell similar:** if price.txt has a Tier A **exact-match**
-  sold comp with a URL, navigate there and click **"Sell similar"** /
-  "Sell one like this" (NOT "Find similar"). Cloned category + aspect
-  set are correct by definition. Preserve the cloned title (flag if it
-  differs from draft); overwrite other fields from draft; delete cloned
-  photos before uploading ours.
+- **Path A — Sell similar:** price.txt has a Tier A **exact-match** sold
+  comp with a URL → navigate there, click **"Sell similar"** / "Sell one
+  like this" (NOT "Find similar"). Cloned category + aspect set are
+  correct by definition. Preserve the cloned title (flag if it differs
+  from draft); overwrite other fields from draft; delete cloned photos
+  before uploading ours.
 - **Path B — no exact match (common):** go to
-  `https://www.ebay.com/sl/prelist/suggest`, type a short descriptor
-  (not the full title), let eBay resolve a category, and proceed past
-  any similar-items grid via **"Continue without match"** — never click
-  an item card. Fill the title from draft. (The live hen run was Path B.)
+  `https://www.ebay.com/sl/prelist/suggest`, type a short descriptor (not
+  the full title), let eBay resolve a category, proceed past any
+  similar-items grid via **"Continue without match"** — never click an
+  item card. Fill the title from draft.
 
 ## Workflow
 
-1. **Land on the form** (Path A or B). eBay may show a **Confirm details**
-   condition dialog (New / New other / Used) — pick per the draft's
-   `condition` (USED_* → "Used"), Continue. Record the `draftId` from the
-   URL (eBay auto-saves server-side).
+1. **Land on the form** (Path A or B). A **Confirm details** condition
+   dialog (New / New other / Used) → pick per the draft's `condition`
+   (USED_* → "Used"), Continue. Record the `draftId` from the URL (eBay
+   auto-saves server-side).
 2. **Core fields (JS, one batch):** title (input `maxLength===80` —
    Path A: don't overwrite, flag discrepancy), `aria-label="Item price"`,
    quantity (`maxLength===5`), condition-description (textarea
    `maxLength===1000`), weight `aria-label="Enter weight in pounds"` /
    `"…ounces"`, dims `"Enter package length/width/depth in inches"`.
-3. **Description:** focus + clear the editor via JS, then **TYPE the body
-   with the Chrome MCP `computer` `type`/`key` actions** (trusted input —
-   JS injection does NOT persist). Wait ~1.5–2s, then poll until
-   `textarea[aria-label="Description"]`.value.length > 0; re-type up to 3×
-   if still empty. (See "Why the description goes missing" above.)
+3. **Description:** focus + clear via JS, then **TYPE the body with
+   `computer` `type`/`key`** (trusted input). Wait ~1.5–2s, poll until the
+   mirror textarea is non-empty; re-type up to 3×.
 4. **Item specifics:** eBay shows AI-suggested specifics with an
-   **"Apply all"**. Prefer it, THEN correct anything wrong — the
-   suggester makes category-plausible but item-wrong guesses (the hen run
-   got "Subject: Rooster"; cleared it — it's a poule). Per `_shared`
-   honesty, never leave an inaccurate specific. Required aspects not
-   suggested (e.g. **Brand**): find the aspect's "Search or enter your
-   own" textbox, `form_input` the canonical value, dispatch Enter to
-   commit. Skip aspects the draft leaves empty.
-5. **Best Offer (gate per draft.md):** Best Offer controls sit behind a
-   pricing expander — expand it. If `best_offer.enabled` is true, check
-   "Allow offers" and set auto-decline to `best_offer.auto_decline_amount`
-   (= the Recommended tier). Leave auto-accept empty. If
-   `best_offer.enabled` is false (list price ≤ Recommended), leave offers
-   off.
-6. **Shipping:** if `shipping.fulfillment_mode` is **LOCAL_PICKUP**, do NOT
-   set a parcel service — instead choose eBay's **local pickup** option
-   ("No shipping — local pickup only" / enable "Local pickup") and leave the
-   shipping service empty; weight/dims can stay for reference. The draft's
-   description already carries the "freight by quote" line. Otherwise
-   (**SHIP**, the default): confirm/set free shipping + `primary_service`
-   (three-dot → Change service → search → select → Done). Weight/dims already
-   set.
-7. **Photos:** see "Photo upload" below — use the first method that's
-   available; never fake success.
-8. **Settle + verify before save (MANDATORY — this is what stops missing
-   fields).** Do NOT save on a timer or right after the last fill. Instead:
-   a. **Blur the active field** (`document.activeElement.blur()`) and **wait
-      ~1.5–2s** so every debounced React/eBay sync flushes to save-state.
-   b. **Re-read the save-state via JS** and build a checklist of REQUIRED,
-      persisted values: title (input value), price, quantity,
-      condition-description, **description = outer `textarea[aria-label=
-      "Description"]`.value.length > 0**, each filled item-specific shows
-      its value, Best Offer reflects the gate, weight/dims. Confirm no
-      variations modal.
-   c. **Re-apply any field that didn't persist** (description → re-run the
-      execCommand+blur+wait; others → re-run setVal/tag-select), then wait
-      and re-read again. Loop up to 3×.
-   d. **Hard gate:** if the description mirror is still empty, or any
-      required field is still missing after 3 tries, **DO NOT SAVE** —
-      report exactly which field failed. A saved draft with a blank
-      description is the failure we are preventing; an unsaved draft you
-      can retry is better than a silently-broken one.
-9. **Save:** only after step 8's checklist is fully green, click **"Save
-   for later"** (find by text; it may report width 0 in a sticky footer —
-   `.click()` it anyway).
-10. **Post-save persistence check (catch the debounce that slipped):**
-    after landing on Seller Hub → Drafts, **reopen the draft**
-    (`lstng?draftId=…&mode=AddItem`), wait for load, and re-read the
-    description mirror + title + price. If the description came back empty,
-    the debounce lost it on save — re-apply the description, re-run the
-    settle gate (step 8), and Save again. Only report success once the
-    reloaded draft shows a non-empty description.
-11. Write the `draftId` back into draft.md `meta.ebay_offer_id` and
-    `meta.last_synced`, and append a `[LIST/EDIT]` line to NEEDS_REVIEW
-    with the draftId + every manual-completion item.
+   **"Apply all"**. Prefer it, THEN correct anything wrong — the suggester
+   makes category-plausible but item-wrong guesses. Per `_shared` honesty,
+   never leave an inaccurate specific. Required aspects not suggested
+   (e.g. **Brand**): find the aspect's "Search or enter your own" textbox,
+   `form_input` the canonical value, dispatch Enter. Skip aspects the
+   draft leaves empty.
+5. **Best Offer (gate per draft.md):** controls sit behind a pricing
+   expander — expand it. `best_offer.enabled` true → check "Allow offers",
+   set auto-decline to `best_offer.auto_decline_amount`, leave auto-accept
+   empty. False → leave offers off.
+6. **Shipping:** `fulfillment_mode` **LOCAL_PICKUP** → do NOT set a parcel
+   service; choose eBay's **local pickup** option and leave the service
+   empty (weight/dims may stay for reference; the description already
+   carries the freight-by-quote line). Otherwise (**SHIP**): confirm/set
+   free shipping + `primary_service` (three-dot → Change service → search
+   → select → Done).
+7. **Photos:** see "Photo upload" below — first available method; never
+   fake success.
+8. **Settle + verify before save (MANDATORY).** Never save on a timer or
+   right after the last fill:
+   a. **Blur the active field** (`document.activeElement.blur()`), **wait
+      ~1.5–2s** so every debounced sync flushes.
+   b. **Re-read the save-state via JS**: title, price, quantity,
+      condition-description, **description mirror non-empty**, each filled
+      item-specific shows its value, Best Offer reflects the gate,
+      weight/dims. Confirm no variations modal.
+   c. **Re-apply any field that didn't persist**, wait, re-read. Loop up
+      to 3×.
+   d. **Hard gate:** description mirror still empty, or any required field
+      missing after 3 tries → **DO NOT SAVE** — report exactly which field
+      failed. An unsaved draft you can retry beats a silently-broken one.
+9. **Save:** only on a fully green checklist, click **"Save for later"**
+   (find by text; it may report width 0 in a sticky footer — `.click()`
+   anyway).
+10. **Post-save persistence check:** reopen the draft from Seller Hub →
+    Drafts (`lstng?draftId=…&mode=AddItem`), wait for load, re-read the
+    description mirror + title + price. Description came back empty → the
+    debounce lost it on save: re-apply, re-run step 8, Save again. Only
+    report success once the RELOADED draft shows a non-empty description.
+11. Write the `draftId` into draft.md `meta.ebay_offer_id` +
+    `meta.last_synced`; append a `[LIST/EDIT]` line to NEEDS_REVIEW with
+    the draftId + every manual-completion item.
 
 ## Status report (back to the user)
 
 - Path taken (A/B) + draftId + "Saved as draft; not published."
 - Title in the saved draft + char count (Path A: discrepancy block if
-  the cloned and draft titles differ).
+  cloned and draft titles differ).
 - Fields set & verified (price, condition, description, weight/dims,
   specifics, Best Offer).
 - **Manual completion needed** (bullets) — photos if upload was blocked,
@@ -222,45 +183,34 @@ typing + Enter (via `form_input`/`computer`), not a JS value set.
 
 ## Photo upload (methods, in priority order)
 
-Findings from the 2026-06-07 live run. The eBay photo input is a hidden
-`input[type=file]` (multi) plus a "Drag and drop files" zone. Use the
-first method that works in the current environment:
+The eBay photo input is a hidden `input[type=file]` (multi) plus a "Drag
+and drop files" zone. Use the first method that works:
 
-1. **eBay Sell API → EPS (target, full-res, no UI).** The real fix. When
-   `lib/list_edit.py` is implemented, photos POST to eBay Picture
-   Services and attach by URL — no sandbox, no dialog, full resolution,
-   correct order. Prefer this once the dev key exists; it makes upload
-   fully hands-off.
-
+1. **eBay Sell API → EPS (primary, full-res, no UI).** Photos POST to
+   eBay Picture Services and attach by URL — no sandbox, no dialog,
+   correct order. Prefer whenever the API path is available.
 2. **`upload_image` injection (full-res, no API) — preferred interim.**
-   If the user drags the shoot photos into the chat once, each becomes an
+   The user drags the shoot photos into chat once; each becomes an
    in-session image with an `imageId`;
-   `upload_image({imageId, ref:<file input>, filename})` injects them into
-   the hidden file input at full resolution, in call order (first = hero).
-   This is the most reliable local-disk method when the Sell API isn't
-   available — it sidesteps both the read-tier wall and the file_upload
-   sandbox.
+   `upload_image({imageId, ref:<file input>, filename})` injects into the
+   hidden file input at full resolution, in call order (first = hero).
+3. **Native Windows file dialog — only if the browser is FULL tier.**
+   Click "Upload from computer", type the path + quoted filenames into the
+   **Open** dialog. Blocked at computer-use **read** tier (Chrome rejects
+   typing and the MCP refuses the click) — only viable when
+   `list_granted_applications` shows the browser at `full`.
 
-3. **Native Windows file dialog — only if the browser is FULL tier.** Click
-   "Upload from computer", then type the shoot-dir path + quoted filenames
-   into the Windows **Open** dialog and click Open. **Confirmed blocked
-   2026-06-07** when the browser is granted at computer-use **read** tier:
-   Chrome (and its Open dialog) reject typing, and the Chrome MCP refuses
-   the file-button click. Only viable if `list_granted_applications` shows
-   the browser at `full` tier. Do not rely on it otherwise.
+**Does NOT work — do not retry:** `file_upload` on arbitrary disk paths
+(project paths, `~/Downloads`, and `request_directory` folders all
+rejected). Only viable for genuinely session-shared files.
 
-**Does NOT work — do not retry:** `file_upload` on arbitrary disk paths.
-It accepts only files shared with the session; project paths, `~/Downloads`,
-AND folders connected via `request_directory` were all REJECTED in testing.
-`file_upload` is only viable for genuinely session-shared files.
+**Tooling note:** granting computer-use over Chrome can flip the Chrome
+MCP to read-only on the active tab ("Permission denied … on this
+domain") — the user re-clicks the extension on the tab to restore write
+access. Finish all Chrome MCP field-fills BEFORE requesting computer-use
+access.
 
-**Tooling note:** granting computer-use over Chrome can flip the Chrome MCP
-to read-only on the active tab ("Permission denied … on this domain"). If
-that happens, the user re-clicks the Claude-in-Chrome extension on the tab
-to restore write access. Prefer finishing all Chrome MCP field-fills BEFORE
-requesting computer-use access.
-
-If none are available this run, flag photos for manual drag-drop (DSC
+If no method is available this run, flag photos for manual drag-drop (DSC
 order, first = hero) in the status report and continue — the rest of the
 draft is still worth saving.
 
@@ -270,7 +220,3 @@ draft is still worth saving.
 - eBay forces a similar-item pick with no "Continue without match" → STOP.
 - Category-change or policy-violation prompt → STOP, report verbatim.
 - Save gated behind a violation → report; do not work around it.
-
-When `lib/list_edit.py` gains the live Sell API, this prompt is
-deprecated (the API path avoids the RTE quirks, the scroll/coordinate
-fragility, and the photo-upload limitation via EPS).

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -1,4 +1,4 @@
-# PRICE — v3, Function 2
+# PRICE — v4, Function 2
 
 Obeys [`_shared.md`](_shared.md). Read it first.
 

--- a/prompts/promote.md
+++ b/prompts/promote.md
@@ -1,4 +1,4 @@
-# PROMOTE — v3, Function 8 (paid placement)
+# PROMOTE — v4, Function 8 (paid placement)
 
 Obeys [`_shared.md`](_shared.md). Read it first.
 
@@ -32,8 +32,7 @@ call is printed and not sent:
     --bidding DYNAMIC   hand bid management to eBay
     --delete ID         remove a campaign
 
-This is not timidity about the API. It is that an ad added by mistake is not
-free to undo: it spends before anyone notices.
+An ad added by mistake is not free to undo: it spends before anyone notices.
 
 ## What the funding model decides — and what decides the funding model
 
@@ -106,10 +105,10 @@ score as measured return.
 
 ## Reuse a campaign before creating one
 
-The account accumulates campaigns — five already, four of them paused, 81 ads
-inside them doing nothing. Resuming a paused ON_SITE campaign keeps the ads it
-already holds and costs one call; a new campaign starts from zero and adds
-another thing to reconcile. Create one only when there is nothing to reuse.
+The account accumulates campaigns. Resuming a paused ON_SITE campaign keeps
+the ads it already holds and costs one call; a new campaign starts from zero
+and adds another thing to reconcile. Create one only when there is nothing to
+reuse.
 
 **Items already carrying an ACTIVE ad in a RUNNING campaign are excluded** —
 they are already promoted, and adding them again is not a second bet.

--- a/prompts/reference/identify-notes.md
+++ b/prompts/reference/identify-notes.md
@@ -1,0 +1,46 @@
+# IDENTIFY — rationale, history, and evidence
+
+Companion to [prompts/identify.md](../identify.md). The prompt holds the
+rules; this file holds *why* they exist. Read only when a rule is disputed
+or being changed.
+
+## Why the CLIP/forum index is disabled for marbles
+
+CLIP embeds at 224px and matches on colour, not seams — in practice the
+forum-index tools returned colour look-alikes rather than maker matches,
+and the forum thread titles they surfaced are OP guesses (often wrong;
+only high-rep reply answers are trustworthy). Measured against an expert
+gold set, the classifier also floats toward generic machine-made calls
+(67% of expert handmade/transitional called machine). The tools are kept
+but dormant; the maker/type call comes from photos + the specialization's
+tells alone. They run only on an explicit user request, outside the
+identify record.
+
+## The Lens OCR caveat: how it was verified
+
+`lib/lens_id.py`'s OCR reliably reads printed/painted marks (paper labels,
+painted backstamps, ink) and routinely returns "No results" on
+low-contrast embossed metal stamps — verified on silver/pewter/buckle/
+jewelry pieces. That is why an empty OCR result must never be read as "no
+mark": for pressed metal, the step-1 close-read is the authority, and the
+tool's verdict says so. Separately, `lens_id.py` can return empty datasets
+with NO error when the tmpfiles host serves an HTML interstitial — always
+run a known-indexed control image before believing "no matches".
+
+## Why the maker-mark stop-and-ask exists
+
+The user is holding the piece; a close-read of a mark beats any web or
+Lens inference and costs nothing. The gate categories (jewelry, precious
+metals, glass, ceramics) are the ones where a mark almost always exists
+and swings value hard — a missed mark is the most expensive thing to leave
+on the table. The exception clause exists because stopping on every plain
+drinking glass taxes the operator for no value; the one-line
+`exception:` log keeps the skip auditable.
+
+## Why photo intake is capped
+
+Full-res photos are the dominant token cost of a shoot, and near-duplicate
+angles add cost without evidence. The 4–6-frame decisive set (hero, mark,
+details, scale) resolves a single-item record; the cap never applies to
+frames that carry a mark, and wide/group shoots read whatever coverage
+enumeration requires.

--- a/prompts/reference/list-edit-chrome-notes.md
+++ b/prompts/reference/list-edit-chrome-notes.md
@@ -1,0 +1,52 @@
+# LIST/EDIT Chrome stand-in — rationale, history, and evidence
+
+Companion to [prompts/list_edit_chrome.md](../list_edit_chrome.md). Read
+only when a rule is disputed or being changed.
+
+## Status: interim fallback, not deprecated
+
+The prompt was written before `lib/list_edit.py` had the live Sell API and
+was expected to be deprecated once it did. The API path is now primary
+(EPS photo upload, offer publish, live revision), but the stand-in stays
+as the fallback for categories the API cannot publish (e.g. eBay Motors —
+see the `[CHANNEL]` convention in NEEDS_REVIEW.md) and for runs where the
+API credentials are unavailable.
+
+## The trusted-input discovery (why the description went missing)
+
+The #1 recurring failure was a saved draft with a blank description. Two
+compounding root causes, found on the first live run (the hen listing):
+
+1. **Untrusted events are ignored by the save-model.** The RTE commits to
+   eBay's save-state only on `isTrusted === true` input. JS value-setters,
+   `innerHTML`, dispatched Events and `execCommand` all update what the
+   editor *shows* but never reach the save-state — the draft saves blank
+   no matter how many times the fill is re-applied. Chrome MCP `computer`
+   `type`/`key` actions dispatch real CDP keystrokes, which are trusted;
+   that is the entire basis of the "type, don't inject" rule.
+2. **Debounced sync.** Even trusted input flushes to the mirror textarea
+   on a debounce (a few hundred ms after blur), so an immediate save races
+   it — hence the settle-and-verify gate and the post-save reload check.
+
+The same trusted-input rule is why item-specifics tag-selects need real
+typing + Enter rather than a JS value set.
+
+## The hen run (first live run, Path B)
+
+- eBay's AI-suggested specifics made a category-plausible but item-wrong
+  guess ("Subject: Rooster" on a poule) — the origin of the "Apply all,
+  THEN correct" rule.
+- The similar-items grid was passed via "Continue without match"; clicking
+  an item card adopts its identity, hence the never-click rule.
+
+## Photo upload findings (2026-06-07 live run)
+
+- Native Windows Open dialog: blocked at computer-use **read** tier —
+  Chrome and its dialog reject typing, and the Chrome MCP refuses the
+  file-button click. Confirmed live, hence "FULL tier only".
+- `file_upload` on arbitrary disk paths: project paths, `~/Downloads`,
+  and folders connected via `request_directory` were all rejected in
+  testing — it accepts only session-shared files.
+- Granting computer-use over Chrome flipped the Chrome MCP to read-only
+  on the active tab; the user re-clicking the extension restored it —
+  hence "field-fills before computer-use access".

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -1,4 +1,4 @@
-# REVIEW — v3, Function 5.5 (the publish gate)
+# REVIEW — v4, Function 5.5 (the publish gate)
 
 Obeys [`_shared.md`](_shared.md). Read it first.
 


### PR DESCRIPTION
## What this lands

Finishes V4_PLAN Phase 1 (#30). Every stage prompt is now a rules-only checklist, with rationale/history/evidence parked in `prompts/reference/`, read only when a rule is disputed — the same split `price.md` (#34) and `prep.md`/`draft.md` (#39) already got.

- **`identify.md` 364 → 326** + `reference/identify-notes.md` (46). Mostly rules already; the CLIP-disabled evidence, the Lens OCR verification story, and the whys behind the maker-mark gate move out. No gate, marker rule, or output field changed.
- **`list_edit_chrome.md` 276 → 222** + `reference/list-edit-chrome-notes.md` (52). The hen-run and 2026-06-07 photo-upload findings move out; the trusted-input rule and all workflow gates stay verbatim. Status corrected: it's the standing fallback for categories the API can't publish (Motors), not a prompt awaiting deprecation.
- **`_shared.md` 208 → 201** — near-pure contract; light trim of the comps-rule verbosity only.
- **`promote.md`** loses its stale account-state snapshot; **`curate.md` / `review.md` / `investigate.md` / `condition-rubric.md`** audited as already rules-only.
- All stage prompts now carry the **v4 header**. (`RUN.md` keeps its v3 label until its own pass.)

The always-loaded per-stage prompt set is now ~2,500 lines of rules (was ~3,300 mixed), with ~490 lines of rationale in `prompts/reference/`.

## Verification

`python tests/run_all.py --fast` green; `python -m pytest tests/` green. The prompt-wiring assertions (`prep.md` exists, `--repoint-draft` in draft.md) and the one external anchor link (`draft.md#the-house-title-pattern` from the patinaelements study) all still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)