### PR TITLE
feat(observer): session transcripts -> friction report (#36, V4 Phase 5 stage 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ desktop.ini
 
 # local working backups (ledger/sales/config) — never committed
 backups/
+session_friction.json

--- a/RUN.md
+++ b/RUN.md
@@ -168,7 +168,8 @@ Every account/ops tool runs through the `ebz` dispatcher (V4_PLAN Phase 3):
 live state, `--apply` to heal), `pick-list` (orders awaiting shipment),
 `policy-sweep`, `price-audit` (asks above their own comp evidence),
 `sales-report`, `promote`, `voice` (in-hand linter, `--audit` for a tree),
-`listing` (the LIST/EDIT CLI), `prep`. Argv passes through untouched, so
+`listing` (the LIST/EDIT CLI), `prep`, `observe` (session transcripts ->
+friction report; read-only, `--report` to print it). Argv passes through untouched, so
 every flag documented for a tool works identically under `ebz`. The direct
 `python tools/<x>.py` / `python lib/<x>.py` invocations keep working.
 

--- a/docs/V4_PLAN.md
+++ b/docs/V4_PLAN.md
@@ -82,10 +82,16 @@ tests so "read only when flagged" can be trusted.
 
 ## Phase 5 — the observer (#36)
 
-- [ ] `tools/session_observer.py`: parse session transcripts (timestamps +
-      token usage are already in the JSONL), compute per-stage wall time,
-      token attribution, interaction hot spots, repeats.
+- [x] `tools/session_observer.py` (+ `ebz observe`, `tests/test_session_observer.py`):
+      streams the session JSONLs into per-stage wall time, token attribution,
+      hot spots and six friction signals — `tool_error`, `denied`, `interrupt`,
+      `redo`, `repeat`, `long_loop`. Terse summary to stdout per the Phase 2
+      convention, detail to `session_friction.json`, full report on `--report`.
+      Read-only: it never writes to the tracker and never touches a listing.
 - [ ] Friction report → auto-filed `Idea:` issue, deduped against open ones.
+      Held deliberately: a counter is evidence, a filed issue is a claim. The
+      signals are heuristics over text (see the module's honesty notes) and
+      want a few weeks of eyeballing before anything writes to the tracker.
 
 ## Ground rules
 

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -46,6 +46,8 @@ COMMANDS = {
                      "in-hand voice linter (draft or --audit tree) — GH #40"),
     "listing":      ("lib.list_edit",
                      "LIST/EDIT: --validate --status --review --sync --publish ..."),
+    "observe":      ("tools.session_observer",
+                     "session transcripts -> friction report (#36, read-only)"),
     "prep":         ("lib.photo_prep.prep",
                      "PREP photo pipeline: --auto --check --apply --approve ..."),
 }

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -1,0 +1,176 @@
+"""The session observer: parsing, the six friction signals, stage attribution.
+
+Builds a synthetic transcript in a temp dir — no dependency on the real
+~/.claude sessions, so the suite is deterministic and runs anywhere.
+
+No pytest fixtures — runs under tests/run_all.py too.
+"""
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from tools.session_observer import (  # noqa: E402
+    _classify, _clean_prompt, _tool_signature, parse_session, report,
+    transcripts_dir,
+)
+
+T0 = "2026-08-27T10:00:0{}.000Z"
+
+
+def _user(text, sec=0):
+    return {"type": "user", "timestamp": T0.format(sec),
+            "message": {"role": "user", "content": text}}
+
+
+def _assistant(sec=0, tools=(), out=100):
+    content = [{"type": "tool_use", "id": f"t{i}", "name": n, "input": inp}
+               for i, (n, inp) in enumerate(tools)]
+    return {"type": "assistant", "timestamp": T0.format(sec),
+            "message": {"role": "assistant", "model": "claude-opus-5",
+                        "content": content,
+                        "usage": {"input_tokens": 1, "output_tokens": out,
+                                  "cache_read_input_tokens": 10,
+                                  "cache_creation_input_tokens": 5}}}
+
+
+def _result(tool_use_id, body, is_error=False):
+    block = {"type": "tool_result", "tool_use_id": tool_use_id, "content": body}
+    if is_error:
+        block["is_error"] = True
+    return {"type": "user", "timestamp": T0.format(1),
+            "message": {"role": "user", "content": [block]}}
+
+
+def _write(records) -> Path:
+    d = Path(tempfile.mkdtemp())
+    p = d / "0000abcd-0000-0000-0000-000000000000.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    return p
+
+
+def test_transcripts_dir_slugifies_the_repo_path():
+    d = transcripts_dir(Path("C:/x/y"))
+    assert d.name == "C--x-y"
+    assert d.parent.name == "projects"
+
+
+def test_clean_prompt_drops_image_placeholders():
+    txt = "[Image: original 4000x3000, displayed at 2000x1500.]\nprice this lot"
+    assert _clean_prompt(txt) == "price this lot"
+    assert _clean_prompt("[Image: original 10x10]") == "[image only]"
+
+
+def test_tool_signature_prefers_the_command_and_is_whitespace_stable():
+    a = _tool_signature("Bash", {"command": "git   status"})
+    b = _tool_signature("Bash", {"command": "git status"})
+    assert a == b == "Bash:git status"
+    assert _tool_signature("Read", {"file_path": "/x/draft.md"}) == "Read:/x/draft.md"
+    assert _tool_signature("Weird", {}) == "Weird"
+
+
+def test_classify_picks_the_stage_and_falls_back_to_other():
+    assert _classify("run the comps and price it against the ceiling") == "PRICE"
+    assert _classify("crop the photos, prep the shoot") == "PREP"
+    assert _classify("hello there") == "OTHER"
+
+
+def test_counts_asks_turns_tools_and_tokens():
+    p = _write([
+        _user("price this lot against comps", 0),
+        _assistant(1, [("Bash", {"command": "echo hi"})], out=200),
+        _result("t0", "hi"),
+        _assistant(2, [], out=50),
+    ])
+    s = parse_session(p)
+    assert s["asks"] == 1 and s["turns"] == 2 and s["tools"] == 1
+    assert s["tokens"]["output_tokens"] == 250
+    assert s["by_stage"]["PRICE"]["asks"] == 1
+    assert s["hot_spots"][0]["stage"] == "PRICE"
+
+
+def test_tool_error_and_denied_are_separate_signals():
+    p = _write([
+        _user("do a thing", 0),
+        _assistant(1, [("Bash", {"command": "boom"})]),
+        _result("t0", "Exit code 2: boom not found", is_error=True),
+        _assistant(2, [("Bash", {"command": "again"})]),
+        _result("t0", "The user doesn't want to take this action", is_error=True),
+    ])
+    kinds = [f["kind"] for f in parse_session(p)["friction"]]
+    assert kinds.count("tool_error") == 1
+    assert kinds.count("denied") == 1
+
+
+def test_redo_fires_on_a_correction_but_not_on_the_first_prompt():
+    p = _write([
+        _user("no, this first one must not count", 0),
+        _assistant(1),
+        _user("actually, do it the other way", 2),
+        _assistant(3),
+        _user("thanks, that works", 4),
+        _assistant(5),
+    ])
+    f = [x for x in parse_session(p)["friction"] if x["kind"] == "redo"]
+    assert len(f) == 1 and "actually" in f[0]["sample"]
+
+
+def test_repeat_fires_at_three_identical_calls():
+    recs = [_user("look at things", 0)]
+    for _ in range(3):
+        recs += [_assistant(1, [("Bash", {"command": "cat draft.md"})])]
+    s = parse_session(_write(recs))
+    rep = [f for f in s["friction"] if f["kind"] == "repeat"]
+    assert len(rep) == 1 and rep[0]["detail"] == "3x"
+
+
+def test_long_loop_fires_at_the_turn_threshold():
+    from tools.session_observer import LOOP_TURNS
+    recs = [_user("a big ask", 0)] + [_assistant(1) for _ in range(LOOP_TURNS)]
+    s = parse_session(_write(recs))
+    assert any(f["kind"] == "long_loop" for f in s["friction"])
+    assert s["hot_spots"][0]["friction"] == ["long_loop"]
+
+
+def test_interrupt_and_sidechain_and_system_reminder_handling():
+    side = _assistant(1)
+    side["isSidechain"] = True
+    p = _write([
+        _user("start", 0),
+        side,                                   # subagent traffic: not counted
+        _user("<system-reminder>noise</system-reminder>", 1),   # not an ask
+        _user("[Request interrupted by user]", 2),
+        _assistant(3),
+    ])
+    s = parse_session(p)
+    assert s["asks"] == 1
+    assert s["turns"] == 1                      # the sidechain turn is excluded
+    assert any(f["kind"] == "interrupt" for f in s["friction"])
+
+
+def test_bad_lines_and_oversized_lines_never_raise():
+    d = Path(tempfile.mkdtemp())
+    p = d / "s.jsonl"
+    p.write_text("\n".join([
+        "{not json at all",
+        json.dumps(_user("ok", 0)),
+        json.dumps({"type": "user", "message": {"content": "x" * 600_000}}),
+        json.dumps(_assistant(1)),
+    ]), encoding="utf-8")
+    s = parse_session(p)
+    assert s["asks"] == 1 and s["skipped_lines"] == 1
+
+
+def test_report_renders_every_section():
+    p = _write([
+        _user("price this", 0),
+        _assistant(1, [("Bash", {"command": "x"})]),
+        _result("t0", "nope", is_error=True),
+    ])
+    body = report([parse_session(p)])
+    for header in ("SESSIONS", "WHERE THE WORK WENT", "FRICTION", "LONGEST ASKS"):
+        assert header in body
+    assert "tool_error" in body

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -186,3 +186,15 @@ def test_the_observer_does_not_count_its_own_output_as_friction():
     ])
     kinds = [f["kind"] for f in parse_session(p)["friction"]]
     assert kinds.count("interrupt") == 1        # the real one only
+
+
+def test_self_guard_survives_a_long_command_prefix():
+    # The signature truncates at 160 chars; a cd + long temp path can push
+    # "observe" past the cut, which is how two false interrupts got through.
+    prefix = 'cd "C:/Users/x/' + "deep/" * 40 + '" && '
+    p = _write([
+        _user("full history please", 0),
+        _assistant(1, [("Bash", {"command": prefix + "python -m lib.cli observe --all --report"})]),
+        _result("t0", "interrupt 13\n  [Request interrupted by user]"),
+    ])
+    assert not [f for f in parse_session(p)["friction"] if f["kind"] == "interrupt"]

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -223,3 +223,25 @@ def test_self_guard_survives_a_long_command_prefix():
         _result("t0", "interrupt 13\n  [Request interrupted by user]"),
     ])
     assert not [f for f in parse_session(p)["friction"] if f["kind"] == "interrupt"]
+
+
+def test_ts_returns_none_for_a_non_string_timestamp():
+    # Copilot review on PR #47: _ts() called .replace() on whatever sat in the
+    # timestamp field, so a malformed line carrying a number/null/object raised
+    # AttributeError — "never raises on bad lines" has to cover the wrong TYPE
+    # as well as the wrong format.
+    for bad in (12345, None, {"t": 1}, ["2026-08-27T10:00:00Z"], True):
+        assert _ts({"timestamp": bad}) is None
+    assert _ts({}) is None
+    assert _ts({"timestamp": ""}) is None
+    assert _ts({"timestamp": "not a date"}) is None
+
+
+def test_a_transcript_with_non_string_timestamps_still_parses():
+    d = Path(tempfile.mkdtemp())
+    p = d / "s.jsonl"
+    recs = [_user("do the thing", 0), _assistant(1)]
+    recs[0]["timestamp"] = 1756300000            # epoch int, not a string
+    p.write_text("\n".join(json.dumps(r) for r in recs), encoding="utf-8")
+    s = parse_session(p)                          # must not raise
+    assert s["asks"] == 1

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -174,3 +174,15 @@ def test_report_renders_every_section():
     for header in ("SESSIONS", "WHERE THE WORK WENT", "FRICTION", "LONGEST ASKS"):
         assert header in body
     assert "tool_error" in body
+
+
+def test_the_observer_does_not_count_its_own_output_as_friction():
+    p = _write([
+        _user("show me the friction report", 0),
+        _assistant(1, [("Bash", {"command": "python -m lib.cli observe --report"})]),
+        _result("t0", "interrupt 2\n  [Request interrupted by user]\n  tool_error 72"),
+        _assistant(2, [("Bash", {"command": "cat notes.txt"})]),
+        _result("t0", "[Request interrupted by user]"),
+    ])
+    kinds = [f["kind"] for f in parse_session(p)["friction"]]
+    assert kinds.count("interrupt") == 1        # the real one only

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -174,6 +174,16 @@ def test_ts_normalizes_a_naive_timestamp_to_utc():
     assert (aware - naive).total_seconds() == 0.0
 
 
+def test_ts_returns_none_for_a_non_string_timestamp():
+    # Copilot review on PR #47: rec["timestamp"] isn't guaranteed to be a
+    # string in a malformed line — _ts() called .replace() on it directly
+    # and raised AttributeError on a number or null, breaking the "never
+    # raises on bad lines" guarantee.
+    assert _ts({"timestamp": None}) is None
+    assert _ts({"timestamp": 12345}) is None
+    assert _ts({"timestamp": ["2026-08-27T10:00:00Z"]}) is None
+
+
 def test_wall_time_does_not_raise_on_a_mixed_naive_and_aware_transcript():
     d = Path(tempfile.mkdtemp())
     p = d / "s.jsonl"

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -14,7 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from tools.session_observer import (  # noqa: E402
-    _classify, _clean_prompt, _tool_signature, parse_session, report,
+    _classify, _clean_prompt, _ts, _tool_signature, parse_session, report,
     transcripts_dir,
 )
 
@@ -162,6 +162,31 @@ def test_bad_lines_and_oversized_lines_never_raise():
     ]), encoding="utf-8")
     s = parse_session(p)
     assert s["asks"] == 1 and s["skipped_lines"] == 1
+
+
+def test_ts_normalizes_a_naive_timestamp_to_utc():
+    # Copilot review on PR #47: a transcript timestamp missing its offset
+    # parsed as naive, and comparing/subtracting it against an aware one
+    # raises TypeError — same fix as _date() in tools/sales_report.py.
+    aware = _ts({"timestamp": "2026-08-27T10:00:00Z"})
+    naive = _ts({"timestamp": "2026-08-27T10:00:00"})
+    assert aware.tzinfo is not None and naive.tzinfo is not None
+    assert (aware - naive).total_seconds() == 0.0
+
+
+def test_wall_time_does_not_raise_on_a_mixed_naive_and_aware_transcript():
+    d = Path(tempfile.mkdtemp())
+    p = d / "s.jsonl"
+    records = [
+        {"type": "user", "timestamp": "2026-08-27T10:00:00",
+         "message": {"role": "user", "content": "hi"}},
+        {"type": "assistant", "timestamp": "2026-08-27T10:00:05.000Z",
+         "message": {"role": "assistant", "model": "claude-opus-5", "content": [],
+                     "usage": {"input_tokens": 1, "output_tokens": 1}}},
+    ]
+    p.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    s = parse_session(p)   # would previously raise TypeError comparing naive/aware
+    assert s["wall_seconds"] == 5.0
 
 
 def test_report_renders_every_section():

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -96,7 +96,10 @@ def transcripts_dir(repo: Path) -> Path:
 
 def _ts(rec: dict):
     t = rec.get("timestamp")
-    if not t:
+    if not isinstance(t, str) or not t:
+        # A malformed line can carry a number, a null or a nested object here.
+        # Anything but a string is unparseable, and "never raises on bad lines"
+        # has to hold for the wrong TYPE as well as the wrong format.
         return None
     try:
         parsed = datetime.fromisoformat(t.replace("Z", "+00:00"))
@@ -355,8 +358,12 @@ def report(sessions: list[dict], top: int = 8) -> str:
                f"(cache read {_k(tok['cache_read_input_tokens'])})")
     out.append("")
     out.append("WHERE THE WORK WENT")
+    # "elapsed", not "active": the session line above sums gap-capped deltas
+    # between turns, this column sums each ask's start-to-end span (capped at
+    # IDLE_GAP * 12). One ask that sat open over lunch counts here and not
+    # there, so giving both the same label would overstate stage time.
     out.append(f"  {'stage':<9} {'asks':>5} {'turns':>6} {'turns/ask':>10} "
-               f"{'active':>8} {'out tok':>9}")
+               f"{'elapsed':>8} {'out tok':>9}")
     for name, v in sorted(stages.items(), key=lambda kv: -kv[1]["turns"]):
         per = v["turns"] / v["asks"] if v["asks"] else 0
         out.append(f"  {name:<9} {v['asks']:>5} {v['turns']:>6} {per:>10.1f} "

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -172,7 +172,7 @@ def parse_session(path: Path) -> dict:
     asks: list[Ask] = []
     cur = None
     tool_names: dict[str, str] = {}       # tool_use_id -> tool name
-    tool_sigs: dict[str, str] = {}        # tool_use_id -> full call signature
+    self_calls: set = set()               # tool_use_ids of the observer's own runs
     sigs = Counter()
     tokens = Counter()
     stamps = []
@@ -216,7 +216,7 @@ def parse_session(path: Path) -> dict:
                     for b in results:
                         tid = b.get("tool_use_id")
                         name = tool_names.get(tid, "?")
-                        if SELF.search(tool_sigs.get(tid, "")):
+                        if tid in self_calls:
                             continue          # the observer reading itself
                         body = _text_of(b.get("content")) or str(b.get("content") or "")
                         if b.get("is_error"):
@@ -258,7 +258,12 @@ def parse_session(path: Path) -> dict:
                 name = b.get("name") or "?"
                 tool_names[b.get("id")] = name
                 sig = _tool_signature(name, b.get("input") or {})
-                tool_sigs[b.get("id")] = sig
+                # Match the WHOLE input, not the truncated signature: a long cd
+                # prefix pushes "observe" past the signature's 160-char cut.
+                if SELF.search(json.dumps(b.get("input") or {})):
+                    self_calls.add(b.get("id"))
+                else:
+                    self_calls.discard(b.get("id"))   # last write wins, as for names
                 sigs[sig] += 1
                 if cur is not None:
                     cur.tools += 1

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""SESSION OBSERVER — read our own transcripts and find the friction (#36, V4_PLAN Phase 5).
+
+Every session between us is already recorded: Claude Code writes one JSONL per
+session under `~/.claude/projects/<slug>/`, with timestamps, token usage, every
+tool call and every tool result. Nothing reads them. So the same friction keeps
+happening — a tool that errors the same way every batch, a question I ask that
+you have already answered three sessions running, a prompt that takes twenty
+round-trips because the first answer missed.
+
+This is stage 1 of the observer: the parser and the report. It measures where
+the time and the tokens went, and it counts six friction signals:
+
+  tool_error   a tool call came back is_error — the loop paid for a retry
+  denied       a permission prompt was declined — I asked for the wrong thing
+  interrupt    you stopped a turn in flight — I was going the wrong way
+  redo         your next message opens with a correction ("no", "actually")
+  repeat       the same Bash command or file read 3+ times in one session
+  long_loop    one ask that needed LOOP_TURNS+ assistant turns to answer
+
+Stage 2 (auto-filing an `Idea:` issue, deduped against the open ones) is NOT
+here on purpose. A counter is evidence; a filed issue is a claim. The counts
+want a few weeks of eyeballing before anything writes to the tracker.
+
+  session_observer.py [--days 7] [--limit 20] [--all] [--report] [--json out.json]
+
+Three honesty notes. The signals are heuristics over text: "redo" reads the
+first words of your message, so a cheerful "no, that's perfect" counts as a
+correction it isn't. `is_error` counts an expected probe (a grep that finds
+nothing, a --check that reports work to do) the same as a real failure, so the
+tool_error count is an upper bound — read the samples, not the number. And
+active time is wall time with gaps over IDLE_GAP dropped, which is a guess at
+attention, not a timesheet: a five-minute think while the screen sits idle
+looks the same as walking away.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+IDLE_GAP = 300         # s — a longer gap is you away from the desk, not work
+LOOP_TURNS = 25        # assistant turns on one ask before it counts as a long loop
+REPEAT_HITS = 3        # identical command/read this many times = a repeat
+MAX_LINE = 500_000     # chars — longer lines are attachments/base64, skipped
+
+# The first words of a message that mean "that was wrong, do it again".
+REDO = re.compile(
+    r"^\W*(no+\b|nope\b|nah\b|actually\b|wrong\b|that'?s not\b|thats not\b|"
+    r"not (?:what|quite|right)\b|don'?t\b|stop\b|undo\b|revert\b|instead\b|"
+    r"i said\b|again\b|still (?:not|wrong|broken)\b)", re.I)
+DENIED = re.compile(r"user doesn'?t want|rejected|denied permission|"
+                    r"user has denied|not allowed by permission", re.I)
+INTERRUPT = re.compile(r"\[Request interrupted", re.I)
+# A pasted photo arrives as a size placeholder ahead of the actual words; it is
+# not what you asked, and left in it becomes the label on every PRICE hot spot.
+IMAGE_LINE = re.compile(r"^\s*\[Image:[^\]]*\]\s*$", re.M)
+
+# Stage attribution. Each stage owns prompt words and tool-input fragments; the
+# stage with the most hits over one ask wins. Deliberately coarse — this says
+# "that was a PRICE ask", not which rule inside PRICE was slow.
+STAGES = {
+    "PREP":     ("prep", "photo", "crop", "orient", "rotate", "unskew", "hero",
+                 "contact sheet", "photo_prep", "prep_run", "prep_card"),
+    "IDENTIFY": ("identify", "what is this", "maker", "marble", "hallmark",
+                 "identify.txt", "marble_triage", "marble_decide"),
+    "PRICE":    ("price", "comp", "apify", "ceiling", "median", "sold for",
+                 "price_stats", "comps_board", "price.txt"),
+    "DRAFT":    ("draft", "title", "description", "voice", "write the copy",
+                 "draft.md", "voice_check"),
+    "REVIEW":   ("review", "approve", "review_card", "needs_review"),
+    "LIST":     ("publish", "list it", "sync", "relist", "offer", "list_edit",
+                 "--publish", "--list", "--update", "--sync"),
+    "OPS":      ("ledger", "reconcile", "audit", "sales", "pick list", "ship",
+                 "postage", "promote", "sales_report", "live_audit"),
+    "DEV":      ("git ", "gh ", "commit", "branch", "test", "refactor", "bug",
+                 "pytest", "tests/", "lib/", "tools/"),
+}
+
+
+def transcripts_dir(repo: Path) -> Path:
+    """Claude Code slugifies the cwd: every ':', '\\' and '/' becomes '-'."""
+    slug = re.sub(r"[:\\/]", "-", str(repo))
+    return Path.home() / ".claude" / "projects" / slug
+
+
+def _ts(rec: dict):
+    t = rec.get("timestamp")
+    if not t:
+        return None
+    try:
+        return datetime.fromisoformat(t.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _text_of(content) -> str:
+    """Flatten a message content field to searchable text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out = []
+        for b in content:
+            if not isinstance(b, dict):
+                continue
+            if b.get("type") == "text":
+                out.append(b.get("text") or "")
+        return "\n".join(out)
+    return ""
+
+
+def _clean_prompt(text: str) -> str:
+    """Drop image placeholders so an ask is labelled by its words, not its pixels."""
+    stripped = IMAGE_LINE.sub("", text).strip()
+    return stripped or "[image only]"
+
+
+def _tool_signature(name: str, inp: dict) -> str:
+    """A short, comparable identity for a tool call — what a repeat repeats."""
+    if not isinstance(inp, dict):
+        return name
+    for key in ("command", "file_path", "pattern", "path", "url", "query"):
+        v = inp.get(key)
+        if isinstance(v, str) and v.strip():
+            return f"{name}:{' '.join(v.split())[:160]}"
+    return name
+
+
+def _classify(blob: str) -> str:
+    blob = blob.lower()
+    scores = {s: sum(blob.count(w) for w in words) for s, words in STAGES.items()}
+    best = max(scores, key=lambda s: scores[s])
+    return best if scores[best] else "OTHER"
+
+
+class Ask:
+    """One human prompt and everything the loop did to answer it."""
+
+    def __init__(self, prompt: str, started):
+        self.prompt = prompt
+        self.started = started
+        self.ended = started
+        self.turns = 0
+        self.tools = 0
+        self.out_tokens = 0
+        self.blob = [prompt]
+        self.friction = []
+
+    @property
+    def seconds(self) -> float:
+        if not (self.started and self.ended):
+            return 0.0
+        return max(0.0, (self.ended - self.started).total_seconds())
+
+    @property
+    def stage(self) -> str:
+        return _classify("\n".join(self.blob[:400]))
+
+
+def parse_session(path: Path) -> dict:
+    """Stream one transcript into a per-session record. Never raises on bad lines."""
+    asks: list[Ask] = []
+    cur = None
+    tool_names: dict[str, str] = {}       # tool_use_id -> tool name
+    sigs = Counter()
+    tokens = Counter()
+    stamps = []
+    skipped = 0
+    friction = []
+    model = None
+
+    def note(kind, detail, sample=""):
+        item = {"kind": kind, "detail": detail}
+        if sample:
+            item["sample"] = " ".join(sample.split())[:200]
+        friction.append(item)
+        if cur is not None:
+            cur.friction.append(kind)
+
+    with path.open(encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            if len(line) > MAX_LINE:      # attachment / base64 payload
+                skipped += 1
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            kind = rec.get("type")
+            if kind not in ("user", "assistant"):
+                continue
+            if rec.get("isSidechain"):    # subagent traffic, not our conversation
+                continue
+            when = _ts(rec)
+            if when:
+                stamps.append(when)
+            msg = rec.get("message") or {}
+            content = msg.get("content")
+
+            if kind == "user":
+                blocks = content if isinstance(content, list) else []
+                results = [b for b in blocks
+                           if isinstance(b, dict) and b.get("type") == "tool_result"]
+                if results:
+                    for b in results:
+                        name = tool_names.get(b.get("tool_use_id"), "?")
+                        body = _text_of(b.get("content")) or str(b.get("content") or "")
+                        if b.get("is_error"):
+                            if DENIED.search(body):
+                                note("denied", name, body)
+                            else:
+                                note("tool_error", name, body)
+                        elif INTERRUPT.search(body):
+                            note("interrupt", name, body)
+                    if cur is not None and when:
+                        cur.ended = when
+                    continue
+                text = _text_of(content)
+                if not text.strip() or text.lstrip().startswith("<system-reminder>"):
+                    continue
+                if INTERRUPT.search(text):
+                    note("interrupt", "user", text)
+                    continue
+                cur = Ask(_clean_prompt(text), when)
+                asks.append(cur)
+                if REDO.match(text) and len(asks) > 1:
+                    note("redo", "prompt opens with a correction", text)
+                continue
+
+            # assistant
+            model = msg.get("model") or model
+            usage = msg.get("usage") or {}
+            for k in ("input_tokens", "output_tokens",
+                      "cache_creation_input_tokens", "cache_read_input_tokens"):
+                tokens[k] += usage.get(k) or 0
+            if cur is not None:
+                cur.turns += 1
+                cur.out_tokens += usage.get("output_tokens") or 0
+                if when:
+                    cur.ended = when
+            for b in (content if isinstance(content, list) else []):
+                if not isinstance(b, dict) or b.get("type") != "tool_use":
+                    continue
+                name = b.get("name") or "?"
+                tool_names[b.get("id")] = name
+                sig = _tool_signature(name, b.get("input") or {})
+                sigs[sig] += 1
+                if cur is not None:
+                    cur.tools += 1
+                    cur.blob.append(sig)
+
+    for ask in asks:
+        if ask.turns >= LOOP_TURNS:
+            friction.append({"kind": "long_loop",
+                             "detail": f"{ask.turns} turns on one ask",
+                             "sample": " ".join(ask.prompt.split())[:200]})
+            ask.friction.append("long_loop")
+    for sig, n in sigs.items():
+        if n >= REPEAT_HITS and sig.split(":", 1)[0] in ("Bash", "Read", "Grep", "PowerShell"):
+            friction.append({"kind": "repeat", "detail": f"{n}x", "sample": sig})
+
+    stamps.sort()
+    wall = (stamps[-1] - stamps[0]).total_seconds() if len(stamps) > 1 else 0.0
+    active = sum(min((b - a).total_seconds(), IDLE_GAP)
+                 for a, b in zip(stamps, stamps[1:])) if len(stamps) > 1 else 0.0
+    by_stage = defaultdict(lambda: {"asks": 0, "turns": 0, "seconds": 0.0, "out_tokens": 0})
+    for ask in asks:
+        s = by_stage[ask.stage]
+        s["asks"] += 1
+        s["turns"] += ask.turns
+        s["seconds"] += min(ask.seconds, IDLE_GAP * 12)
+        s["out_tokens"] += ask.out_tokens
+
+    return {
+        "session": path.stem,
+        "file": str(path),
+        "started": stamps[0].isoformat() if stamps else None,
+        "model": model,
+        "wall_seconds": round(wall, 1),
+        "active_seconds": round(active, 1),
+        "asks": len(asks),
+        "turns": sum(a.turns for a in asks),
+        "tools": sum(a.tools for a in asks),
+        "tokens": dict(tokens),
+        "skipped_lines": skipped,
+        "by_stage": {k: v for k, v in sorted(by_stage.items())},
+        "friction": friction,
+        "hot_spots": sorted(
+            ({"stage": a.stage, "turns": a.turns, "tools": a.tools,
+              "seconds": round(a.seconds, 1), "out_tokens": a.out_tokens,
+              "friction": sorted(set(a.friction)),
+              "prompt": " ".join(a.prompt.split())[:160]}
+             for a in asks if a.turns),
+            key=lambda h: -h["turns"])[:5],
+    }
+
+
+def _hms(sec: float) -> str:
+    sec = int(sec)
+    return f"{sec // 3600}h{(sec % 3600) // 60:02d}m" if sec >= 3600 else f"{sec // 60}m"
+
+
+def _k(n) -> str:
+    return f"{n / 1000:.0f}k" if n >= 1000 else str(n)
+
+
+def report(sessions: list[dict], top: int = 8) -> str:
+    """The human-readable friction report — what to read before filing anything."""
+    out = []
+    kinds = Counter()
+    samples = defaultdict(list)
+    stages = defaultdict(lambda: {"asks": 0, "turns": 0, "seconds": 0.0, "out_tokens": 0})
+    tok = Counter()
+    for s in sessions:
+        for f in s["friction"]:
+            kinds[f["kind"]] += 1
+            if len(samples[f["kind"]]) < top:
+                samples[f["kind"]].append((s["session"][:8], f))
+        for name, v in s["by_stage"].items():
+            for k in ("asks", "turns", "seconds", "out_tokens"):
+                stages[name][k] += v[k]
+        tok.update(s["tokens"])
+
+    asks = sum(s["asks"] for s in sessions)
+    turns = sum(s["turns"] for s in sessions)
+    active = sum(s["active_seconds"] for s in sessions)
+    out.append(f"SESSIONS {len(sessions)}  asks {asks}  turns {turns}  "
+               f"active {_hms(active)}  out {_k(tok['output_tokens'])} tok "
+               f"(cache read {_k(tok['cache_read_input_tokens'])})")
+    out.append("")
+    out.append("WHERE THE WORK WENT")
+    out.append(f"  {'stage':<9} {'asks':>5} {'turns':>6} {'turns/ask':>10} "
+               f"{'active':>8} {'out tok':>9}")
+    for name, v in sorted(stages.items(), key=lambda kv: -kv[1]["turns"]):
+        per = v["turns"] / v["asks"] if v["asks"] else 0
+        out.append(f"  {name:<9} {v['asks']:>5} {v['turns']:>6} {per:>10.1f} "
+                   f"{_hms(v['seconds']):>8} {_k(v['out_tokens']):>9}")
+    out.append("")
+    out.append("FRICTION")
+    if not kinds:
+        out.append("  none of the six signals fired")
+    for kind, n in kinds.most_common():
+        out.append(f"  {kind:<11} {n}")
+        for sid, f in samples[kind][:3]:
+            out.append(f"      {sid}  {f['detail']}  {f.get('sample', '')[:110]}")
+    out.append("")
+    out.append("LONGEST ASKS")
+    hot = sorted((h for s in sessions for h in s["hot_spots"]),
+                 key=lambda h: -h["turns"])[:top]
+    for h in hot:
+        flag = (" [" + ",".join(h["friction"]) + "]") if h["friction"] else ""
+        out.append(f"  {h['stage']:<9} {h['turns']:>3} turns  {_hms(h['seconds']):>5}  "
+                   f"{_k(h['out_tokens']):>5}  {h['prompt'][:80]}{flag}")
+    return "\n".join(out)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Parse Claude Code session transcripts into a friction report.")
+    ap.add_argument("--dir", help="transcript directory (default: this repo's)")
+    ap.add_argument("--days", type=int, default=7, help="only sessions this recent (default 7)")
+    ap.add_argument("--limit", type=int, default=20, help="most recent N sessions (default 20)")
+    ap.add_argument("--all", action="store_true", help="every session, no window")
+    ap.add_argument("--report", action="store_true", help="print the full report to stdout")
+    ap.add_argument("--json", dest="json_path", default="session_friction.json",
+                    help="detail file (default session_friction.json)")
+    args = ap.parse_args(argv)
+
+    root = Path(args.dir) if args.dir else transcripts_dir(REPO)
+    if not root.is_dir():
+        print(f"no transcripts at {root}")
+        return 2
+    files = sorted(root.glob("*.jsonl"), key=os.path.getmtime, reverse=True)
+    if not args.all:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=args.days)
+        files = [f for f in files
+                 if datetime.fromtimestamp(os.path.getmtime(f), timezone.utc) >= cutoff]
+        files = files[:args.limit]
+    if not files:
+        print(f"no sessions in the last {args.days}d under {root}")
+        return 0
+
+    sessions = [parse_session(f) for f in files]
+    sessions = [s for s in sessions if s["asks"]]
+    flagged = sum(1 for s in sessions if s["friction"])
+    body = report(sessions)
+
+    out = Path(args.json_path)
+    out.write_text(json.dumps(
+        {"generated_at": datetime.now(timezone.utc).isoformat(),
+         "transcripts": str(root),
+         "window": "all" if args.all else f"{args.days}d",
+         "sessions": sessions,
+         "report": body}, indent=2), encoding="utf-8")
+
+    if args.report:
+        print(body)
+        print()
+    signals = sum(len(s["friction"]) for s in sessions)
+    print(f"observer: OK {len(sessions)}/{len(files)} sessions, {flagged} flagged, "
+          f"{signals} signals -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -96,7 +96,7 @@ def transcripts_dir(repo: Path) -> Path:
 
 def _ts(rec: dict):
     t = rec.get("timestamp")
-    if not t:
+    if not isinstance(t, str) or not t:
         return None
     try:
         parsed = datetime.fromisoformat(t.replace("Z", "+00:00"))

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -62,6 +62,9 @@ INTERRUPT = re.compile(r"\[Request interrupted", re.I)
 # A pasted photo arrives as a size placeholder ahead of the actual words; it is
 # not what you asked, and left in it becomes the label on every PRICE hot spot.
 IMAGE_LINE = re.compile(r"^\s*\[Image:[^\]]*\]\s*$", re.M)
+# The observer prints its own samples, so a session where it ran contains the
+# marker text it looks for. Results from its own invocations are not evidence.
+SELF = re.compile(r"session_observer|cli observe|ebz observe", re.I)
 
 # Stage attribution. Each stage owns prompt words and tool-input fragments; the
 # stage with the most hits over one ask wins. Deliberately coarse — this says
@@ -169,6 +172,7 @@ def parse_session(path: Path) -> dict:
     asks: list[Ask] = []
     cur = None
     tool_names: dict[str, str] = {}       # tool_use_id -> tool name
+    tool_sigs: dict[str, str] = {}        # tool_use_id -> full call signature
     sigs = Counter()
     tokens = Counter()
     stamps = []
@@ -210,7 +214,10 @@ def parse_session(path: Path) -> dict:
                            if isinstance(b, dict) and b.get("type") == "tool_result"]
                 if results:
                     for b in results:
-                        name = tool_names.get(b.get("tool_use_id"), "?")
+                        tid = b.get("tool_use_id")
+                        name = tool_names.get(tid, "?")
+                        if SELF.search(tool_sigs.get(tid, "")):
+                            continue          # the observer reading itself
                         body = _text_of(b.get("content")) or str(b.get("content") or "")
                         if b.get("is_error"):
                             if DENIED.search(body):
@@ -251,6 +258,7 @@ def parse_session(path: Path) -> dict:
                 name = b.get("name") or "?"
                 tool_names[b.get("id")] = name
                 sig = _tool_signature(name, b.get("input") or {})
+                tool_sigs[b.get("id")] = sig
                 sigs[sig] += 1
                 if cur is not None:
                     cur.tools += 1

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -99,9 +99,15 @@ def _ts(rec: dict):
     if not t:
         return None
     try:
-        return datetime.fromisoformat(t.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(t.replace("Z", "+00:00"))
     except ValueError:
         return None
+    # A transcript timestamp without an offset would otherwise come back
+    # naive, and mixing naive/aware datetimes raises on any later comparison
+    # or subtraction (wall/active time) — exactly what "never raises on bad
+    # lines" is supposed to prevent. Same normalization as _date() in
+    # tools/sales_report.py: absent offset means UTC.
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
 
 
 def _text_of(content) -> str:


### PR DESCRIPTION
Closes nothing yet — this is **stage 1 of two** on #36 (self-optimizing sessions),
the feedback loop in `docs/V4_PLAN.md` Phase 5.

## The problem

Every session is already recorded — Claude Code writes one JSONL per session with
timestamps, token usage, every tool call and every tool result. Nothing has ever
read them. So the same friction repeats: a tool that errors the same way every
batch, a question already answered three sessions running, an ask that takes
twenty round-trips because the first answer missed.

## What landed

`tools/session_observer.py` (+ `ebz observe`, 13 tests). It streams the session
JSONLs — skipping sidechain/subagent traffic and oversized attachment lines — and
reports per-stage wall time, token attribution, hot spots, and six friction
signals:

| signal | what it means |
|---|---|
| `tool_error` | a tool came back `is_error` — the loop paid for a retry |
| `denied` | a permission prompt was declined — the wrong thing was asked for |
| `interrupt` | a turn was stopped in flight |
| `redo` | the next human message opens with a correction |
| `repeat` | the same Bash command or file read 3+ times in one session |
| `long_loop` | one ask that needed 25+ assistant turns |

Terse summary to stdout per the Phase 2 convention, detail to
`session_friction.json` (gitignored), full report on `--report`. Read-only by
construction: it never writes to the tracker and never touches a listing.

    python -m lib.cli observe --days 7 --report

## First real read (20 sessions, 7 days, 2.4s)

- **PRICE is the cost center** — 61 asks but 2,134 turns (35/ask) and 2.7M output
  tokens, more than DRAFT + PREP + LIST combined. Phase 4's comp cache is aimed
  at exactly this, and now there is a number to beat.
- **72 `tool_error`s**, the top two being Bash heredoc quoting failures — agent
  behaviour, not repo defect.
- **3 `redo`s**, all the same shape: being pointed back at information already
  available in the repo.

## What is deliberately NOT here

Stage 2 — auto-filing an `Idea:` issue, deduped against the open ones. A counter
is evidence; a filed issue is a claim. These signals are text heuristics with
known false positives (documented in the module's honesty notes: `tool_error` is
an upper bound because an expected probe counts the same as a real failure;
`redo` matches opening words, so "no, that's perfect" would count). They want a
few weeks of eyeballing before anything writes to the tracker. The plan checkbox
records that reasoning.

The second commit is one such false positive caught in the demo and fixed: the
observer flagged its own printed samples as an `interrupt`, since a session where
`observe --report` ran contains the marker text the scanner looks for. Results
from its own tool calls are now skipped by call signature.

## Test

`tests/test_session_observer.py` — 13 tests over a synthetic transcript built in
a temp dir, so the suite is deterministic and never depends on real `~/.claude`
sessions. Covers each signal, the sidechain/system-reminder exclusions, malformed
and oversized lines, stage attribution, and the self-observation guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
