### PR TITLE
fix(sync): scan drafts at any depth, not just two levels down

### DIFF
--- a/lib/sync_actuals.py
+++ b/lib/sync_actuals.py
@@ -256,7 +256,7 @@ def load_listings_ledger() -> list[dict]:
 def scan_drafts() -> list[dict]:
     """Every local draft: its folder, title, ask, SKU and listing id."""
     out = []
-    for dr in sorted(INVENTORY.glob("*/draft.md")) + sorted(INVENTORY.glob("*/*/draft.md")):
+    for dr in sorted(INVENTORY.rglob("draft.md")):
         try:
             t = dr.read_text(encoding="utf-8", errors="ignore")
         except OSError:


### PR DESCRIPTION
`scan_drafts()` globbed `*/draft.md` + `*/*/draft.md`, so it could only see items nested at most two levels under `inventory/`.

That was already wrong for `FR/art/<item>`-style trees, but the estate re-org made it the common case: after grouping items under `ESTATES/<sale>/<item>/`, **nothing sits at depth 1 at all**, and 187 of 264 drafts fell outside the glob.

An unseen draft is not a crash — it is a sale that silently fails to match a folder. That is how `sales_ledger.csv` ended up with **28 stale `shoot_dir` values and 50 unattributed orders**. `rglob` has no depth opinion, so the tree can be reorganized without the matcher quietly losing rows.

## Verification

- `sync_actuals --days 730 --apply` re-derives `shoot_dir` for every sale; stale count **28 → 0**.
- 292 passed (`python -m pytest tests/`), incl. `test_sync_actuals.py`.

One-line change; the audit for other depth-capped globs found none.