### PR TITLE
feat(voice): lint in-hand voice in code + resolve draft state from the API (closes #40)

### DIFF
--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -84,6 +84,7 @@ from typing import Optional
 from config import ConfigError, config_path, load_config
 from draft_io import (Draft, parse_draft, resolve_photo_paths, set_photo_order,
                        update_meta)
+from voice_check import check_voice
 from ebay_client import (
     DEFAULT_MARKETPLACE,
     EbayAPIError,
@@ -462,6 +463,12 @@ def validate_draft_for_sync(draft_path: Path) -> list[str]:
         v = draft.get(dotpath)
         if v not in (None, "") and len(str(v)) > cap:
             issues.append(f"{dotpath}: {v!r} exceeds maxLen {cap}")
+
+    # In-hand voice (prompts/draft.md, GH #40). Camera-frame language in
+    # buyer-visible copy blocks the sync — it is cheap to fix in the file and
+    # expensive to fix once live. Soft normalizations are warnings and do not
+    # block; run `python lib/voice_check.py --audit inventory/ --warnings`.
+    issues.extend(check_voice(draft))
 
     return issues
 
@@ -1530,6 +1537,71 @@ def offer_sellable_state(sku: str, creds: EbayCredentials) -> dict:
                 listing_id=listing.get("listingId"), reason=reason)
 
 
+def resolve_draft_state(draft_path: Path,
+                        creds: Optional[EbayCredentials] = None) -> dict:
+    """What state is this draft ACTUALLY in? Ask eBay, keyed on SKU.
+
+    Read-only. Makes no writes and cannot publish.
+
+    A draft's own `meta.ebay_*` fields are a log of what happened at sync time,
+    not a record of what is true now — and they go stale silently. During the
+    2026-08 voice sweep, `inventory/FR/christmas-elk/draft.md` carried
+    `ebay_offer_id: null` and no listing id while being LIVE on eBay as
+    206494264413. It was classified as an unpublished draft and skipped.
+
+    `offer_sellable_state()` already asks eBay the right question, but it was
+    only reachable from inside `update_listing_fields()` — so the only way to
+    learn a draft's real state was to attempt a write. This exposes it for
+    triage, which is what any audit or bulk sweep actually needs. Same doctrine
+    as tools/ledger_reconcile.py, one level down: the API is truth, the local
+    copy is assumed stale.
+
+    Returns the offer_sellable_state dict plus `sku`, `draft_offer_id`,
+    `draft_listing_id` and `meta_stale` (True when the draft disagrees).
+    """
+    creds = creds or load_credentials()
+    draft_path = _resolve_draft_path(draft_path)
+    draft = parse_draft(draft_path)
+    sku = str(draft.get("meta.ebay_inventory_sku") or "").strip()
+    if not sku:
+        return dict(sellable=False, status="NO_SKU", quantity=0, offer_id=None,
+                    listing_id=None, reason="draft has no meta.ebay_inventory_sku",
+                    sku=None, draft_offer_id=None, draft_listing_id=None,
+                    meta_stale=False, path=draft_path)
+
+    state = offer_sellable_state(sku, creds)
+    d_offer = str(draft.get("meta.ebay_offer_id") or "").strip() or None
+    d_listing = str(draft.get("meta.ebay_listing_id") or "").strip() or None
+    state.update(sku=sku, draft_offer_id=d_offer, draft_listing_id=d_listing,
+                 path=draft_path)
+    state["meta_stale"] = (
+        (state.get("offer_id") and d_offer != str(state["offer_id"])) or
+        (state.get("listing_id") and d_listing != str(state["listing_id"]))
+    )
+    return state
+
+
+def repair_draft_meta(draft_path: Path, creds: Optional[EbayCredentials] = None,
+                      apply: bool = False) -> dict:
+    """Write eBay's true offer/listing ids back into a draft whose meta is stale.
+
+    No-op on a draft that already agrees. Touches only `meta.*` — never copy,
+    price, photos, or anything eBay serves.
+    """
+    state = resolve_draft_state(draft_path, creds)
+    if not state.get("meta_stale"):
+        return state
+    updates: dict[str, str] = {}
+    if state.get("offer_id"):
+        updates["ebay_offer_id"] = str(state["offer_id"])
+    if state.get("listing_id"):
+        updates["ebay_listing_id"] = str(state["listing_id"])
+    if updates and apply:
+        update_meta(state["path"], updates)
+    state["repairs"] = updates
+    return state
+
+
 def update_listing_fields(draft_path: Path, fields,
                           creds: Optional[EbayCredentials] = None,
                           allow_not_sellable: bool = False) -> list[str]:
@@ -1994,6 +2066,8 @@ def _cli() -> None:
     ap.add_argument("--allow-not-sellable", action="store_true",
                     help="update even if the SKU's offer is not live (DANGEROUS: writing to a sold item can relist it)")
     ap.add_argument("--fields", metavar="LIST", help="Comma-separated field groups for --update (e.g. description,price). Groups: description,title,price,condition,aspects,photos,shipping,quantity,bestoffer,policies. Use 'policies' after changing shipping.international — it re-points the live offer at the right fulfillment policy.")
+    ap.add_argument("--status", metavar="TARGET", help="Read-only: ask eBay (by SKU) what state a draft is really in. Accepts a draft.md, a shoot dir, or a tree to walk. Never writes.")
+    ap.add_argument("--repair-meta", metavar="TARGET", help="Backfill eBay's true offer/listing ids into drafts whose meta.* is stale. DRY RUN unless --confirm.")
     ap.add_argument("--end", metavar="TARGET", help="End (withdraw) a live listing from a draft. DRY RUN unless --confirm is also given.")
     ap.add_argument("--offers", action="store_true", help="Query ALL offers on the account (sku, offerId, status, listingId, price).")
     ap.add_argument("--withdraw-offer", metavar="OFFER_ID", help="Withdraw (end) a live offer by ID — keeps the offer. DRY RUN unless --confirm.")
@@ -2016,6 +2090,54 @@ def _cli() -> None:
                 for i in issues:
                     print(f"  - {i}")
                 sys.exit(1)
+            return
+        if args.status:
+            root = Path(args.status)
+            targets = sorted(root.rglob("draft.md")) if root.is_dir() and not (root / "draft.md").exists() else [root]
+            creds = load_credentials()
+            rows = []
+            for t in targets:
+                if ".prior-run-bak" in str(t):
+                    continue
+                try:
+                    st = resolve_draft_state(t, creds)
+                except Exception as e:
+                    print(f"  ERR  {t}: {e}")
+                    continue
+                flag = " STALE-META" if st.get("meta_stale") else ""
+                name = t.parent.name if t.name == "draft.md" else t.name
+                print(f"  {st['status']:<12} {name:<42} sku={st.get('sku')} "
+                      f"listing={st.get('listing_id')}{flag}")
+                rows.append(st)
+            stale = sum(1 for r in rows if r.get("meta_stale"))
+            live = sum(1 for r in rows if r.get("status") == "PUBLISHED")
+            print(f"\n{len(rows)} draft(s): {live} live, {stale} with stale meta.")
+            if stale:
+                print("  fix with: python lib/list_edit.py --repair-meta <dir> --confirm")
+            return
+        if args.repair_meta:
+            root = Path(args.repair_meta)
+            targets = sorted(root.rglob("draft.md")) if root.is_dir() and not (root / "draft.md").exists() else [root]
+            creds = load_credentials()
+            fixed = 0
+            for t in targets:
+                if ".prior-run-bak" in str(t):
+                    continue
+                try:
+                    st = repair_draft_meta(t, creds, apply=args.confirm)
+                except Exception as e:
+                    print(f"  ERR  {t}: {e}")
+                    continue
+                if st.get("repairs"):
+                    fixed += 1
+                    verb = "repaired" if args.confirm else "WOULD repair"
+                    print(f"  {verb} {t.parent.name}: {st['repairs']}")
+            if not fixed:
+                print("[OK] no stale draft metadata found.")
+            elif not args.confirm:
+                print(f"\nDRY RUN — {fixed} draft(s) would change. Re-run with --confirm.")
+            else:
+                print(f"\n[OK] repaired {fixed} draft(s).")
             return
         if args.record:
             sku, ledger = record_draft(Path(args.record))

--- a/lib/voice_check.py
+++ b/lib/voice_check.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""In-hand voice linter — enforce the house rule in code, not in a grep.
+
+THE RULE (prompts/draft.md, adopted 2026-08-26). Buyer-visible copy speaks as
+a seller holding the item, never from behind the camera. Banned:
+
+  * camera framing        "visible in the photos", "shown/pictured", "as-shown",
+                          "photographed surfaces", "in the frames shown"
+  * photo-limit confession "not verifiable from the photos", "not assessable
+                          from photos", "measured off the photographs"
+  * inspection narration  tests that were never run — "not shake-tested",
+                          "odor not verified", "no ruler frame was shot"
+
+The fix is always the same: **state the finding, never the method.**
+"no chips visible" -> "No chips noted." "Knife handle seated tight in photos;
+not shake-tested" -> "Knife handle sits tight."
+
+----- Why this file exists -----
+
+The rule lived only in prose, so enforcement was whatever regex somebody typed
+that day. On the 2026-08 sweep that regex matched `shown in` and `as shown` but
+not bare `shown`, and silently missed 12 LIVE listings — "in the frames shown",
+"on the shown surfaces", "any soiling not shown", "between shown spreads". They
+were found days later by a second, wider pass. See GH #40.
+
+Two things make a linter like this useful rather than ignorable:
+
+1. **Field scoping.** Only title / condition_description / item_specifics /
+   body are buyer-visible. `meta.notes` legitimately records every can't-assess
+   observation, and the internal record is REQUIRED to keep doing so. Scanning
+   whole files makes ~90% of hits internal noise. We parse the draft and read
+   the named fields, so internal state is structurally out of reach.
+
+2. **Exemptions.** A checker that cries wolf gets muted. These are correct and
+   must never be flagged: the standing "Please see the photos" close line; PII
+   redaction disclosures ("name and street masked in the photos"), which
+   another house rule REQUIRES; sealed-item limits phrased physically ("cannot
+   be assessed through the sealed bag"); grade-setting "Untested; sold as-is";
+   the item's own printed content ("every player pictured and named", picture
+   *frames* on art listings); and ordinary in-hand uses of the same words
+   ("shows wear", "visible under magnification", "staples visible in gutter").
+
+CLI:
+    python lib/voice_check.py <draft.md|shoot-dir>     # check one
+    python lib/voice_check.py --audit inventory/       # sweep a tree
+    python lib/voice_check.py --audit inventory/ --warnings   # include nits
+
+Exit code is 1 if any BLOCKing finding was made, else 0.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from draft_io import Draft, parse_draft  # noqa: E402
+
+BLOCK = "block"
+WARN = "warn"
+
+# Everything after this marker in a body is an internal working note.
+_END_BUYER = re.compile(r"END BUYER DESCRIPTION", re.I)
+
+# --- The banned set -----------------------------------------------------
+# (pattern, severity, human fix). Ordered roughly by how often each fired
+# across the 131-draft sweep. `shown` MUST be matched bare — that gap is the
+# whole reason this file exists.
+_RULES: list[tuple[re.Pattern, str, str]] = [
+    (re.compile(r"visible\s+in\s+(the\s+)?(photo|frame|picture|listing|any\s+photo)\w*", re.I),
+     BLOCK, 'camera framing — drop it: "no chips visible in the photos" -> "No chips noted."'),
+    (re.compile(r"\bnot\s+(shown|pictured|photographed)\b", re.I),
+     BLOCK, "photo-coverage confession — delete it, or state the physical limit "
+            '("the foot rim sits beneath the label")'),
+    (re.compile(r"\b(shown|pictured|photographed)\s+"
+                r"(in|on|fully|honestly|close|exactly|as|through|base-on|un-)", re.I),
+     BLOCK, 'camera framing — delete the clause; the finding itself stays'),
+    # Both word orders. "surfaces shown" AND "the shown surfaces" — missing the
+    # adjectival form is exactly the bug this linter exists to prevent, and the
+    # first draft of this file had it. Caught by tests/test_voice_check.py.
+    (re.compile(r"\b(pages?|frames?|spreads?|surfaces?|areas?|views?|faces?|sections?|"
+                r"lot|car|pieces?)\s+(shown|photographed|pictured)\b", re.I),
+     BLOCK, 'drop the camera scope: "no tears noted on the surfaces shown" -> "no tears noted"'),
+    (re.compile(r"\b(shown|photographed|pictured)\s+"
+                r"(pages?|frames?|spreads?|surfaces?|areas?|views?|faces?|sections?|pieces?)\b", re.I),
+     BLOCK, 'drop the camera scope: "no tears noted on the shown surfaces" -> "no tears noted"'),
+    # `frames` PLURAL only. "seated in the frame" (a tie bar) and "no glass in
+    # the frame" (a painting) are physical objects, and flagging them is how a
+    # linter loses its audience.
+    (re.compile(r"\bin\s+the\s+(frames|photos?|photographs?|pictures?)\b", re.I),
+     BLOCK, "camera framing — delete"),
+    (re.compile(r"\bas[-\s](shown|pictured|photographed)\b", re.I),
+     BLOCK, 'delete, or "Sold as-is." where it genuinely sets the grade'),
+    (re.compile(r"\bunshown\b|\bunphotographed\b", re.I),
+     BLOCK, 'replace with an in-hand limit: "Not collated page by page."'),
+    # NB: `photo(graph)?s?` — an earlier `photograph?s?` silently failed to
+    # match the commonest form of all, "from photos".
+    (re.compile(r"\b(from|off)\s+(the\s+)?photo(graph)?s?\b", re.I),
+     BLOCK, 'photo-limit confession — state the estimate plainly ("approximately 3/8 inch")'),
+    # Trailing form: "the top face is photographed", "all five undersides are
+    # photographed". "photographed" is unambiguously about the camera, so it
+    # blocks; "is shown" can legitimately describe what an item DEPICTS
+    # ("Elina is shown with butterfly wings"), so it only warns.
+    (re.compile(r"\b(is|are|was|were)\s+photographed\b", re.I),
+     BLOCK, "camera narration — delete; the finding stands on its own"),
+    (re.compile(r"\b(is|are|was|were)\s+(shown|pictured)\b(?!\s+(with|wearing|in\s+a))", re.I),
+     WARN, "if this describes the listing photos, delete it; if it describes what "
+           "the item depicts, it is fine"),
+    (re.compile(r"\bnot\s+(verifiable|identifiable|assessable)\b", re.I),
+     BLOCK, 'use "Not identified:" / "not individually verified" instead'),
+    (re.compile(r"assessable\s+from\b", re.I),
+     BLOCK, "photo-limit confession — delete or rephrase as a physical limit"),
+    (re.compile(r"\bany\s+(photo|frame)\b", re.I),
+     BLOCK, 'camera framing — "no hairlines visible in any photo" -> "no hairlines noted"'),
+    (re.compile(r"no\s+scale\s+(photograph|reference)|ruler\s+frame\s+was\s+shot", re.I),
+     BLOCK, "camera narration — just give the approximate measurement"),
+    (re.compile(r"at\s+full\s+resolution", re.I),
+     BLOCK, 'narrates inspecting the photo — "the underside was examined."'),
+    (re.compile(r"\bshake.?test\w*", re.I),
+     BLOCK, 'test-not-run narration — "Knife handle sits tight."'),
+    (re.compile(r"\bodou?rs?\b", re.I),
+     BLOCK, "odor was never testable from photos — delete the clause entirely "
+            "(it belongs in meta.notes / NEEDS_REVIEW)"),
+    # Only the NOT-done form. "I checked both backs under raking light" is an
+    # inspection that actually happened, described in-hand — exactly the voice
+    # the rule wants, and an earlier bare `raking.light` match flagged it.
+    (re.compile(r"\b(not|no|never)\b[^.]{0,25}"
+                r"\b(raking[-\s]?light|ring[-\s]?test\w*|ring/?tap|ring/?backlight|backlight\s+test)\b", re.I),
+     BLOCK, "test-not-run narration — delete; keep only the hedge it supports"),
+    (re.compile(r"\b(raking[-\s]?light|ring[-\s]?tap|ring[-\s]?test\w*)\b[^.]{0,40}"
+                r"\b(recommended|not\s+(performed|run|done|possible))\b", re.I),
+     BLOCK, "test-not-run narration — delete the recommendation, state the finding"),
+    # --- softer normalizations: true statements, wrong idiom ---
+    (re.compile(r"\bno\s+[a-z][a-z ,/–-]{2,40}?\s+visible\b", re.I),
+     WARN, 'prefer "noted" over "visible": "no monogram visible" -> "no monogram noted"'),
+    (re.compile(r"\(no\s+caliper\)|not\s+measured\s+with\s+calipers", re.I),
+     WARN, 'drop the tool narration — "approximately" already carries the estimate'),
+]
+
+# --- The exemption set --------------------------------------------------
+# Checked against a window around each match. Every one of these is live in
+# production copy and is CORRECT; flagging them is how a linter gets ignored.
+_EXEMPT = re.compile(r"""
+      please\s+(see|review|read|use|study|confirm|ask)      # standing close line
+    | you\s+can\s+see[^.]{0,40}(photo|picture)              # same family: a pointer
+    | (see|shown\s+in)\s+(photo|picture)\s*\d               # bare pointer "(photo 4)"
+    | (blocked\s+out|covered|redacted|masked|obscured|left\s+visible)
+      [^.]{0,70}(privacy|photos)                            # PII disclosure (required)
+    | privacy[^.]{0,50}(photos|listing)
+    # Sealed-item limits are PHYSICAL, and survive. But the exemption must be
+    # about an assessment, not merely near the word "sealed" — a blanket
+    # \bsealed\b let "Photographed through the packaging" pass because the
+    # preceding sentence happened to say "sealed poly bag".
+    | (cannot|can\s?not|can't|could\s+not|not)\s+(be\s+)?
+      (assessed|assessable|verified|inspected|judged|determined|ruled\s+out)
+      [^.]{0,60}(sealed|through\s+the\s+(bag|plastic|packaging|sleeve|wrap))
+    | (assessed|assessable|judged|seen|verified)\s+(while\s+sealed|through\s+the\s+
+      (bag|plastic|packaging|sleeve|wrap))
+    | while\s+(the\s+\w+\s+)?(is\s+)?sealed
+    | not\s+(opened|unwrapped|removed\s+from)
+    | untested;\s*sold\s+as-is                              # grade-setting
+    | pictured\s+and\s+named | merchandise\s+pictured | styles\s+pictured
+    | photography\s+by | photographic\s+(cover|plate) | \(photographs?\)
+    | camera'?s\s+own | own\s+EXIF                          # the item IS a camera
+    | under\s+magnification | in\s+gutter | when\s+worn     # in-hand observations
+    | at\s+raking\s+angles
+""", re.I | re.X)
+
+_WINDOW = 80
+
+
+@dataclass
+class Finding:
+    field: str
+    severity: str
+    phrase: str
+    fix: str
+    context: str
+
+    def __str__(self) -> str:
+        tag = "BLOCK" if self.severity == BLOCK else "warn "
+        return f"[{tag}] {self.field}: {self.phrase!r} — {self.fix}\n          …{self.context}…"
+
+
+def _buyer_visible(draft: Draft) -> list[tuple[str, str]]:
+    """The four buyer-visible surfaces, and nothing else.
+
+    Reading named fields (rather than scanning lines) is what keeps
+    `meta.notes` — which is SUPPOSED to record every can't-assess — out of
+    scope structurally instead of by regex luck.
+    """
+    out: list[tuple[str, str]] = []
+    title = draft.get("title")
+    if title:
+        out.append(("title", str(title)))
+    cond = draft.get("condition_description")
+    if cond:
+        out.append(("condition_description", str(cond)))
+
+    specifics = draft.frontmatter.get("item_specifics")
+    if isinstance(specifics, dict):
+        def walk(node, prefix):
+            for k, v in node.items():
+                if isinstance(v, dict):
+                    walk(v, f"{prefix}.{k}")
+                elif v:
+                    out.append((f"{prefix}.{k}", str(v)))
+        walk(specifics, "item_specifics")
+
+    body = draft.body or ""
+    cut = _END_BUYER.search(body)
+    if cut:
+        body = body[:cut.start()]
+    if body.strip():
+        out.append(("body", body))
+    return out
+
+
+def scan_text(field: str, text: str) -> list[Finding]:
+    found: list[Finding] = []
+    for pat, sev, fix in _RULES:
+        for m in pat.finditer(text):
+            a = max(0, m.start() - _WINDOW)
+            b = min(len(text), m.end() + _WINDOW)
+            window = text[a:b].replace("\n", " ")
+            if _EXEMPT.search(window):
+                continue
+            found.append(Finding(field=field, severity=sev, phrase=m.group(0),
+                                 fix=fix, context=" ".join(window.split())))
+    return found
+
+
+def check_voice_detailed(draft: Draft) -> list[Finding]:
+    """Every finding, blocking and soft, across all buyer-visible fields."""
+    out: list[Finding] = []
+    for field, text in _buyer_visible(draft):
+        out.extend(scan_text(field, text))
+    # de-dupe: condition_description is usually mirrored into the body
+    seen, uniq = set(), []
+    for f in out:
+        key = (f.field, f.phrase.lower(), f.context[:60])
+        if key in seen:
+            continue
+        seen.add(key)
+        uniq.append(f)
+    return uniq
+
+
+def check_voice(draft: Draft) -> list[str]:
+    """Blocking issues only, as strings — the shape validate_draft_for_sync wants."""
+    return [str(f) for f in check_voice_detailed(draft) if f.severity == BLOCK]
+
+
+def _iter_drafts(target: Path):
+    if target.is_dir():
+        yield from sorted(target.rglob("draft.md"))
+    else:
+        yield target
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Lint buyer-visible copy for camera-frame language.")
+    ap.add_argument("target", nargs="?", help="a draft.md, or a shoot dir")
+    ap.add_argument("--audit", metavar="DIR", help="walk a tree and report every draft")
+    ap.add_argument("--warnings", action="store_true", help="include soft normalizations")
+    args = ap.parse_args(argv)
+
+    root = Path(args.audit) if args.audit else (Path(args.target) if args.target else None)
+    if root is None:
+        ap.error("give a draft.md / dir, or --audit DIR")
+    if root.is_dir() and (root / "draft.md").exists() and not args.audit:
+        root = root / "draft.md"
+
+    files = dirty = blocking = 0
+    for path in _iter_drafts(root):
+        if ".prior-run-bak" in str(path):
+            continue
+        files += 1
+        try:
+            draft = parse_draft(path)
+        except Exception as e:
+            print(f"\n{path}: parse error — {e}")
+            continue
+        findings = check_voice_detailed(draft)
+        if not args.warnings:
+            findings = [f for f in findings if f.severity == BLOCK]
+        if findings:
+            dirty += 1
+            blocking += sum(1 for f in findings if f.severity == BLOCK)
+            print(f"\n{path}")
+            for f in findings:
+                print(f"  {f}")
+
+    print(f"\n{files} draft(s) checked, {dirty} with findings, {blocking} blocking.")
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_voice_check.py
+++ b/tests/test_voice_check.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""The in-hand voice linter (GH #40).
+
+Written after the 2026-08 sweep, where the rule was enforced by whatever regex
+somebody typed that day. That regex matched `shown in` and `as shown` but not
+bare `shown`, so it silently missed 12 LIVE listings. Every BLOCK case below is
+a real phrase that shipped to a real buyer, and every EXEMPT case is real copy
+that a naive checker would wrongly flag — the exemptions matter as much as the
+catches, because a linter that cries wolf gets muted.
+
+Run:  python tests/test_voice_check.py
+  or: pytest tests/test_voice_check.py
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "lib"))
+
+import voice_check as V                                      # noqa: E402
+from draft_io import Draft                                   # noqa: E402
+
+
+def _draft(cond: str = "", body: str = "", title: str = "A vintage thing",
+           specifics: dict | None = None) -> Draft:
+    fm = {"title": title, "condition_description": cond,
+          "meta": {"notes": "internal: odor not verified; undersides not photographed"}}
+    if specifics:
+        fm["item_specifics"] = specifics
+    return Draft(path=Path("draft.md"), frontmatter=fm, body=body)
+
+
+def _blocks(draft) -> list[str]:
+    return V.check_voice(draft)
+
+
+# --- the phrases that shipped, and must now be caught --------------------
+
+def test_blocks_real_phrases_that_reached_live_listings():
+    cases = [
+        "Knife handle seated tight in photos; not shake-tested.",
+        "No wear-through or brassing noted on the surfaces shown.",
+        "Boards square; no tears noted on the shown surfaces.",
+        "Bindings intact in frames shown; order form present.",
+        "Binding tight; no detached or missing pages in the frames shown.",
+        "Not assessed: backs of interior panels; any soiling/foxing not shown.",
+        "Exact page count and spine staples not assessable from photos.",
+        "Cannot assess from photos: stone material beyond rhinestone.",
+        "with no chips, cracks, flaking, or hairlines visible in any photo.",
+        "Interior odor and lid seal untested.",
+        "Photographed through the packaging.",
+        "Sold uncleaned, as photographed.",
+        "Original box worn. Sold as pictured.",
+        "Undersides not photographed on every piece.",
+        "height approximately 3 in, estimated - no vertical ruler frame was shot.",
+        "the underside was examined at full resolution.",
+        "Country of origin and UPC are not shown in the photographed surfaces.",
+        "Surface not raking-light inspected - tiny fleabites cannot be ruled out.",
+        "Measured off the photos rather than with a caliper.",
+    ]
+    for phrase in cases:
+        assert _blocks(_draft(cond=phrase)), f"MISSED: {phrase!r}"
+
+
+def test_bare_shown_is_caught():
+    """The exact gap that let 12 live listings through."""
+    assert _blocks(_draft(cond="no tears noted on the shown surfaces"))
+    assert _blocks(_draft(cond="pages shown are clean and bright"))
+    assert _blocks(_draft(body="- Only the top face is photographed."))
+
+
+# --- the exemptions: correct copy that must NOT be flagged --------------
+
+def test_standing_close_line_is_exempt():
+    assert not _blocks(_draft(
+        body="Please see the photos and read the description for full details."))
+    assert not _blocks(_draft(body="Please review all photos."))
+
+
+def test_pii_redaction_disclosure_is_exempt():
+    """Required by the PII house rule — live on gilhes, lot2, the-eagle."""
+    for phrase in [
+        "the recipient name and address are redacted in the photos.",
+        "addressee blocked out for privacy in the photos.",
+        "subscriber name and street masked in the photos for privacy.",
+        "the return address and store names are left visible.",
+    ]:
+        assert not _blocks(_draft(cond=phrase)), f"WRONGLY FLAGGED: {phrase!r}"
+
+
+def test_sealed_item_limits_are_exempt():
+    """A physical limit is not a camera limit."""
+    for phrase in [
+        "Odour cannot be assessed while the bag is sealed.",
+        "Backs of pieces not assessable while sealed; pattern read from the fronts.",
+        "Toning judged through the plastic; the piece was not unwrapped.",
+    ]:
+        assert not _blocks(_draft(cond=phrase)), f"WRONGLY FLAGGED: {phrase!r}"
+
+
+def test_item_own_content_is_exempt():
+    """'pictured' about the item's own pages/artwork is a description, not a hedge."""
+    for phrase in [
+        "a full player photo section in which every athlete is pictured and named",
+        "Named styles pictured include the clayton wing-tip and the cooper slip-on.",
+        "Catalog only - no merchandise pictured inside is included.",
+        "Full-bleed editorial fashion photography by Fabrizio Ferri.",
+    ]:
+        assert not _blocks(_draft(body=phrase)), f"WRONGLY FLAGGED: {phrase!r}"
+
+
+def test_in_hand_uses_of_the_same_words_are_exempt():
+    for phrase in [
+        "the gold bands show wear and rubbing from age and handling",
+        "Full mirror polish on the show face, no scratch field.",
+        "Saddle-stitched (staples visible in gutter); binding sound.",
+        "light haze in the foil backing, visible under magnification only",
+        "plating haze on the BACK of the ID plate only (not visible when worn)",
+    ]:
+        assert not _blocks(_draft(cond=phrase)), f"WRONGLY FLAGGED: {phrase!r}"
+
+
+def test_grade_setting_untested_is_exempt():
+    assert not _blocks(_draft(cond="UNTESTED; sold as-is as a vintage component."))
+
+
+def test_clean_rewrites_pass():
+    """The AFTER side of every fix the sweep applied must lint clean."""
+    for phrase in [
+        "Knife handle sits tight.",
+        "No chips, cracks, flaking, or hairlines noted.",
+        "The foot rim sits beneath the original label.",
+        "Not collated page by page; completeness not individually verified.",
+        "Spreader: 6 7/8 inches",
+        "Piece count not individually verified against the standard set.",
+        "Sold sealed in the original packaging; assessed through the bag.",
+    ]:
+        assert not _blocks(_draft(cond=phrase)), f"FALSE POSITIVE: {phrase!r}"
+
+
+# --- scoping ------------------------------------------------------------
+
+def test_internal_meta_is_never_scanned():
+    """meta.notes MUST keep recording can't-assess observations."""
+    d = _draft(cond="No chips or cracks noted.")
+    d.frontmatter["meta"]["notes"] = ("odor not verified; undersides not photographed; "
+                                      "not assessable from photos; sold as pictured")
+    assert not _blocks(d)
+
+
+def test_body_after_end_marker_is_internal():
+    body = ("A clean vintage piece.\n\n"
+            "<!-- END BUYER DESCRIPTION -->\n"
+            "internal: undersides not photographed, odor not verified")
+    assert not _blocks(_draft(body=body))
+
+
+def test_item_specifics_are_scanned():
+    d = _draft(specifics={"pattern": "as shown", "brand": "Rogers"})
+    assert _blocks(d)
+
+
+def test_title_is_scanned():
+    assert _blocks(_draft(title="Vintage Brooch Sold As Pictured Estate Find"))
+
+
+def test_warnings_do_not_block():
+    """'no monogram visible' is true but off-idiom: warn, never block."""
+    d = _draft(cond="No use-wear, no plate wear-through, and no monogram visible.")
+    assert not _blocks(d)
+    detailed = V.check_voice_detailed(d)
+    assert any(f.severity == V.WARN for f in detailed)
+
+
+def test_findings_carry_a_fix_hint():
+    f = V.check_voice_detailed(_draft(cond="no chips visible in the photos"))[0]
+    assert f.severity == V.BLOCK and f.fix and f.field == "condition_description"
+
+
+if __name__ == "__main__":
+    fails = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS  {name}")
+            except AssertionError as e:
+                fails += 1
+                print(f"FAIL  {name}: {e}")
+    print(f"\n{'FAILED' if fails else 'OK'} — {fails} failure(s)")
+    raise SystemExit(1 if fails else 0)


### PR DESCRIPTION
Implements #40.

## What this fixes

**1. The in-hand-voice rule had no enforcement.** It lived in `prompts/draft.md` as prose, so whatever regex somebody typed that day *was* the rule. On the 2026-08 sweep that regex matched `shown in` and `as shown` but not bare `shown`, and silently missed **12 live listings** — "in the frames shown", "on the shown surfaces", "any soiling not shown", "between shown spreads". They were found days later by a second pass.

`lib/voice_check.py` turns the rule into a check, called from `validate_draft_for_sync()` so it runs offline on `--validate`/`--sync`/`--review` and blocks before publish.

**2. A draft's `meta.ebay_*` can lie about whether it is live.** `FR/christmas-elk/draft.md` carried `ebay_offer_id: null` while being live as 206494264413, and got skipped as an unpublished draft. `offer_sellable_state()` already asked eBay the right question, but was reachable only from inside `update_listing_fields()` — so the only way to learn a draft's real state was to attempt a write. `resolve_draft_state()` exposes it read-only.

## New surface

```bash
python lib/voice_check.py --audit inventory/            # sweep a tree
python lib/voice_check.py --audit inventory/ --warnings # include soft nits
python lib/list_edit.py --status inventory/             # what state are these REALLY in
python lib/list_edit.py --repair-meta inventory/ --confirm   # backfill stale ids
```

## Design notes worth reviewing

**Field scoping over line scanning.** The checker reads the four named buyer-visible fields through `parse_draft`, so `meta.notes` is structurally out of reach. That matters: the internal record is *required* to keep logging every can't-assess observation, and a whole-file scan makes ~90% of hits internal noise.

**The exemption set is the load-bearing part.** A linter that cries wolf gets muted, so these are tested as first-class cases: PII redaction disclosures (required by another house rule), physical sealed-item limits, the standing close line, grade-setting `Untested; sold as-is`, the item's own printed content, and in-hand uses of the same words.

**Severity split.** Camera-frame confessions block. Soft normalizations ("no monogram visible" → "noted") warn only. `is photographed` blocks, but `is shown` only warns, because an item can legitimately *depict* something.

## What testing found

Writing the tests exposed the mirror image of the original bug **in the linter itself** — it matched "surfaces shown" but not "the shown surfaces", `photograph?s?` never matched "photos", and a blanket `\bsealed\b` exemption swallowed "Photographed through the packaging" whenever a nearby sentence mentioned a sealed bag.

Auditing real inventory then caught three false positives that were more valuable than the catches: "seated in the frame" (a tie bar), "no glass in the frame" (a painting), and "I checked both backs under raking light" — an inspection that *did* happen, described exactly as the rule wants.

## Verification

- 248 tests pass (`python -m pytest tests/`), 15 new
- `--audit inventory/` reports every live listing clean after the sweep, with one exception it found that the manual sweep never looked at: `gear-catalogs-mailers` ("some pieces shown stacked/fanned") — since fixed and pushed live
- 57 non-live drafts still flag; that backlog is deliberately untouched here

## Heads-up for reviewers

This **blocks `--sync`** on a draft with camera-frame copy. That is the intent, but it means several of the 57 dirty unpublished drafts will refuse to sync until their copy is fixed. `--allow-not-sellable` does not bypass it; fix the copy or use the printed suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)