### PR TITLE
feat(shipping): route US-export-restricted items to a US-only policy

### DIFF
--- a/lib/config.example.yaml
+++ b/lib/config.example.yaml
@@ -76,6 +76,17 @@ ebay:
                                          # used for ship-risky items (fragile/over-
                                          # sized) marked fulfillment_mode LOCAL_PICKUP.
                                          # Create via `--create-pickup-policy`.
+    fulfillment_policy_id_us_only: null  # optional but REQUIRED to list firearm
+                                         # magazines/parts, body armor or night
+                                         # vision: a policy whose shipToLocations
+                                         # is US only. eBay refuses those publishes
+                                         # (errorId 25019, ITAR Part 121) while a
+                                         # listing is eBay-International-Shipping
+                                         # eligible, and eIS eligibility comes from
+                                         # shipToLocations "Worldwide" on the policy
+                                         # — NOT from globalShipping and NOT from
+                                         # the draft's shipping.international flag.
+                                         # Routing is automatic; see lib/us_only.py.
     payment_policy_id: null
     payment_policy_id_auction: null      # optional: a payment policy with immediate
                                          # payment OFF; required for AUCTION offers
@@ -103,6 +114,17 @@ ebay:
                                          # used for ship-risky items (fragile/over-
                                          # sized) marked fulfillment_mode LOCAL_PICKUP.
                                          # Create via `--create-pickup-policy`.
+    fulfillment_policy_id_us_only: null  # optional but REQUIRED to list firearm
+                                         # magazines/parts, body armor or night
+                                         # vision: a policy whose shipToLocations
+                                         # is US only. eBay refuses those publishes
+                                         # (errorId 25019, ITAR Part 121) while a
+                                         # listing is eBay-International-Shipping
+                                         # eligible, and eIS eligibility comes from
+                                         # shipToLocations "Worldwide" on the policy
+                                         # — NOT from globalShipping and NOT from
+                                         # the draft's shipping.international flag.
+                                         # Routing is automatic; see lib/us_only.py.
     payment_policy_id: null
     payment_policy_id_auction: null      # optional: a payment policy with immediate
                                          # payment OFF; required for AUCTION offers

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -1062,7 +1062,8 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
         msgs.append("shipping: INTERNATIONAL REFUSED — US-export-restricted ("
                     + "; ".join(us_reasons) + "). eBay will not publish this "
                     "listing at all while it is reachable by eBay International "
-                    "Shipping. Routed US-only.")
+                    "Shipping. See the routing message below for the policy "
+                    "actually chosen.")
     if wants_intl and mode == "LOCAL_PICKUP":
         wants_intl = False
         msgs.append("shipping: international requested but item is LOCAL_PICKUP — "

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -777,7 +777,8 @@ def _resolve_policies_and_location(creds: EbayCredentials) -> tuple[dict, str]:
     policies["payment_auction"] = _ebay_extra("payment_policy_id_auction")
     location = _ebay_extra("merchant_location_key")
     for k, v in policies.items():
-        if k in ("fulfillment_media", "fulfillment_local_pickup", "payment_auction"):
+        if k in ("fulfillment_media", "fulfillment_local_pickup", "fulfillment_us_only",
+                  "payment_auction"):
             continue  # optional
         if not v:
             missing.append(f"ebay.{k}_policy_id")
@@ -1055,6 +1056,13 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
         "true", "yes", "1", "on")
     msgs: list[str] = []
 
+    # LOCAL_PICKUP is checked first: a pickup-only item ships nowhere, so that
+    # is the real reason international is moot — regardless of US-export
+    # status — and it must not be masked by the US-only message below.
+    if wants_intl and mode == "LOCAL_PICKUP":
+        wants_intl = False
+        msgs.append("shipping: international requested but item is LOCAL_PICKUP — "
+                    "ignored (a pickup-only item has nothing to ship).")
     # A US export restriction is not a preference — it overrides an
     # international request rather than negotiating with it.
     if us_reasons and wants_intl:
@@ -1064,10 +1072,6 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
                     "listing at all while it is reachable by eBay International "
                     "Shipping. See the routing message below for the policy "
                     "actually chosen.")
-    if wants_intl and mode == "LOCAL_PICKUP":
-        wants_intl = False
-        msgs.append("shipping: international requested but item is LOCAL_PICKUP — "
-                    "ignored (a pickup-only item has nothing to ship).")
     if wants_intl:
         blockers = _international_blockers(draft)
         if blockers:

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -86,6 +86,7 @@ from draft_io import (Draft, parse_draft, resolve_photo_paths, set_photo_order,
                        update_meta)
 from verdict import emit as _verdict_emit
 from voice_check import check_voice
+from us_only import us_only_reasons
 from ebay_client import (
     DEFAULT_MARKETPLACE,
     EbayAPIError,
@@ -766,6 +767,10 @@ def _resolve_policies_and_location(creds: EbayCredentials) -> tuple[dict, str]:
     # `shipping.international: true` use it, and only if they clear the
     # dangerous-goods gate in _international_blockers().
     policies["fulfillment_international"] = _ebay_extra("fulfillment_policy_id_international")
+    # US-ONLY: items US export law keeps in the country (firearm magazines and
+    # parts, body armor, night vision). Needs its own policy because the
+    # default one ships Worldwide — see lib/us_only.py for why that matters.
+    policies["fulfillment_us_only"] = _ebay_extra("fulfillment_policy_id_us_only")
     # Optional: a payment policy WITHOUT immediate-payment, required for AUCTION
     # offers (eBay forbids immediate-pay on auctions — error 25003). Only auction
     # listings need it; falls back to the default payment policy otherwise.
@@ -1010,13 +1015,17 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
     1. If the draft is `fulfillment_mode: LOCAL_PICKUP` (DRAFT sets this for
        ship-risky items the user confirmed as local-pickup), use the
        local-pickup policy.
-    2. Else if `shipping.international: true` AND the item clears the
+    2. Else if the item is US-EXPORT-RESTRICTED (firearm magazines and parts,
+       body armor, night vision, anything marked ITAR — see lib/us_only.py),
+       use the US-only policy. This OUTRANKS an international request: a legal
+       restriction beats reach, and beats the media rate too.
+    3. Else if `shipping.international: true` AND the item clears the
        dangerous-goods / weight gate, use the international (eIS) policy.
-    3. Else if `primary_service` is Media Mail (DRAFT sets this for books /
+    4. Else if `primary_service` is Media Mail (DRAFT sets this for books /
        sheet music / recordings / computer media — NOT magazines, catalogs, or
        anything carrying advertising, which are excluded from Media Mail by
        DMM 173.4.2) AND a media policy is configured, use it.
-    4. Else use the default (USPS Ground) policy.
+    5. Else use the default (USPS Ground) policy.
     Returns (chosen_fulfillment_id, messages).
 
     International is OPT-IN per item, never global. eBay International Shipping
@@ -1028,12 +1037,22 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
     media_fid = str(policies.get("fulfillment_media") or "")
     pickup_fid = str(policies.get("fulfillment_local_pickup") or "")
     intl_fid = str(policies.get("fulfillment_international") or "")
+    usonly_fid = str(policies.get("fulfillment_us_only") or "")
+    us_reasons = us_only_reasons(draft)
     mode = str(draft.get("shipping.fulfillment_mode") or "SHIP").strip().upper()
     want = str(draft.get("shipping.primary_service") or "").strip()
     wants_intl = str(draft.get("shipping.international") or "").strip().lower() in (
         "true", "yes", "1", "on")
     msgs: list[str] = []
 
+    # A US export restriction is not a preference — it overrides an
+    # international request rather than negotiating with it.
+    if us_reasons and wants_intl:
+        wants_intl = False
+        msgs.append("shipping: INTERNATIONAL REFUSED — US-export-restricted ("
+                    + "; ".join(us_reasons) + "). eBay will not publish this "
+                    "listing at all while it is reachable by eBay International "
+                    "Shipping. Routed US-only.")
     if wants_intl and mode == "LOCAL_PICKUP":
         wants_intl = False
         msgs.append("shipping: international requested but item is LOCAL_PICKUP — "
@@ -1061,6 +1080,29 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
             msgs.append("shipping: item is LOCAL_PICKUP but ebay.fulfillment_policy_id_local_pickup "
                         "is unset — falling back to the default ground policy. Add a local-pickup "
                         "policy (see SETUP_EBAY_API.md) so ship-risky items list as pickup-only.")
+    elif us_reasons:
+        if usonly_fid:
+            chosen, label = usonly_fid, "US-ONLY (export-restricted policy)"
+            msgs.append("shipping: US-ONLY — " + "; ".join(us_reasons) +
+                        ". Routed to the US-only policy so the listing is not "
+                        "eBay-International-Shipping eligible; without it eBay "
+                        "refuses the publish outright (errorId 25019, ITAR).")
+        else:
+            # Refusing to fall back is the point. The default policy ships
+            # Worldwide, so falling back would not merely be suboptimal — the
+            # publish would fail, and if eBay ever stopped catching it we would
+            # be exporting a restricted item.
+            chosen, label = default_fid, "default ground (NO US-only policy configured)"
+            msgs.append("shipping: BLOCKER — item is US-export-restricted (" +
+                        "; ".join(us_reasons) + ") but "
+                        "ebay.fulfillment_policy_id_us_only is unset. The default "
+                        "policy ships Worldwide, so eBay will refuse this publish. "
+                        "Create a US-only fulfillment policy (shipToLocations = US) "
+                        "and set that key before listing this item.")
+        if _is_media_service(want):
+            msgs.append("shipping: item wanted Media Mail but is US-export-"
+                        "restricted — the US-only policy carries Ground "
+                        "Advantage. Legal routing wins over the media rate.")
     elif wants_intl:
         chosen, label = intl_fid, "international (eIS-enabled policy)"
         for w in _international_warnings(draft):

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -1008,7 +1008,8 @@ def _international_warnings(draft: Draft) -> list[str]:
 
 
 def _resolve_shipping_policy(draft: Draft, policies: dict,
-                             creds: EbayCredentials) -> tuple[str, list[str]]:
+                             creds: EbayCredentials,
+                             strict: bool = False) -> tuple[str, list[str]]:
     """Choose the fulfillment policy for THIS item and validate it.
 
     Routing, in order:
@@ -1032,6 +1033,15 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
     is an account-level enrollment, so the moment a listing uses a policy whose
     shipToLocations include Worldwide, eIS offers it abroad — including for
     items eIS will refuse at the hub. The gate below is what stops that.
+
+    `strict` distinguishes advisory callers (preflight, which only reports
+    problems for a human to read) from callers that are about to WRITE the
+    resolved policy into an offer (sync, offer-field updates). A US-export
+    restriction with no US-only policy configured is a hard stop for the
+    latter: raises ValueError instead of returning the Worldwide default,
+    because writing that default is exactly the publish-time failure (or,
+    if eBay ever stopped catching it, the export) this function exists to
+    prevent.
     """
     default_fid = str(policies.get("fulfillment") or "")
     media_fid = str(policies.get("fulfillment_media") or "")
@@ -1092,13 +1102,16 @@ def _resolve_shipping_policy(draft: Draft, policies: dict,
             # Worldwide, so falling back would not merely be suboptimal — the
             # publish would fail, and if eBay ever stopped catching it we would
             # be exporting a restricted item.
+            blocker = ("shipping: BLOCKER — item is US-export-restricted (" +
+                       "; ".join(us_reasons) + ") but "
+                       "ebay.fulfillment_policy_id_us_only is unset. The default "
+                       "policy ships Worldwide, so eBay will refuse this publish. "
+                       "Create a US-only fulfillment policy (shipToLocations = US) "
+                       "and set that key before listing this item.")
+            if strict:
+                raise ValueError(blocker)
             chosen, label = default_fid, "default ground (NO US-only policy configured)"
-            msgs.append("shipping: BLOCKER — item is US-export-restricted (" +
-                        "; ".join(us_reasons) + ") but "
-                        "ebay.fulfillment_policy_id_us_only is unset. The default "
-                        "policy ships Worldwide, so eBay will refuse this publish. "
-                        "Create a US-only fulfillment policy (shipToLocations = US) "
-                        "and set that key before listing this item.")
+            msgs.append(blocker)
         if _is_media_service(want):
             msgs.append("shipping: item wanted Media Mail but is US-export-"
                         "restricted — the US-only policy carries Ground "
@@ -1439,7 +1452,7 @@ def create_or_update_listing(draft_path: Path,
             print(f"  [preflight] {reason}")
     # Shipping: pick the right fulfillment policy (Media Mail for media items,
     # else default ground) and use it for this offer.
-    chosen_fulfillment, ship_msgs = _resolve_shipping_policy(draft, policies, creds)
+    chosen_fulfillment, ship_msgs = _resolve_shipping_policy(draft, policies, creds, strict=True)
     policies = {**policies, "fulfillment": chosen_fulfillment}
     for _m in ship_msgs + _insurance_notes(draft):
         print(f"  [preflight] {_m}")
@@ -1746,7 +1759,7 @@ def update_listing_fields(draft_path: Path, fields,
             # dangerous-goods gate runs here too, so an item that must not go
             # abroad silently stays on the domestic policy.
             pol_ids, _loc = _resolve_policies_and_location(creds)
-            fid, pol_msgs = _resolve_shipping_policy(draft, pol_ids, creds)
+            fid, pol_msgs = _resolve_shipping_policy(draft, pol_ids, creds, strict=True)
             lp = offer.setdefault("listingPolicies", {})
             prev = lp.get("fulfillmentPolicyId")
             lp["fulfillmentPolicyId"] = fid

--- a/lib/us_only.py
+++ b/lib/us_only.py
@@ -1,0 +1,148 @@
+"""US-only routing — items eBay requires be sold domestically.
+
+Some items are legal to sell on eBay.com but ONLY to US buyers, by US export
+law rather than by carrier rule. Firearm magazines and parts are the case that
+forced this module: eBay refuses the publish outright with errorId 25019 and
+
+    "The item that you tried to list can only be sold on the U.S. eBay website
+     (eBay.com) by sellers located in the United States. Please edit your
+     listing to offer shipping to the United States only."
+     (PI_USFAW_CBT_v2rep10006258 — firearms/weapons policy + ITAR Part 121)
+
+**The trap this module exists to close.** That refusal is NOT prevented by
+`shipping.international: false`, and it is NOT prevented by a policy with
+`globalShipping: false` and zero international shipping options. Measured
+2026-08-27 on a Ruger Mini-14 magazine: the draft had international false, the
+default policy had globalShipping false and no international options, and the
+publish still failed. The actual trigger is
+`shipToLocations.regionIncluded = "Worldwide"` on the fulfillment policy, which
+is what makes a listing eBay-International-Shipping eligible. eIS is an
+ACCOUNT-level enrollment, so it cannot be switched off per listing from the
+draft — the only lever is a policy whose shipToLocations are US-only.
+
+Hence `ebay.fulfillment_policy_id_us_only`. Routing lives in
+`list_edit.py:_resolve_shipping_policy`; this module only decides WHETHER an
+item needs it.
+
+**Detection follows the house rule from `_DANGEROUS_GOODS_PATTERNS`:** scan the
+TITLE and item specifics, never the body or condition text. Titles name what a
+thing IS; descriptions say what it looks like. That distinction matters more
+here than anywhere else in the codebase, because this inventory genuinely sells
+MAGAZINES — Esquire, Britches catalogs, periodical lots. A bare `\\bmagazine\\b`
+would route half the paper inventory to a firearms policy. Every pattern below
+therefore requires firearm CONTEXT alongside the part word.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# --- the aspect signal (strongest, zero false positives) -------------------
+# eBay's own firearm-accessory categories REQUIRE these aspects; if a draft
+# carries one, eBay has already classified the item as gun-related and the
+# ITAR gate is certain to fire. Matched case-insensitively on the key.
+_GUN_ASPECT_KEYS = (
+    "for gun type",
+    "number of rounds",
+    "caliber/gauge",
+    "caliber",
+    "gauge",
+)
+
+# --- part words: meaningless alone, decisive with firearm context ----------
+_PART_WORDS = (
+    r"magazine|mag\b|clip|barrel|receiver|bolt carrier|bolt|trigger|"
+    r"handguard|hand guard|buttstock|butt stock|stock|upper|lower|"
+    r"charging handle|firing pin|extractor|muzzle|choke|forend|fore-end"
+)
+
+# --- firearm context: any ONE of these next to a part word is enough -------
+_GUN_CONTEXT = (
+    r"rifle|pistol|handgun|shotgun|firearm|carbine|revolver|gun\b|"
+    r"ruger|glock|colt|remington|winchester|mossberg|marlin|savage|"
+    r"beretta|sig sauer|sig\b|springfield|kel-?tec|henry|browning|"
+    r"smith\s*&\s*wesson|s&w\b|ar-?15|ak-?47|m1a|mini-?14|1911|10/22"
+)
+
+# --- calibers: a caliber beside a part word is unambiguous ----------------
+_CALIBER = (
+    r"\.?223\b|5\.56|7\.62|\.308\b|\.30-06|9\s?mm|\.45\s?acp|\.40\s?s&w|"
+    r"\.380\b|\.22\s?lr|\.22\b|12\s?ga(uge)?|20\s?ga(uge)?|\.410\b|"
+    r"\.243\b|\.270\b|\.357\b|\.38\s?spl|\.44\s?mag"
+)
+
+US_ONLY_PATTERNS: tuple[tuple[str, str], ...] = (
+    # An explicit export marker needs no corroboration.
+    (r"\bitar\b|\bexport[- ]restricted\b",
+     "explicitly marked export-restricted (ITAR)"),
+    # A named firearm platform plus a part word.
+    (rf"(?:{_GUN_CONTEXT})[\w\s\-/.,']{{0,40}}?(?:{_PART_WORDS})",
+     "firearm part or magazine (US export-restricted)"),
+    # A part word plus a named firearm platform, the other way round.
+    (rf"(?:{_PART_WORDS})[\w\s\-/.,']{{0,40}}?(?:{_GUN_CONTEXT})",
+     "firearm part or magazine (US export-restricted)"),
+    # A caliber beside a part word — covers unbranded parts.
+    (rf"(?:{_CALIBER})[\w\s\-/.,']{{0,40}}?(?:{_PART_WORDS})",
+     "firearm part in a named caliber (US export-restricted)"),
+    (rf"(?:{_PART_WORDS})[\w\s\-/.,']{{0,40}}?(?:{_CALIBER})",
+     "firearm part in a named caliber (US export-restricted)"),
+    # Whole categories that are US-only regardless of wording.
+    (r"\bgun\s+parts?\b|\bfirearm\s+parts?\b|\brifle\s+parts?\b",
+     "firearm parts (US export-restricted)"),
+    (r"\bbody\s?armou?r\b|\bballistic\s+(vest|plate|panel)\b|\bplate\s+carrier\b",
+     "body armor (US export-restricted)"),
+    (r"\bsuppressor\b|\bsilencer\b", "suppressor (US-only, heavily regulated)"),
+    (r"\bnight\s?vision\b|\bthermal\s+(scope|sight|imager)\b",
+     "night vision / thermal optic (ITAR Cat. XII)"),
+)
+
+_TRUE = ("true", "yes", "1", "on")
+
+
+def _haystack(draft: Any) -> str:
+    """Title + item specifics only — never the body. See module docstring."""
+    parts = [str(draft.get("title") or "")]
+    for key in ("item_specifics.type", "item_specifics.material",
+                "item_specifics.subject", "item_specifics.brand"):
+        parts.append(str(draft.get(key) or ""))
+    extra = draft.get("item_specifics.extra")
+    if isinstance(extra, dict):
+        for k, v in extra.items():
+            parts.append(f"{k} {v}")
+    return " ".join(parts)
+
+
+def _gun_aspect_hits(draft: Any) -> list[str]:
+    extra = draft.get("item_specifics.extra")
+    if not isinstance(extra, dict):
+        return []
+    hits = []
+    for key in extra:
+        if str(key).strip().lower() in _GUN_ASPECT_KEYS:
+            hits.append(f'carries the "{key}" item specific — eBay classes this '
+                        f"as a firearm accessory")
+    return hits
+
+
+def us_only_reasons(draft: Any) -> list[str]:
+    """Why this item must ship US-only. Empty list = no restriction found.
+
+    Returns human-readable reasons, not booleans, so REVIEW can show the
+    operator WHICH signal fired — a routing decision nobody can audit is a
+    routing decision nobody will trust.
+    """
+    if str(draft.get("shipping.us_only") or "").strip().lower() in _TRUE:
+        return ["shipping.us_only is set in the draft"]
+
+    reasons = _gun_aspect_hits(draft)
+    hay = _haystack(draft)
+    for pattern, label in US_ONLY_PATTERNS:
+        if re.search(pattern, hay, re.I):
+            if label not in reasons:
+                reasons.append(label)
+    return reasons
+
+
+def is_us_only(draft: Any) -> bool:
+    return bool(us_only_reasons(draft))

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -174,11 +174,36 @@ parcel shipping to buyers. Say so at REVIEW. Decide `fulfillment_mode`:
   local? Message me for a freight quote."* Log the decision (+ trigger) in
   `meta.notes`.
 
-**Carrier: there is no carrier choice.** Every item ships on the one
-fulfillment policy, `296458692014` ("Free USPS Ground + eBay International
-Shipping", free calculated USPS Ground Advantage, 1 day handling). Do not
-propose a carrier switch, do not estimate a rival carrier's cost, and do not
-override the policy at LIST time. Weight and dimensions are still worth
+**US-only gate (automatic — do not hand-route).** Some items are legal to sell
+on eBay.com but ONLY to US buyers, by US export law: firearm magazines and
+parts, body armor, night vision and thermal optics, anything marked ITAR. These
+route to the **US-only fulfillment policy** (`fulfillment_policy_id_us_only`),
+and `lib/us_only.py` decides it automatically from the title and item specifics
+— you do not set it per item. Set `shipping.us_only: true` by hand ONLY when
+you know an item is export-restricted and its wording does not say so.
+
+Understand why it is a separate policy, because the obvious fix does not work:
+`shipping.international: false` is NOT enough. The default policy carries
+`shipToLocations: Worldwide`, and that alone makes a listing eBay-International-
+Shipping eligible, which makes eBay refuse the publish outright — errorId 25019,
+firearms policy plus ITAR Part 121. eIS is an account-level enrollment, so a
+US-only `shipToLocations` is the only lever. Measured on a Ruger Mini-14
+magazine, 2026-08-27.
+
+Two consequences worth stating: the US-only route **outranks an international
+request** (a legal restriction beats reach) and it **outranks Media Mail** (it
+beats the postage saving too). If an item is US-restricted and no US-only policy
+is configured, preflight raises a BLOCKER rather than falling back — the
+fallback would fail at publish anyway, and would mean offering a restricted item
+abroad. Also set `shipping.international: false` on these for tidiness, but do
+not mistake that flag for the protection.
+
+**Carrier: there is no carrier choice.** Every item ships on one of the account's
+policies — normally `296458692014` ("Free USPS Ground + eBay International
+Shipping", free calculated USPS Ground Advantage, 1 day handling), or
+`297194269014` ("US Only - Free USPS Ground") when the gate above fires. Same
+terms either way. Do not propose a carrier switch, do not estimate a rival
+carrier's cost, and do not override the policy at LIST time. Weight and dimensions are still worth
 recording — they drive the calculated rate and a freight quote. If an item
 genuinely cannot go USPS (oversize / >70 lb), say so in `meta.notes` and
 append a NEEDS_REVIEW line rather than selecting a different policy.

--- a/templates/listing-v1.md
+++ b/templates/listing-v1.md
@@ -133,6 +133,19 @@ shipping:
   # NOTE: with international ON the delivered-price basis no longer holds —
   # our free-shipping domestic price is NOT what an overseas buyer pays.
   international: false
+  # Force this item onto the US-ONLY fulfillment policy
+  # (ebay.fulfillment_policy_id_us_only). Leave false and let lib/us_only.py
+  # detect it — firearm magazines and parts, body armor, night vision and
+  # anything marked ITAR are routed automatically off the title and item
+  # specifics. Set true by hand only when you know an item is export-restricted
+  # and the wording does not say so.
+  #
+  # NOTE: this is NOT the same as `international: false`. That flag only
+  # declines to use the eIS policy; the DEFAULT policy still carries
+  # shipToLocations "Worldwide", which is what makes a listing eIS-eligible and
+  # trips eBay's ITAR refusal (errorId 25019). Only the US-only policy prevents
+  # it. Measured on a Ruger Mini-14 magazine, 2026-08-27.
+  us_only: false
   free_shipping: true          # eBay form field [61] — default ON; ignored when LOCAL_PICKUP
   # CALCULATED | FLAT_RATE | FREE_FLAT_RATE
   # When free_shipping is true this is FREE_FLAT_RATE.

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -63,6 +63,11 @@ DRAFT_SHIPPING = {
     "domestic_shipping_type", "free_shipping", "fulfillment_mode",
     "handling_time_days", "international", "item_location_zip", "local_pickup",
     "package_in", "primary_service", "weight",
+    # Added 2026-08-27, additive and safe: absent means false, so drafts
+    # written before it read identically. Routes US-export-restricted items
+    # (firearm parts, body armor, night vision) to the US-only fulfillment
+    # policy. Normally set by lib/us_only.py, not by hand.
+    "us_only",
 }
 # The limits the eBay form actually enforces. A wrong number here is a publish
 # rejection or a silently truncated listing, so they are pinned by value.

--- a/tests/test_shipping_policy_strict.py
+++ b/tests/test_shipping_policy_strict.py
@@ -54,6 +54,24 @@ def _fulfillment_policies_stub(ids):
             for fid in ids]
 
 
+class _patched_fulfillment_policies:
+    """Patch `list_edit.get_fulfillment_policies` for the block, then restore it.
+
+    A bare assignment leaks into later tests under pytest, which runs the
+    whole suite in one process — this makes the patch test-scoped instead.
+    """
+
+    def __init__(self, ids):
+        self._ids = ids
+
+    def __enter__(self):
+        self._orig = L.get_fulfillment_policies
+        L.get_fulfillment_policies = lambda creds=None: _fulfillment_policies_stub(self._ids)
+
+    def __exit__(self, *exc):
+        L.get_fulfillment_policies = self._orig
+
+
 # --------------------------------------------------------- strict=True (write paths)
 def test_strict_raises_when_us_only_policy_missing():
     draft = _draft({"title": RESTRICTED_TITLE})
@@ -68,27 +86,24 @@ def test_strict_raises_when_us_only_policy_missing():
 def test_strict_does_not_raise_when_us_only_policy_configured():
     policies = {**_BASE_POLICIES, "fulfillment_us_only": "usonly-fid"}
     draft = _draft({"title": RESTRICTED_TITLE})
-    L.get_fulfillment_policies = lambda creds=None: _fulfillment_policies_stub(
-        list(policies.values()))
-    chosen, msgs = L._resolve_shipping_policy(draft, policies, _Creds(), strict=True)
+    with _patched_fulfillment_policies(list(policies.values())):
+        chosen, msgs = L._resolve_shipping_policy(draft, policies, _Creds(), strict=True)
     assert chosen == "usonly-fid"
     assert any("US-ONLY" in m for m in msgs)
 
 
 def test_strict_does_not_raise_for_ordinary_item():
     draft = _draft({"title": ORDINARY_TITLE})
-    L.get_fulfillment_policies = lambda creds=None: _fulfillment_policies_stub(
-        list(_BASE_POLICIES.values()))
-    chosen, _msgs = L._resolve_shipping_policy(draft, dict(_BASE_POLICIES), _Creds(), strict=True)
+    with _patched_fulfillment_policies(list(_BASE_POLICIES.values())):
+        chosen, _msgs = L._resolve_shipping_policy(draft, dict(_BASE_POLICIES), _Creds(), strict=True)
     assert chosen == _BASE_POLICIES["fulfillment"]
 
 
 # --------------------------------------------------------- strict=False (preflight, advisory)
 def test_non_strict_falls_back_with_blocker_message():
     draft = _draft({"title": RESTRICTED_TITLE})
-    L.get_fulfillment_policies = lambda creds=None: _fulfillment_policies_stub(
-        list(_BASE_POLICIES.values()))
-    chosen, msgs = L._resolve_shipping_policy(draft, dict(_BASE_POLICIES), _Creds())
+    with _patched_fulfillment_policies(list(_BASE_POLICIES.values())):
+        chosen, msgs = L._resolve_shipping_policy(draft, dict(_BASE_POLICIES), _Creds())
     assert chosen == _BASE_POLICIES["fulfillment"]
     assert any("BLOCKER" in m for m in msgs)
 

--- a/tests/test_shipping_policy_strict.py
+++ b/tests/test_shipping_policy_strict.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""`_resolve_shipping_policy(strict=True)` must fail fast, not fall back.
+
+Copilot flagged this on PR #49: when an item is US-export-restricted and no
+`fulfillment_policy_id_us_only` is configured, the write paths (--sync, the
+`policies` field update) chose the DEFAULT policy anyway and only logged a
+"BLOCKER" string. The default policy ships Worldwide, so that default choice
+is exactly the eIS-eligibility trap this module exists to close — and if eBay
+ever stopped catching it at publish time, it would mean actually exporting a
+restricted item. `strict=True` (used by every caller that is about to WRITE
+the resolved policy into an offer) now raises instead.
+
+`preflight_listing` stays non-strict on purpose: it is read-only and its job
+is to SHOW the operator this exact problem before they decide to fix it, so
+raising there would break the "check without touching anything" workflow.
+
+Run:  python tests/test_shipping_policy_strict.py
+  or: pytest tests/test_shipping_policy_strict.py
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "lib"))
+
+import list_edit as L                                         # noqa: E402
+from draft_io import Draft                                    # noqa: E402
+
+
+class _Creds:
+    has_user = True
+
+
+def _draft(frontmatter):
+    return Draft(path=Path("inventory/example/draft.md"), frontmatter=frontmatter, body="")
+
+
+RESTRICTED_TITLE = "RUGER Mini 14 Factory 5 Round Magazine 223 5.56 Blued Steel OEM"
+ORDINARY_TITLE = "Vintage Cast Iron Skillet No. 8 Smooth Bottom"
+
+_BASE_POLICIES = {
+    "fulfillment": "default-fid",
+    "fulfillment_media": "media-fid",
+    "fulfillment_local_pickup": "pickup-fid",
+    "fulfillment_international": "intl-fid",
+}
+
+
+def _fulfillment_policies_stub(ids):
+    """Fake get_fulfillment_policies(): a parcel-shipping policy per id."""
+    return [{"fulfillmentPolicyId": fid,
+             "shippingOptions": [{"shippingServices": [{"shippingServiceCode": "USPSGround"}]}]}
+            for fid in ids]
+
+
+# --------------------------------------------------------- strict=True (write paths)
+def test_strict_raises_when_us_only_policy_missing():
+    draft = _draft({"title": RESTRICTED_TITLE})
+    try:
+        L._resolve_shipping_policy(draft, dict(_BASE_POLICIES), _Creds(), strict=True)
+        raise AssertionError("expected ValueError — US-restricted item with no US-only policy")
+    except ValueError as e:
+        assert "BLOCKER" in str(e)
+        assert "US-export-restricted" in str(e)
+
+
+def test_strict_does_not_raise_when_us_only_policy_configured():
+    policies = {**_BASE_POLICIES, "fulfillment_us_only": "usonly-fid"}
+    draft = _draft({"title": RESTRICTED_TITLE})
+    L.get_fulfillment_policies = lambda creds=None: _fulfillment_policies_stub(
+        list(policies.values()))
+    chosen, msgs = L._resolve_shipping_policy(draft, policies, _Creds(), strict=True)
+    assert chosen == "usonly-fid"
+    assert any("US-ONLY" in m for m in msgs)
+
+
+def test_strict_does_not_raise_for_ordinary_item():
+    draft = _draft({"title": ORDINARY_TITLE})
+    L.get_fulfillment_policies = lambda creds=None: _fulfillment_policies_stub(
+        list(_BASE_POLICIES.values()))
+    chosen, _msgs = L._resolve_shipping_policy(draft, dict(_BASE_POLICIES), _Creds(), strict=True)
+    assert chosen == _BASE_POLICIES["fulfillment"]
+
+
+# --------------------------------------------------------- strict=False (preflight, advisory)
+def test_non_strict_falls_back_with_blocker_message():
+    draft = _draft({"title": RESTRICTED_TITLE})
+    L.get_fulfillment_policies = lambda creds=None: _fulfillment_policies_stub(
+        list(_BASE_POLICIES.values()))
+    chosen, msgs = L._resolve_shipping_policy(draft, dict(_BASE_POLICIES), _Creds())
+    assert chosen == _BASE_POLICIES["fulfillment"]
+    assert any("BLOCKER" in m for m in msgs)
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [(n, f) for n, f in sorted(globals().items())
+           if n.startswith("test_") and callable(f)]
+    bad = 0
+    for name, fn in fns:
+        try:
+            fn()
+            print(f"  ok   {name}")
+        except Exception:
+            bad += 1
+            print(f"  FAIL {name}")
+            traceback.print_exc()
+    print(f"\n{len(fns) - bad}/{len(fns)} passed")
+    sys.exit(1 if bad else 0)

--- a/tests/test_us_only.py
+++ b/tests/test_us_only.py
@@ -1,0 +1,122 @@
+"""US-only routing tests.
+
+The load-bearing test in this file is `test_periodicals_are_not_firearms`.
+This inventory sells MAGAZINES — Esquire, Britches catalogs, periodical lots —
+and a naive `\\bmagazine\\b` would route them to a firearms policy. Every
+firearm pattern requires gun context for exactly that reason. If someone
+loosens a pattern, that test is what should stop them.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+
+from us_only import is_us_only, us_only_reasons  # noqa: E402
+
+
+class D(dict):
+    """Minimal stand-in for Draft: dotted-key .get()."""
+    def get(self, key, default=None):  # noqa: D102
+        return dict.get(self, key, default)
+
+
+def mk(title="", extra=None, **kw):
+    d = D({"title": title})
+    if extra is not None:
+        d["item_specifics.extra"] = extra
+    d.update(kw)
+    return d
+
+
+# --------------------------------------------------------------- must route
+def test_ruger_magazine_routes_us_only():
+    """The item that forced this module into existence."""
+    d = mk("RUGER Mini 14 Factory 5 Round Magazine 223 5.56 Blued Steel OEM Ranch Rifle")
+    assert is_us_only(d)
+
+
+def test_gun_aspect_alone_is_enough():
+    """eBay's own required aspects are the strongest signal."""
+    d = mk("Some Part", extra={"For Gun Type": "Rifle", "Number of Rounds": "5"})
+    assert is_us_only(d)
+    assert any("For Gun Type" in r for r in us_only_reasons(d))
+
+
+def test_explicit_flag_wins_without_any_pattern():
+    d = mk("A Perfectly Ordinary Teacup")
+    d["shipping.us_only"] = "true"
+    assert is_us_only(d)
+
+
+def test_unbranded_part_by_caliber():
+    assert is_us_only(mk("Blued Steel 5 Round Magazine .308 Winchester"))
+
+
+def test_various_restricted_categories():
+    for title in (
+        "Vintage Colt 1911 Barrel .45 ACP",
+        "AR-15 Lower Receiver Stripped",
+        "Level III Ballistic Plate Carrier Body Armor",
+        "Gen 2 Night Vision Scope",
+        "Remington 870 12 Gauge Choke Tube",
+        "Assorted Gun Parts Lot",
+    ):
+        assert is_us_only(mk(title)), title
+
+
+# ----------------------------------------------------- must NOT route (!!!)
+def test_periodicals_are_not_firearms():
+    """The false-positive case this whole design is shaped around."""
+    for title in (
+        "Esquire Magazine Lot of 12 1979 1980 Mens Fashion Periodicals",
+        "Vintage LIFE Magazine March 1969 Apollo 9 Cover",
+        "Britches of Georgetowne Catalog Mailer 1983 Menswear",
+        "National Geographic Magazine Bound Volume 1972",
+        "Playbill Magazine Broadway 1988",
+    ):
+        assert not is_us_only(mk(title)), f"false positive: {title}"
+
+
+def test_ordinary_inventory_is_not_restricted():
+    for title in (
+        "Vintage SPEIDEL USA Gold Tone Curb Link ID Bracelet Blank Plate 7 in Unisex",
+        "Vintage Polaroid Automatic 320 Land Camera Cold Clip Strap Rangefinder 1969",
+        "Vintage 1/20 12K Gold Filled Cross Pendant Necklace 24 in Curb Chain Satin",
+        "Antique Cast Iron Skillet No. 8 Smooth Bottom",
+        "Mid Century Teak Magazine Rack Danish Modern",
+        "Sterling Silver Bolt Ring Clasp Findings Lot",
+    ):
+        assert not is_us_only(mk(title)), f"false positive: {title}"
+
+
+def test_stock_and_barrel_need_gun_context():
+    """'Stock' and 'barrel' are common antique words on their own."""
+    for title in (
+        "Antique Oak Barrel Stave Basket Primitive Farmhouse",
+        "Vintage Stock Certificate Railroad 1923 Scripophily",
+        "Wooden Barrel Butter Churn Dasher Antique",
+    ):
+        assert not is_us_only(mk(title)), f"false positive: {title}"
+
+
+def test_reasons_are_human_readable():
+    reasons = us_only_reasons(mk("Ruger Mini 14 5 Round Magazine"))
+    assert reasons and all(isinstance(r, str) and len(r) > 10 for r in reasons)
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [(n, f) for n, f in sorted(globals().items())
+           if n.startswith("test_") and callable(f)]
+    bad = 0
+    for name, fn in fns:
+        try:
+            fn()
+            print(f"  ok   {name}")
+        except Exception:
+            bad += 1
+            print(f"  FAIL {name}")
+            traceback.print_exc()
+    print(f"\n{len(fns) - bad}/{len(fns)} passed")
+    sys.exit(1 if bad else 0)


### PR DESCRIPTION
Routes US-export-restricted items (firearm magazines and parts) to a US-only
fulfillment policy so they can publish at all.

## The trap this closes

eBay refuses to publish a firearm magazine while the listing is reachable by
eBay International Shipping — errorId 25019, firearms policy plus ITAR Part 121.
Measured 2026-08-27 on a Ruger Mini-14 magazine.

`shipping.international: false` does NOT prevent it, and neither does a policy
with `globalShipping: false` and zero international shipping options. Both were
already true on that draft and the publish still failed. The actual trigger is
`shipToLocations: Worldwide` on the fulfillment policy, which is what makes a
listing eIS-eligible. eIS is an account-level enrollment, so a US-only
`shipToLocations` is the only lever.

## What changed

- `lib/us_only.py` — detection. Patterns require firearm CONTEXT beside the part
  word, because this inventory genuinely sells MAGAZINES; a bare `\bmagazine\b`
  would route Esquire and the Britches catalogs to a firearms policy. Scans title
  + item specifics only, per the house rule already used by
  `_DANGEROUS_GOODS_PATTERNS`.
- `_resolve_shipping_policy` — new tier above international and above Media Mail:
  a legal restriction outranks reach, and outranks the postage saving. With no
  US-only policy configured it raises a BLOCKER rather than falling back — the
  fallback would fail at publish anyway, and would mean offering a restricted
  item abroad.
- Reasons are returned as strings, not booleans, so REVIEW shows WHICH signal
  fired. Routing nobody can audit is routing nobody will trust.
- `templates/listing-v1.md` — `shipping.us_only`, additive and safe (absent reads
  as false), added to the format lock in the same commit per RUN.md.
- `prompts/draft.md`, `lib/config.example.yaml`.

## Verification

- **292 passed** (`python -m pytest tests/`), including 9 new `test_us_only.py`
  cases and the format lock. Note `tests/run_all.py` cannot supply pytest
  fixtures and skips 20 tests — pytest is the authoritative run.
- Live: the Ruger magazine routes US-only and published (206520014259).
  `esquire-gentleman` and `gear-catalogs-mailers` still route normally.

## Reviewer note — detection is deliberately broad

A sweep of all drafts finds two items that route US-only:

| item | signals | status |
| --- | --- | --- |
| `ESTATES/SCJ/ej-8-27/ruger-mini-14-magazine` | 5 (gun aspects + magazine + caliber) | live, 206520014259 |
| `ESTATES/SCJ/faux-stag-1911-grips` | 1 ("For Gun Type" aspect only) | sold 2026-08-19 |

The grips **published fine worldwide and sold** before this change, so the
detector is broader than eBay's actual refusal. That is intentional for an ITAR
question, but it means future grips/holsters lose international reach on a single
aspect hit. Flagging in case we'd rather require >=2 signals for non-magazine
parts. No live listing needs re-routing today.
