### PR TITLE
v4 phase 2: terse tool output, the in-hand voice linter, and API-truth draft state

### DIFF
--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -84,6 +84,8 @@ from typing import Optional
 from config import ConfigError, config_path, load_config
 from draft_io import (Draft, parse_draft, resolve_photo_paths, set_photo_order,
                        update_meta)
+from verdict import emit as _verdict_emit
+from voice_check import check_voice
 from ebay_client import (
     DEFAULT_MARKETPLACE,
     EbayAPIError,
@@ -462,6 +464,10 @@ def validate_draft_for_sync(draft_path: Path) -> list[str]:
         v = draft.get(dotpath)
         if v not in (None, "") and len(str(v)) > cap:
             issues.append(f"{dotpath}: {v!r} exceeds maxLen {cap}")
+
+    # In-hand voice (GH #40): camera-frame confessions in buyer copy block a
+    # sync. Warns are advisory — see `python lib/voice_check.py`.
+    issues += [f for f in check_voice(draft) if f.startswith("voice (block)")]
 
     return issues
 
@@ -1252,6 +1258,18 @@ def build_review_card(draft_path: Path,
     nr = shoot / "NEEDS_REVIEW.md"
     if nr.exists():
         flags = ["  • " + ln.strip() for ln in nr.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    # Stale-meta check (GH #40): surface a meta/eBay disagreement at the gate
+    # rather than in an audit months later. SOFT — an API failure never blocks
+    # the card.
+    try:
+        _st = resolve_draft_state(draft_path, creds)
+        if _st["stale"] and (_st["offer_id"] or _st["meta_offer_id"]):
+            flags.append(
+                f"  • ⚠ draft meta says offer {_st['meta_offer_id']}/listing "
+                f"{_st['meta_listing_id']} but eBay says {_st['offer_id']}/"
+                f"{_st['listing_id']} ({_st['status']}) — run --repair-meta")
+    except Exception:                                      # noqa: BLE001
+        pass
     if not flags:
         flags = ["  • None"]
 
@@ -1532,6 +1550,32 @@ def offer_sellable_state(sku: str, creds: EbayCredentials) -> dict:
     return dict(sellable=not reason, status=status or lstatus or "unknown",
                 quantity=qty, offer_id=o.get("offerId"),
                 listing_id=listing.get("listingId"), reason=reason)
+
+
+def resolve_draft_state(draft_path: Path,
+                        creds: Optional[EbayCredentials] = None) -> dict:
+    """The eBay-API-is-truth rule applied to a single draft (GH #40).
+
+    A draft's own meta can lie about whether it is live — christmas-elk
+    carried `ebay_offer_id: null` while live as 206494264413 — so any triage
+    that reads `meta.ebay_*` inherits stale state. Resolve by SKU via the
+    Inventory API; never from draft meta, never from the ledger.
+
+    Returns {sku, status, sellable, quantity, offer_id, listing_id, reason,
+    meta_offer_id, meta_listing_id, stale}; `stale` means the draft's meta
+    disagrees with eBay and `--repair-meta` would rewrite it.
+    """
+    creds = creds or load_credentials()
+    draft = parse_draft(draft_path)
+    sku = _sku_for(draft)
+    st = offer_sellable_state(sku, creds)
+    api_offer = str(st.get("offer_id")) if st.get("offer_id") else None
+    api_listing = str(st.get("listing_id")) if st.get("listing_id") else None
+    meta_offer = str(draft.get("meta.ebay_offer_id") or "").strip() or None
+    meta_listing = str(draft.get("meta.ebay_listing_id") or "").strip() or None
+    return dict(sku=sku, meta_offer_id=meta_offer, meta_listing_id=meta_listing,
+                stale=(meta_offer != api_offer or meta_listing != api_listing),
+                **st)
 
 
 def update_listing_fields(draft_path: Path, fields,
@@ -1985,6 +2029,8 @@ def _cli() -> None:
         description="ebaybiz — LIST/EDIT (Function 6): sync draft.md -> eBay DRAFT; publish only via --publish/--list --confirm (post review-gate).",
         formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
     ap.add_argument("--validate", metavar="TARGET", help="Validate a draft.md or shoot dir (no creds).")
+    ap.add_argument("--status", metavar="TARGET", help="Read-only: resolve a draft's REAL eBay state by SKU via the API — never from meta or the ledger. TARGET is a draft.md, a shoot dir, or a tree (bulk triage). GH #40.")
+    ap.add_argument("--repair-meta", metavar="TARGET", help="--status plus: write the true ebay_offer_id/ebay_listing_id back into any draft whose meta is stale. No-op on already-correct drafts. GH #40.")
     ap.add_argument("--record", metavar="TARGET", help="DRAFT-time: stamp the SKU into the draft + create its ledger record (DRAFTED). No creds.")
     ap.add_argument("--normalize", metavar="TARGET", help="Migrate a legacy url-style SKU to canonical 8-hex + clear orphaned offer/listing ids in a draft.md or shoot dir. No creds.")
     ap.add_argument("--preflight", metavar="TARGET", help="Check (and auto-correct) condition + shipping against the eBay category (needs creds).")
@@ -2020,6 +2066,37 @@ def _cli() -> None:
                 for i in issues:
                     print(f"  - {i}")
                 sys.exit(1)
+            return
+        if args.status or args.repair_meta:
+            target = Path(args.status or args.repair_meta)
+            repair = bool(args.repair_meta)
+            drafts = ([target] if target.is_file()
+                      else sorted(target.rglob("draft.md")))
+            if not drafts:
+                raise SystemExit(f"no draft.md under {target}")
+            creds = load_credentials()
+            flagged = []
+            for dp in drafts:
+                try:
+                    st = resolve_draft_state(dp, creds)
+                except Exception as e:                     # noqa: BLE001
+                    flagged.append((str(dp), f"resolve failed: {str(e)[:80]}"))
+                    continue
+                if len(drafts) == 1:
+                    print(f"  {st['sku']}  {st['status']}  offer {st['offer_id']}"
+                          f"  listing {st['listing_id']}"
+                          + (f"  ({st['reason']})" if st.get("reason") else ""))
+                if st["stale"]:
+                    note = (f"meta {st['meta_offer_id']}/{st['meta_listing_id']}"
+                            f" but eBay {st['offer_id']}/{st['listing_id']}"
+                            f" ({st['status']})")
+                    if repair:
+                        update_meta(dp, {"ebay_offer_id": st["offer_id"] or "",
+                                         "ebay_listing_id": st["listing_id"] or ""})
+                        note += " — REPAIRED"
+                    flagged.append((str(dp), note))
+            _verdict_emit("repair-meta" if repair else "status",
+                          len(drafts), flagged)
             return
         if args.record:
             sku, ledger = record_draft(Path(args.record))

--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -71,6 +71,10 @@ from . import categories as catmod
 from . import subject as subjectmod
 from . import unskew as skewmod
 from .subject import mask_for
+try:
+    from ..verdict import emit as verdict_emit
+except ImportError:          # lib/ itself on sys.path: photo_prep is top-level
+    from verdict import emit as verdict_emit
 
 IMG_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".heic", ".heif", ".tif", ".tiff"}
 MANIFEST_VERSION = 1
@@ -727,9 +731,11 @@ def plan_geometry(shoot: Path, quiet: bool = False,
     pad = float(m["settings"].get("pad", DEFAULT_PAD))
     smode = subject_mode(m)
 
+    refused = []
     for key, rec in m["photos"].items():
         src = shoot / key
         if not src.exists():
+            refused.append((key, "source file missing"))
             continue
         upright = orientmod.rotate_bgr(_load_bgr(src), rec["orientation"]["applied"])
         sm = mask_for(upright, smode)
@@ -757,14 +763,16 @@ def plan_geometry(shoot: Path, quiet: bool = False,
                                        bg_class_effective=stats.bg_class))
         rec["status"] = "SHIP" if crop["applied"] else "PASSTHROUGH"
         rec.pop("pending_orientation", None)
-        if not quiet:
-            print(f"  {key:28} "
-                  f"{'crop' if crop['applied'] else 'no crop: ' + (crop.get('reason') or '')[:44]}")
+        # An operator's crop-off is an answer, not a refusal — only the
+        # pipeline's own refusals are exceptions worth a line.
+        if not crop["applied"] and not crop.get("operator"):
+            refused.append((key, "no crop: " + (crop.get("reason") or "")[:60]))
 
     m["backdrop"] = _unify_backdrop(m["photos"], quiet)
     save_manifest(shoot, m)
     if not quiet:
-        print(f"\n{shoot.name}: geometry and colour planned on the approved rotations")
+        verdict_emit(f"{shoot.name} geometry", len(m["photos"]), refused,
+                     detail=shoot / ".prep" / "prep.json")
     return m
 
 
@@ -881,11 +889,6 @@ def run_check(shoot: Path, aspect_s: str, pad: float, pop: str,
         # confirming something that is not what will ship.
         thumbs.append((key, _thumb(cam)))
 
-        if not quiet:
-            rot = f"exif {v.exif_angle}+subj {v.subject_angle}={v.applied}"
-            print(f"  {key:28} {rot:<26} {v.source:<12}"
-                  + ("  [ASK]" if v.needs_ask else ""))
-
     m["photos"] = photos
     _corroborate_orientation(photos, quiet)
     # The backdrop verdict is a MEASUREMENT of the upright frame, so it belongs
@@ -898,12 +901,11 @@ def run_check(shoot: Path, aspect_s: str, pad: float, pop: str,
 
     _rotation_sheet(thumbs, photos, shoot / ".prep" / "rotation_sheet.jpg")
     if not quiet:
-        asks = sum(1 for r in photos.values() if r["orientation"]["needs_ask"])
-        print(f"\n{shoot.name}: {len(photos)} photos · "
-              f"{asks} awaiting an orientation answer")
-        print("  orientation is the first stage and nothing else is measured "
-              "until it is approved.")
-        print(f"  next: --stage orientation")
+        flags = [(k, f"orientation ASK ({r['orientation']['source']})")
+                 for k, r in photos.items() if r["orientation"]["needs_ask"]]
+        verdict_emit(f"{shoot.name} check", len(photos), flags,
+                     detail=shoot / ".prep" / "prep.json",
+                     next_hint="--stage orientation")
     return m
 
 
@@ -965,11 +967,13 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
     out_dir = shoot / "listing"
     out_dir.mkdir(exist_ok=True)
     rows = []
+    flags = []
 
     for name, rec in m["photos"].items():
         src = shoot / name
         if not src.exists():
             rec["status"] = "MISSING"
+            flags.append((name, "source file MISSING"))
             continue
 
         before = _load_bgr(src)
@@ -1041,12 +1045,16 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
         rec["status"] = "ASK" if rec["orientation"]["needs_ask"] else "PICK"
 
         rows.append((name, before, variants, rec))
-        if not quiet:
-            c = creport
-            print(f"  {name:28} {len(variants)} presets  "
-                  f"bg {c['bg_luma_before']:.0f}->{c['bg_luma_after']:.0f} "
-                  f"str={c['strength']} new-clip={c['subject_newly_clipped']} "
-                  f"new-crush={c['subject_newly_crushed']}")
+        # Exceptions only: the colour pass measuring its own output as having
+        # damaged item pixels, or an orientation still unresolved. Routine
+        # per-frame render stats live in the manifest.
+        c = creport
+        if c["subject_newly_clipped"] or c["subject_newly_crushed"]:
+            flags.append((name, f"colour pass touched item pixels "
+                                f"(new-clip={c['subject_newly_clipped']}, "
+                                f"new-crush={c['subject_newly_crushed']})"))
+        if rec["orientation"]["needs_ask"]:
+            flags.append((name, "orientation still ASK"))
 
     m["approved"] = False
     m["approved_at"] = None
@@ -1056,6 +1064,9 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
     # 3.5 GB of them. See _sweep_unreferenced_presets.
     _sweep_unreferenced_presets(shoot, m, quiet=quiet)
     _presets_sheet(rows, shoot / ".prep" / "prep_presets.jpg")
+    if not quiet:
+        verdict_emit(f"{shoot.name} apply", len(m["photos"]), flags,
+                     detail=shoot / ".prep" / "prep.json")
 
     # Adopt the backdrop's default look so `listing/` is populated without a
     # separate step. Both looks stay rendered and `--pick` swaps them; the
@@ -1538,12 +1549,13 @@ def run_auto(shoot: Path, aspect_s: str, pad: float, pop: str,
 
     photos = m.get("photos") or {}
     cropped = [n for n, r in photos.items() if (r.get("crop") or {}).get("applied")]
-    print(f"\n{shoot.name}: auto first pass — {len(photos)} frames, "
-          f"{len(cropped)} cropped, {len(guessed)} orientation guessed")
-    if guessed:
-        print("  guessed (worth a look): " + ", ".join(guessed))
-    print("  nothing is approved. --approve-auto to take it as it stands, "
-          "or --stage orientation to open the review.")
+    print(f"\n{shoot.name}: auto first pass — {len(cropped)}/{len(photos)} "
+          f"cropped, nothing approved")
+    verdict_emit("auto", len(photos),
+                 [(k, "orientation guessed — worth a look") for k in guessed],
+                 detail=shoot / ".prep" / "prep.json",
+                 next_hint="--approve-auto takes it as it stands; "
+                           "--stage orientation opens the review")
     return m
 
 

--- a/lib/verdict.py
+++ b/lib/verdict.py
@@ -1,0 +1,42 @@
+"""One-line tool verdicts — the v4 terse-output convention (V4_PLAN Phase 2).
+
+A tool's default stdout is a VERDICT, not a narration:
+
+      FLAG <name>  <reason>            (one line per flagged item, first)
+    <label>: OK <ok>/<total>[, <k> flagged] -> <detail>
+      next: <hint>                     (only when there is a next step)
+
+The detail file — usually JSON the tool already writes, e.g. PREP's
+`.prep/prep.json` manifest — carries everything else and is read only when
+something is flagged. A flagged row is an EXCEPTION the operator (or the
+model driving the run) should look at; routine per-item success lines are
+noise and never print.
+
+ASCII only ("->", "FLAG"): these lines must survive any Windows console
+codepage without the tool caring.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+
+def emit(label: str, total: int,
+         flagged: Iterable[Tuple[str, str]] = (),
+         detail=None, next_hint: str = "") -> str:
+    """Print flagged rows then the one-line verdict; return the verdict line.
+
+    `flagged` is (name, reason) pairs. `detail` is the path of the file
+    holding the full record (printed verbatim; pass a Path or str).
+    """
+    rows = list(flagged)
+    for name, reason in rows:
+        print(f"  FLAG {name}  {reason}")
+    line = f"{label}: OK {total - len(rows)}/{total}"
+    if rows:
+        line += f", {len(rows)} flagged"
+    if detail is not None:
+        line += f" -> {detail}"
+    print(line)
+    if next_hint:
+        print(f"  next: {next_hint}")
+    return line

--- a/lib/voice_check.py
+++ b/lib/voice_check.py
@@ -1,0 +1,188 @@
+"""In-hand voice linter — buyer copy never speaks from behind the camera.
+
+GH #40: the rule lives in prompts/draft.md ("In-hand voice"), and until now
+its enforcement was whatever regex an agent typed that day — which missed 12
+live listings on the first sweep. This is the linter, wired into
+`validate_draft_for_sync()` so it runs on `--validate`, `--sync` and
+`--review` with no eBay call.
+
+The pattern and exemption sets were validated empirically against 131 drafts
+and the 84-listing live sweep (2026-08-26/27); tune them HERE and port the
+change back to issue #40, never ad hoc in a session. Two deliberate
+refinements of the issue's list: the bare `odou?r` / `shake-test` patterns
+block only as TESTS-NOT-RUN NARRATION ("odor not verified", "not
+shake-tested") — a genuine defect disclosure ("slight musty odor") must
+never be blocked, per the honesty ground rules — and four adjective-order /
+"for these photographs" forms are added because the issue's own example
+listings require them.
+
+API:  check_voice(draft) -> list[str]
+      findings look like  "voice (block): body: 'no tears noted on the shown surfaces'"
+      Blocks fail sync; warns are advisory.
+
+CLI:  python lib/voice_check.py <draft.md | shoot-dir> [...]
+      python lib/voice_check.py --audit inventory/        # every **/draft.md
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    from draft_io import Draft, parse_draft
+except ImportError:                       # imported as lib.voice_check
+    from lib.draft_io import Draft, parse_draft  # type: ignore
+
+# Everything after this marker in a body is internal, never buyer-visible.
+END_MARKER = "END BUYER DESCRIPTION"
+
+_B = [  # camera-frame confessions — BLOCK
+    r"visible\s+in\s+(the\s+)?(photo|frame|any\s+photo|listing)",
+    r"\bnot\s+(shown|pictured|photographed)\b",
+    r"\b(shown|pictured|photographed)\s+(in|on|fully|honestly|close|exactly|as|through|base-)",
+    r"\b(pages|frames|spreads|surfaces|areas|views|faces|sections|lot|car|piece)\s+(shown|photographed|pictured)\b",
+    r"\b(shown|pictured|photographed)\s+(surfaces?|pages?|frames?|spreads?|areas?|views?|sides?|sections?)\b",
+    r"\bin\s+the\s+(frames|photos|photographs|pictures)\b",
+    r"\bas[-\s]shown\b",
+    r"\bas\s+pictured\b",
+    r"\bunshown\b",
+    r"\bunphotographed\b",
+    r"for\s+(these|the)\s+photo(graph)?s\b",
+    r"from\s+(the\s+)?photo",
+    r"assessable\s+from",
+    r"\bnot\s+(verifiable|identifiable|assessable)\b",
+    r"\bcannot\s+be\s+(verified|identified|assessed)\s+from\b",
+    r"\bany\s+photo\b",
+    r"\bany\s+frame\b",
+    r"no\s+scale\s+(photograph|reference)",
+    r"at\s+full\s+resolution",
+    r"ruler\s+frame\s+was\s+shot",
+    r"\b(not\s+)?shake[-\s]?tested?\b|\bshake\s+test\b",
+    r"\bodou?r\b[^.!?\n]{0,24}\b(not\s+)?(verified|checked|tested|assessed)",
+    r"\b(ring|sound)\s+test\s+(not\s+)?(performed|run|done)",
+]
+BLOCK = [re.compile(p, re.IGNORECASE) for p in _B]
+
+_W = [  # softer normalizations — WARN, never block
+    (r"\bno\s+[\w\s,/-]{0,40}?\bvisible\b",
+     "prefer 'no X noted' over 'no X visible'"),
+    (r"\bodou?r\b",
+     "odor: fine as a defect disclosure, never as a test not run"),
+]
+WARN = [(re.compile(p, re.IGNORECASE), why) for p, why in _W]
+
+_E = [  # sentence-level exemptions — correct copy that must NOT be flagged
+    r"please\s+(see|review|read|study)",                     # the standing close
+    r"\b(masked|redacted|blocked[-\s]?out|covered)\b",       # PII disclosure
+    r"(through|while|inside)\s+(the\s+)?(sealed|plastic|poly|sleeve|bag|shrink)",
+    r"while\s+sealed|\bsealed\s+(bag|sleeve|packaging|poly)",
+    r"\buntested\b",                                         # grade-setter
+    r"photography\s+by",                                     # the item's own content
+    r"pictured\s+(and\s+named|include)",
+    r"\(\s*(see\s+)?photo\s*\d*\s*\)",                       # bare photo pointer
+]
+EXEMPT = [re.compile(p, re.IGNORECASE) for p in _E]
+
+_SENT_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+|(?:^|\s)[-•*]\s+")
+
+
+def _sentences(text: str):
+    for s in _SENT_SPLIT.split(text or ""):
+        s = (s or "").strip()
+        if s:
+            yield s
+
+
+def _specific_values(node, prefix="item_specifics"):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            yield from _specific_values(v, f"{prefix}.{k}")
+    elif isinstance(node, (list, tuple)):
+        for v in node:
+            yield from _specific_values(v, prefix)
+    elif node not in (None, ""):
+        yield prefix, str(node)
+
+
+def _buyer_fields(draft: Draft):
+    """The positive list of buyer-visible text. Everything else is skipped —
+    meta (esp. meta.notes, which legitimately records every can't-assess),
+    photos, _field_constraints, and anything after the END marker."""
+    yield "title", str(draft.get("title") or "")
+    yield "condition_description", str(draft.get("condition_description") or "")
+    yield from _specific_values(draft.get("item_specifics") or {})
+    body = draft.body or ""
+    if END_MARKER in body:
+        body = body.split(END_MARKER, 1)[0]
+    yield "body", body
+
+
+def check_voice(draft: Draft) -> list[str]:
+    """Lint the draft's buyer-visible fields. Returns findings, blocks first."""
+    blocks, warns, seen = [], [], set()
+    for field, text in _buyer_fields(draft):
+        for sent in _sentences(text):
+            if any(e.search(sent) for e in EXEMPT):
+                continue
+            snip = sent if len(sent) <= 90 else sent[:87] + "..."
+            for rx in BLOCK:
+                if rx.search(sent):
+                    key = (field, snip)
+                    if key not in seen:
+                        seen.add(key)
+                        blocks.append(f"voice (block): {field}: '{snip}'")
+                    break
+            else:
+                for rx, why in WARN:
+                    if rx.search(sent):
+                        key = (field, snip)
+                        if key not in seen:
+                            seen.add(key)
+                            warns.append(f"voice (warn): {field}: '{snip}' — {why}")
+                        break
+    return blocks + warns
+
+
+def _iter_drafts(target: Path):
+    if target.is_file():
+        yield target
+    else:
+        yield from sorted(target.rglob("draft.md"))
+
+
+def main(argv=None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    audit = "--audit" in args
+    targets = [Path(a) for a in args if not a.startswith("--")]
+    if not targets:
+        print(__doc__.strip().splitlines()[0])
+        print("usage: voice_check.py <draft.md | dir> [--audit]")
+        return 2
+
+    flagged, total = [], 0
+    for t in targets:
+        for dp in _iter_drafts(t):
+            total += 1
+            try:
+                findings = check_voice(parse_draft(dp))
+            except Exception as e:                       # noqa: BLE001
+                flagged.append((str(dp), f"parse error: {e}"))
+                continue
+            n_block = sum(1 for f in findings if f.startswith("voice (block)"))
+            if findings:
+                flagged.append((str(dp),
+                                f"{n_block} block / {len(findings) - n_block} warn"))
+                if not audit:                            # single-draft: full detail
+                    for f in findings:
+                        print(f"  {f}")
+    try:
+        from verdict import emit as verdict_emit
+    except ImportError:
+        from lib.verdict import emit as verdict_emit     # type: ignore
+    verdict_emit("voice", total, flagged)
+    return 1 if any("block" in r for _, r in flagged) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -1,0 +1,53 @@
+"""The terse-output convention: format stability for lib/verdict.py.
+
+Other tooling (and the operator's eye) greps these lines; the shape is a
+contract. No pytest fixtures — runs under tests/run_all.py too.
+"""
+import io
+import re
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from lib.verdict import emit  # noqa: E402
+
+VERDICT_RE = re.compile(
+    r"^[\w ./-]+: OK \d+/\d+(, \d+ flagged)?( -> \S.*)?$")
+
+
+def _run(*args, **kw):
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        line = emit(*args, **kw)
+    return line, buf.getvalue().splitlines()
+
+
+def test_clean_run_is_one_line():
+    line, out = _run("check", 14)
+    assert line == "check: OK 14/14"
+    assert out == [line]
+    assert VERDICT_RE.match(line)
+
+
+def test_flagged_rows_print_before_the_verdict():
+    line, out = _run("check", 14,
+                     [("DSC_0101.jpg", "orientation ASK"),
+                      ("DSC_0104.jpg", "no crop: detectors disagree")],
+                     detail=".prep/prep.json")
+    assert out[0] == "  FLAG DSC_0101.jpg  orientation ASK"
+    assert out[1] == "  FLAG DSC_0104.jpg  no crop: detectors disagree"
+    assert out[2] == line == "check: OK 12/14, 2 flagged -> .prep/prep.json"
+    assert VERDICT_RE.match(line)
+
+
+def test_next_hint_prints_after_the_verdict():
+    _, out = _run("check", 3, [("a.jpg", "ASK")], next_hint="--stage orientation")
+    assert out[-1] == "  next: --stage orientation"
+
+
+def test_detail_accepts_a_path():
+    line, _ = _run("geometry", 5, detail=Path(".prep") / "prep.json")
+    assert line.endswith("prep.json")
+    assert VERDICT_RE.match(line)

--- a/tests/test_voice_check.py
+++ b/tests/test_voice_check.py
@@ -1,0 +1,183 @@
+"""In-hand voice linter + draft state resolution — the GH #40 acceptance set.
+
+Every block/exemption example here is a real phrase from the 2026-08 live
+sweep (the five listings named in the issue). No pytest fixtures — runs
+under tests/run_all.py too.
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "lib"))
+sys.path.insert(0, str(ROOT))
+
+from voice_check import check_voice  # noqa: E402
+from draft_io import parse_draft  # noqa: E402
+
+
+def _draft(body: str, cond: str = "Clean copy.", title: str = "Vintage Book") -> object:
+    tmpl = "\n".join([
+        "---",
+        "template_version: v1",
+        "meta:",
+        "  item_id: t",
+        '  ebay_inventory_sku: "deadbeef"',
+        "  ebay_offer_id: null",
+        "  ebay_listing_id: null",
+        '  notes: "UPC not shown in the photographed surfaces"',
+        f'title: "{title}"',
+        "condition: USED_EXCELLENT",
+        f'condition_description: "{cond}"',
+        "item_specifics:",
+        "  type: Book",
+        'price: "10.00"',
+        "quantity: 1",
+        "photos:",
+        "  - a.jpg",
+        "---",
+        body,
+    ])
+    td = tempfile.mkdtemp()
+    p = Path(td) / "draft.md"
+    p.write_text(tmpl, encoding="utf-8")
+    return parse_draft(p)
+
+
+def _blocks(findings):
+    return [f for f in findings if f.startswith("voice (block)")]
+
+
+def test_shown_surfaces_blocks_and_noted_passes():
+    # Acceptance #1, verbatim from a-brief-history-of-time.
+    assert _blocks(check_voice(_draft("No tears noted on the shown surfaces.")))
+    assert not check_voice(_draft("No tears noted."))
+
+
+def test_the_sweeps_missed_phrases_all_block():
+    for phrase in [
+        "One was taken out only for these photographs.",     # car-set
+        "Light wear in the frames shown.",                   # style-incentives
+        "Condition not assessable from photos.",             # style-incentives
+        "No vertical ruler frame was shot.",                 # bronze-dog
+        "The surface was examined at full resolution.",      # bronze-dog
+        "Stones intact on the surfaces shown.",              # broach
+        "Backstamp not verified from photos.",               # broach
+        "Ships as-shown.",
+        "Knife handle seated tight; not shake-tested.",
+        "Odor not verified.",
+    ]:
+        assert _blocks(check_voice(_draft(phrase))), phrase
+
+
+def test_exemptions_do_not_flag():
+    for phrase in [
+        "Please see the photos and read the description for full details.",
+        "The name and street on the mailing label are masked in the photos.",
+        "The backstamp cannot be read through the sealed poly sleeve.",
+        "Untested; sold as-is.",
+        "Every player pictured and named on the back cover.",
+        "Photography by Fabrizio Ferri.",
+        "Staples visible in the gutter.",                    # in-hand use
+        "Shows light wear at the corners.",
+    ]:
+        assert not _blocks(check_voice(_draft(phrase))), phrase
+
+
+def test_no_x_visible_warns_but_does_not_block():
+    fs = check_voice(_draft("No chips or cracks visible."))
+    assert not _blocks(fs)
+    assert any(f.startswith("voice (warn)") for f in fs)
+
+
+def test_honest_odor_disclosure_is_not_blocked():
+    # The honesty ground rule outranks the regex: a real defect must survive.
+    fs = check_voice(_draft("Slight musty odor from storage."))
+    assert not _blocks(fs)
+
+
+def test_meta_notes_are_never_scanned():
+    # The template's meta.notes carries banned copy on purpose.
+    for f in check_voice(_draft("Clean copy throughout.")):
+        assert "meta" not in f
+
+
+def test_condition_description_is_scanned():
+    fs = check_voice(_draft("Clean.", cond="Wear as shown in the photos."))
+    assert any("condition_description" in f for f in _blocks(fs))
+
+
+def test_validate_draft_for_sync_blocks_camera_copy():
+    import list_edit
+
+    td = Path(tempfile.mkdtemp())
+    (td / "a.jpg").write_bytes(b"\xff\xd8\xff\xe0fake")
+    (td / "draft.md").write_text("\n".join([
+        "---",
+        "template_version: v1",
+        "meta:",
+        '  ebay_inventory_sku: "deadbeef"',
+        'title: "Vintage Book"',
+        "condition: USED_EXCELLENT",
+        'condition_description: "No tears noted on the shown surfaces."',
+        "item_specifics:",
+        "  type: Book",
+        'price: "10.00"',
+        "quantity: 1",
+        "photos:",
+        "  - a.jpg",
+        "---",
+        "A clean vintage book from a local estate, described honestly.",
+    ]), encoding="utf-8")
+    issues = list_edit.validate_draft_for_sync(td / "draft.md")
+    assert any(i.startswith("voice (block)") for i in issues), issues
+
+    (td / "draft.md").write_text(
+        (td / "draft.md").read_text(encoding="utf-8").replace(
+            "No tears noted on the shown surfaces.", "No tears noted."),
+        encoding="utf-8")
+    issues = list_edit.validate_draft_for_sync(td / "draft.md")
+    assert not any(i.startswith("voice") for i in issues), issues
+
+
+def test_resolve_draft_state_flags_stale_meta():
+    # christmas-elk's shape: meta says null, eBay says live. API mocked.
+    import list_edit
+
+    td = Path(tempfile.mkdtemp())
+    (td / "draft.md").write_text("\n".join([
+        "---",
+        "meta:",
+        '  ebay_inventory_sku: "deadbeef"',
+        "  ebay_offer_id: null",
+        "  ebay_listing_id: null",
+        'title: "Elk"',
+        "---",
+        "body",
+    ]), encoding="utf-8")
+
+    real = list_edit.offer_sellable_state
+    list_edit.offer_sellable_state = lambda sku, creds: dict(
+        sellable=True, status="PUBLISHED", quantity=1,
+        offer_id="9090", listing_id="206494264413", reason="")
+    try:
+        st = list_edit.resolve_draft_state(td / "draft.md", creds=object())
+    finally:
+        list_edit.offer_sellable_state = real
+    assert st["stale"] and st["listing_id"] == "206494264413"
+    assert st["sku"] == "deadbeef"
+
+    # Correct meta -> not stale.
+    (td / "draft.md").write_text(
+        (td / "draft.md").read_text(encoding="utf-8")
+        .replace("ebay_offer_id: null", 'ebay_offer_id: "9090"')
+        .replace("ebay_listing_id: null", 'ebay_listing_id: "206494264413"'),
+        encoding="utf-8")
+    list_edit.offer_sellable_state = lambda sku, creds: dict(
+        sellable=True, status="PUBLISHED", quantity=1,
+        offer_id="9090", listing_id="206494264413", reason="")
+    try:
+        st = list_edit.resolve_draft_state(td / "draft.md", creds=object())
+    finally:
+        list_edit.offer_sellable_state = real
+    assert not st["stale"]


### PR DESCRIPTION
Closes #40.

## Terse tool output (V4_PLAN Phase 2, #30)

- **`lib/verdict.py`** — the convention: exceptions print as `FLAG <name> <reason>` rows, then one line — `label: OK n/m, k flagged -> detail` — pointing at the file that holds the full record. Format held stable by `tests/test_verdict.py`.
- **`lib/photo_prep/prep.py`** — check/geometry/apply/auto stop narrating every frame. What prints is what needs eyes: orientation ASKs, pipeline crop refusals (an operator's crop-off is an answer, not a refusal), colour passes that touched item pixels, missing sources. The full per-frame record already lives in `.prep/prep.json`.
- Surveyed but deliberately untouched: `list_edit.py` and `sales_report.py` are already verdict-style; the untracked audit tools adopt the convention when Phase 3 folds them into the CLI.

## Issue #40, implemented in full

**The in-hand voice linter** (`lib/voice_check.py`): buyer-visible fields only (meta.notes never scanned), the issue's validated pattern set + exemption set, camera confessions BLOCK / `no X visible` WARNs. Wired into `validate_draft_for_sync()`, so `--validate`, `--sync` and `--review` all enforce it with no eBay call. Two refinements ported back to the issue: odor/shake-test block only as tests-not-run narration (a genuine "musty odor" defect disclosure must survive, per the honesty ground rules), plus four adjective-order/"for these photographs" forms the issue's own example listings require.

**API-truth draft state** (`resolve_draft_state()` + CLI): resolves by SKU via the Inventory API, never meta or ledger. `--status <draft|tree>` for read-only bulk triage, `--repair-meta` to write the true ids back (no-op when correct), and `--review` now flags a meta/eBay disagreement at the gate (SOFT).

## Acceptance criteria — all verified

- "no tears noted on the shown surfaces" blocks; "no tears noted" passes ✔ (test)
- PII / sealed-item / close-line / item-content exemptions unflagged ✔ (tests, real sweep phrases)
- `voice_check --audit inventory/`: 279 drafts, 62 flagged — the known ~50 dirty backlog + warns, hits spot-checked genuine ✔ (live run)
- `--status` reports christmas-elk PUBLISHED / 206494264413 despite `ebay_offer_id: null` ✔ (live run)
- `--repair-meta` corrected that draft and re-runs as a no-op (`status: OK 1/1`) ✔ (live run)

## Verification

Full `python -m pytest tests/` green (149 tests incl. the 10 new); the one import-context regression my prep change introduced (lib/ on sys.path makes photo_prep top-level) was caught by the suite and fixed with a dual-form import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)