### PR TITLE
feat(context): directory-level estate context every item inherits (#46)

### DIFF
--- a/lib/dir_context.py
+++ b/lib/dir_context.py
@@ -215,6 +215,22 @@ def brief(item_dir: Path, root: Path = INVENTORY) -> str:
     return "\n".join(out)
 
 
+def _display_path(item_dir: Path, root: Path) -> str:
+    """Best-effort relative path for a sweep hit.
+
+    item_dir is normally under REPO (the default INVENTORY root), but
+    --root lets a caller point sweep() anywhere, so relative_to(REPO) can
+    raise ValueError. Fall back to root-relative, then absolute, instead
+    of aborting the sweep.
+    """
+    for base in (REPO, root):
+        try:
+            return str(item_dir.relative_to(base)).replace("\\", "/")
+        except ValueError:
+            continue
+    return str(item_dir).replace("\\", "/")
+
+
 def sweep(root: Path = INVENTORY) -> list[tuple[str, str, Blocked]]:
     """Every drafted item asserting a claim its estate contradicts."""
     hits: list[tuple[str, str, Blocked]] = []
@@ -227,8 +243,7 @@ def sweep(root: Path = INVENTORY) -> list[tuple[str, str, Blocked]]:
         for b in ctx.blocks(text):
             phrase = next(p for p in b.phrases if p in low)
             line = text.splitlines()[low[:low.index(phrase)].count("\n")].strip()
-            hits.append((str(dr.parent.relative_to(REPO)).replace("\\", "/"),
-                         line[:120], b))
+            hits.append((_display_path(dr.parent, root), line[:120], b))
     return hits
 
 

--- a/lib/dir_context.py
+++ b/lib/dir_context.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Directory-level estate context — one source summary every item inherits.
+
+WHY: items don't arrive one at a time, they arrive as an ESTATE. Everything
+under inventory/FR/ came out of one house: same address, same decades, same
+air. That shared fact used to live only in the user's head, so every stage
+re-derived (or failed to derive) the same background for every item in the
+tree — and the worst case was never the blank, it was a stage filling the
+blank OPTIMISTICALLY because a book happened to look clean.
+
+A parent directory gets a context.txt; every item under it inherits it.
+
+FORMAT — prose is the payload, `key: value` lines are the part tools read
+without guessing. Keys are only recognized in the leading block, before the
+first blank line, and only as a single lowercase word + colon + value; a prose
+line that happens to end in a colon is prose, not a key.
+
+    source: Frankie (grandmother), estate, Greensboro NC house
+    environment: smoker — indoors, occasional. no pets.
+    storage: attic and closets, unclimatized; decades in place.
+
+    She smoked most of her life and sometimes inside, so nothing from this
+    house can be sold as coming from a smoke-free home.
+
+CASCADE: a stage working on inventory/FR/books/TEJ collects every context.txt
+from the inventory root down to the item dir and merges them NEAREST-WINS, so
+a sub-estate ("these were in the damp basement, not the attic") refines its
+parent without restating it. Prose accumulates outermost-first — the general
+story then the correction — because none of it is redundant.
+
+WHAT IT DOES NOT DO (the clamps — same rails the specializations carry):
+  * Context is BACKGROUND, never a claim upgrade. It can FORBID an assertion
+    or SUPPLY a disclosure. It cannot make a marble German or a book a first
+    edition. "From a house that accumulated 1955-2010" is a prior, not a date.
+  * Negative constraints are HARD. A blocked claim is blocked, not "flagged" —
+    DRAFT refuses to emit it, at any confidence.
+  * No PII in buyer copy. The file may name the person for our own reference;
+    listing copy says "an estate" unless explicitly opted in.
+  * Absent file = today's behavior. No context.txt in the chain changes nothing.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+INVENTORY = REPO / "inventory"
+
+CONTEXT_NAME = "context.txt"
+
+# A key line: one lowercase word, colon, then something. Anchored and narrow on
+# purpose — "Items that I've purchased from my neighbors:" is prose and must
+# not be swallowed as a key with an empty value.
+_KEY_RE = re.compile(r"^([a-z][a-z_]{1,19}):[ \t]+(\S.*)$")
+
+# Claims the estate can forbid. Each entry: (trigger regex over the merged
+# context text, the phrases DRAFT may not emit, why). The trigger reads BOTH
+# the key lines and the prose, because the user writes plainly and the fact
+# lands wherever it lands.
+_BLOCKS: list[tuple[str, tuple[str, ...], str]] = [
+    (r"\bsmok(?:e[rd]?|ing)\b",
+     ("smoke-free", "smoke free", "smokefree", "non-smoking", "nonsmoking",
+      "no smoking", "odor-free", "odour-free", "odor free"),
+     "someone smoked in the source home"),
+    (r"\b(?:cat|dog|pet)s?\b",
+     ("pet-free", "pet free", "petfree", "no pets"),
+     "pets in the source home"),
+    (r"\b(?:unclimatized|unclimated|attic|garage|barn|shed|basement|damp)\b",
+     ("climate-controlled", "climate controlled", "climate-conditioned"),
+     "stored unclimatized"),
+]
+
+# A trigger fires only if the context does not already assert the negative —
+# "no pets" mentions pets but forbids nothing.
+_NEGATED = {
+    "someone smoked in the source home": r"\b(?:no|non[- ]?)\s*smok\w*",
+    "pets in the source home": r"\bno\s+pets\b",
+}
+
+
+@dataclass
+class ContextFile:
+    """One context.txt, as written."""
+    path: Path
+    keys: dict[str, str]
+    prose: str
+
+    @property
+    def rel(self) -> str:
+        try:
+            return str(self.path.relative_to(REPO)).replace("\\", "/")
+        except ValueError:
+            return str(self.path)
+
+
+@dataclass
+class Blocked:
+    """A claim this estate forbids, and the receipt for why."""
+    phrases: tuple[str, ...]
+    why: str
+    source: str
+
+
+@dataclass
+class MergedContext:
+    """The whole chain, merged. Empty is the no-context.txt case."""
+    chain: list[ContextFile] = field(default_factory=list)
+    keys: dict[str, str] = field(default_factory=dict)
+    prose: str = ""
+    blocked: list[Blocked] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return bool(self.chain)
+
+    @property
+    def sources(self) -> list[str]:
+        return [c.rel for c in self.chain]
+
+    def blocks(self, text: str) -> list[Blocked]:
+        """Which forbidden claims does `text` actually make? (DRAFT/REVIEW)"""
+        low = (text or "").lower()
+        return [b for b in self.blocked if any(p in low for p in b.phrases)]
+
+
+def parse(path: Path) -> ContextFile:
+    """One file: leading key block, then prose. Both optional."""
+    raw = path.read_text(encoding="utf-8", errors="ignore")
+    keys: dict[str, str] = {}
+    lines = raw.splitlines()
+    cut = 0
+    for cut, line in enumerate(lines):
+        if not line.strip():
+            break
+        m = _KEY_RE.match(line)
+        if not m:
+            break                              # first non-key line ends the block
+        keys[m.group(1)] = m.group(2).strip()
+    else:
+        cut = len(lines)
+    prose = "\n".join(lines[cut:]).strip() if keys else raw.strip()
+    return ContextFile(path=path, keys=keys, prose=prose)
+
+
+def chain_for(item_dir: Path, root: Path = INVENTORY) -> list[ContextFile]:
+    """Every context.txt from `root` down to `item_dir`, outermost first."""
+    item_dir = Path(item_dir).resolve()
+    root = Path(root).resolve()
+    try:
+        item_dir.relative_to(root)
+    except ValueError:
+        return []
+    parts: list[Path] = []
+    cur = item_dir
+    while True:
+        parts.append(cur)
+        if cur == root:
+            break
+        cur = cur.parent
+    out = []
+    for d in reversed(parts):
+        f = d / CONTEXT_NAME
+        if f.is_file():
+            out.append(parse(f))
+    return out
+
+
+def _derive_blocks(chain: list[ContextFile]) -> list[Blocked]:
+    out: list[Blocked] = []
+    seen: set[str] = set()
+    for cf in chain:
+        text = "\n".join([*(f"{k}: {v}" for k, v in cf.keys.items()),
+                          cf.prose]).lower()
+        for trigger, phrases, why in _BLOCKS:
+            if why in seen:
+                continue
+            neg = _NEGATED.get(why)
+            probe = re.sub(neg, " ", text) if neg else text
+            if not re.search(trigger, probe):
+                continue
+            seen.add(why)
+            out.append(Blocked(phrases=phrases, why=why, source=cf.rel))
+    return out
+
+
+def load(item_dir: Path, root: Path = INVENTORY) -> MergedContext:
+    """The merged estate context for one item dir. Keys nearest-wins."""
+    chain = chain_for(item_dir, root)
+    if not chain:
+        return MergedContext()
+    keys: dict[str, str] = {}
+    for cf in chain:                            # outermost first, nearest wins
+        keys.update(cf.keys)
+    prose = "\n\n".join(f"[{cf.rel}]\n{cf.prose}" for cf in chain if cf.prose)
+    return MergedContext(chain=chain, keys=keys, prose=prose,
+                         blocked=_derive_blocks(chain))
+
+
+def brief(item_dir: Path, root: Path = INVENTORY) -> str:
+    """Plain-text block a stage can paste straight into its working notes."""
+    ctx = load(item_dir, root)
+    if not ctx:
+        return ""
+    out = ["ESTATE CONTEXT (background only — never a claim upgrade)",
+           f"  applied: {', '.join(ctx.sources)}"]
+    for k, v in ctx.keys.items():
+        out.append(f"  {k}: {v}")
+    if ctx.blocked:
+        out.append("  MUST NOT CLAIM:")
+        for b in ctx.blocked:
+            out.append(f"    - {' / '.join(b.phrases[:2])} — {b.why} ({b.source})")
+    if ctx.prose:
+        out += ["", ctx.prose]
+    return "\n".join(out)
+
+
+def sweep(root: Path = INVENTORY) -> list[tuple[str, str, Blocked]]:
+    """Every drafted item asserting a claim its estate contradicts."""
+    hits: list[tuple[str, str, Blocked]] = []
+    for dr in sorted(root.rglob("draft.md")):
+        ctx = load(dr.parent, root)
+        if not ctx.blocked:
+            continue
+        text = dr.read_text(encoding="utf-8", errors="ignore")
+        low = text.lower()
+        for b in ctx.blocks(text):
+            phrase = next(p for p in b.phrases if p in low)
+            line = text.splitlines()[low[:low.index(phrase)].count("\n")].strip()
+            hits.append((str(dr.parent.relative_to(REPO)).replace("\\", "/"),
+                         line[:120], b))
+    return hits
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("item_dir", nargs="?", help="item folder to resolve context for")
+    ap.add_argument("--sweep", action="store_true",
+                    help="scan every draft for a claim its estate forbids")
+    ap.add_argument("--root", default=str(INVENTORY))
+    a = ap.parse_args()
+    root = Path(a.root)
+
+    if a.sweep:
+        hits = sweep(root)
+        for d, line, b in hits:
+            print(f"{d}\n    claims: {line}\n    forbidden: {b.why} ({b.source})")
+        print(f"\n{len(hits)} contradicted claim(s)")
+        return 1 if hits else 0
+
+    if not a.item_dir:
+        ap.error("give an item_dir, or --sweep")
+    print(brief(Path(a.item_dir), root)
+          or "(no context.txt in the chain — no change to behavior)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/dir_context.py
+++ b/lib/dir_context.py
@@ -72,13 +72,6 @@ _BLOCKS: list[tuple[str, tuple[str, ...], str]] = [
      "stored unclimatized"),
 ]
 
-# A trigger fires only if the context does not already assert the negative —
-# "no pets" mentions pets but forbids nothing.
-_NEGATED = {
-    "someone smoked in the source home": r"\b(?:no|non[- ]?)\s*smok\w*",
-    "pets in the source home": r"\bno\s+pets\b",
-}
-
 
 @dataclass
 class ContextFile:
@@ -175,8 +168,15 @@ def _derive_blocks(chain: list[ContextFile]) -> list[Blocked]:
         for trigger, phrases, why in _BLOCKS:
             if why in seen:
                 continue
-            neg = _NEGATED.get(why)
-            probe = re.sub(neg, " ", text) if neg else text
+            # A context asserting one of the forbidden phrases itself (the
+            # estate saying "smoke-free" or "no pets") is a NEGATION of the
+            # trigger, not evidence for it. Strip those phrases before
+            # testing the trigger, or "smoke-free" reads as "smoker" — the
+            # trigger regex matches on the bare root word, not on absence of
+            # a hyphenated qualifier.
+            probe = text
+            for p in phrases:
+                probe = probe.replace(p, " ")
             if not re.search(trigger, probe):
                 continue
             seen.add(why)

--- a/lib/dir_context.py
+++ b/lib/dir_context.py
@@ -53,7 +53,7 @@ CONTEXT_NAME = "context.txt"
 # A key line: one lowercase word, colon, then something. Anchored and narrow on
 # purpose — "Items that I've purchased from my neighbors:" is prose and must
 # not be swallowed as a key with an empty value.
-_KEY_RE = re.compile(r"^([a-z][a-z_]{1,19}):[ \t]+(\S.*)$")
+_KEY_RE = re.compile(r"^([a-z][a-z_]{0,19}):[ \t]+(\S.*)$")
 
 # Claims the estate can forbid. Each entry: (trigger regex over the merged
 # context text, the phrases DRAFT may not emit, why). The trigger reads BOTH

--- a/tests/test_dir_context.py
+++ b/tests/test_dir_context.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""lib/dir_context.py — key/prose parsing, cascade merge, and derived blocks.
+
+Written in response to the review on PR #51 (both the human scrutiny pass
+and Copilot): the module shipped with zero automated tests despite forbidding
+buyer-facing claims (smoke-free, pet-free, climate-controlled) on legal /
+disclosure grounds, where a silent regression in the negation or cascade
+logic is a real-world liability, not just a bug.
+
+Covers: the key-block vs. prose parsing boundary, nearest-wins override
+across directory depth, each of the three block triggers with its negation
+counter-example (including the "smoke-free" / "pet-free" case Copilot
+flagged — the trigger regex matches the bare root word, e.g. "smok", so a
+hyphenated negative qualifier like "smoke-free" used to read as evidence of
+smoking rather than a denial of it), MergedContext.blocks()/brief() output
+shape, and sweep() over a synthetic multi-level tree.
+
+Run:  python tests/test_dir_context.py
+  or: pytest tests/test_dir_context.py
+"""
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+
+import dir_context as DC  # noqa: E402
+
+
+_cleanup: list[Path] = []
+
+
+def _make(files: dict) -> Path:
+    """Write {relpath: content} under a fresh temp dir INSIDE the repo root
+    (ContextFile.rel and sweep() both compute paths relative to dir_context's
+    hardcoded REPO, so a synthetic tree has to live under it to round-trip)."""
+    root = Path(tempfile.mkdtemp(prefix="dctx_", dir=str(DC.REPO)))
+    _cleanup.append(root)
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return root
+
+
+def teardown_module(module):  # picked up by pytest; also called from __main__
+    for root in _cleanup:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+# --------------------------------------------------------------- parse()
+def test_key_block_parses_leading_keys_then_prose():
+    root = _make({"context.txt":
+                  "source: Frankie, estate, Greensboro NC\n"
+                  "environment: smoker\n"
+                  "\n"
+                  "She smoked most of her life.\n"})
+    cf = DC.parse(root / "context.txt")
+    assert cf.keys == {"source": "Frankie, estate, Greensboro NC",
+                       "environment": "smoker"}
+    assert cf.prose == "She smoked most of her life."
+
+
+def test_prose_line_ending_in_colon_is_not_swallowed_as_a_key():
+    """The narrow key regex is the whole point: a prose sentence that
+    happens to end in a colon must stay prose, not become a bogus key with
+    an empty/missing value."""
+    root = _make({"context.txt":
+                  "Items that I've purchased from my neighbors:\n"
+                  "assorted estate lot, mixed sources.\n"})
+    cf = DC.parse(root / "context.txt")
+    assert cf.keys == {}
+    assert "Items that I've purchased from my neighbors:" in cf.prose
+
+
+def test_file_with_no_key_block_is_all_prose():
+    root = _make({"context.txt": "Just background notes, no keys here.\n"})
+    cf = DC.parse(root / "context.txt")
+    assert cf.keys == {}
+    assert cf.prose == "Just background notes, no keys here."
+
+
+def test_file_with_only_keys_has_empty_prose():
+    root = _make({"context.txt": "source: FR\nenvironment: smoker\n"})
+    cf = DC.parse(root / "context.txt")
+    assert cf.keys == {"source": "FR", "environment": "smoker"}
+    assert cf.prose == ""
+
+
+# ------------------------------------------------------------ chain_for() / load()
+def test_chain_for_walks_root_to_item_outermost_first():
+    root = _make({
+        "context.txt": "source: FR\n",
+        "books/context.txt": "storage: attic\n",
+        "books/TEJ/draft.md": "---\ntitle: x\n---\n",
+    })
+    chain = DC.chain_for(root / "books" / "TEJ", root=root)
+    assert [str(c.path.relative_to(root)) for c in chain] == [
+        "context.txt", "books/context.txt"]
+
+
+def test_nearest_wins_child_overrides_parent_key():
+    root = _make({
+        "context.txt": "storage: attic, unclimatized\n",
+        "sub/context.txt": "storage: moved to climate-controlled unit in 2020\n",
+    })
+    ctx = DC.load(root / "sub", root=root)
+    assert ctx.keys["storage"] == "moved to climate-controlled unit in 2020"
+
+
+def test_absent_context_file_is_todays_behavior():
+    root = _make({"item/draft.md": "---\ntitle: x\n---\n"})
+    ctx = DC.load(root / "item", root=root)
+    assert not ctx
+    assert ctx.keys == {} and ctx.blocked == [] and ctx.prose == ""
+
+
+# ------------------------------------------------------- _derive_blocks() / blocks()
+def test_smoker_triggers_smoke_free_block():
+    root = _make({"context.txt": "environment: smoker — indoors, occasional.\n"})
+    ctx = DC.load(root, root=root)
+    whys = {b.why for b in ctx.blocked}
+    assert "someone smoked in the source home" in whys
+
+
+def test_smoke_free_assertion_does_not_trigger_the_block():
+    """Regression: the trigger regex matches the bare root ('smok'), so a
+    context asserting 'smoke-free' must NOT read as evidence of smoking —
+    that would forbid the estate's own true claim."""
+    root = _make({"context.txt": "environment: smoke-free household.\n"})
+    ctx = DC.load(root, root=root)
+    whys = {b.why for b in ctx.blocked}
+    assert "someone smoked in the source home" not in whys
+
+
+def test_no_smoking_assertion_does_not_trigger_the_block():
+    root = _make({"context.txt": "environment: non-smoking household.\n"})
+    ctx = DC.load(root, root=root)
+    assert not any(b.why == "someone smoked in the source home" for b in ctx.blocked)
+
+
+def test_pets_trigger_pet_free_block():
+    root = _make({"context.txt": "environment: two cats lived in the house.\n"})
+    ctx = DC.load(root, root=root)
+    assert any(b.why == "pets in the source home" for b in ctx.blocked)
+
+
+def test_no_pets_assertion_does_not_block_pet_free():
+    """'No pets in the house' must NOT block *pet-free* — it IS pet-free."""
+    root = _make({"context.txt": "environment: no pets in the house.\n"})
+    ctx = DC.load(root, root=root)
+    assert not any(b.why == "pets in the source home" for b in ctx.blocked)
+
+
+def test_unclimatized_storage_triggers_climate_controlled_block():
+    root = _make({"context.txt": "storage: attic, decades in place.\n"})
+    ctx = DC.load(root, root=root)
+    assert any(b.why == "stored unclimatized" for b in ctx.blocked)
+
+
+def test_climate_controlled_assertion_does_not_trigger_the_block():
+    root = _make({"context.txt": "storage: climate-controlled unit throughout.\n"})
+    ctx = DC.load(root, root=root)
+    assert not any(b.why == "stored unclimatized" for b in ctx.blocked)
+
+
+def test_merged_context_blocks_flags_text_making_a_forbidden_claim():
+    root = _make({"context.txt": "environment: smoker.\n"})
+    ctx = DC.load(root, root=root)
+    hit = ctx.blocks("Comes from a smoke-free home, no odors.")
+    assert len(hit) == 1 and hit[0].why == "someone smoked in the source home"
+    assert ctx.blocks("Great condition, ships fast.") == []
+
+
+def test_brief_lists_must_not_claim_and_prose():
+    root = _make({"context.txt": "environment: smoker.\n\nSome background prose.\n"})
+    text = DC.brief(root, root=root)
+    assert "MUST NOT CLAIM" in text
+    assert "Some background prose." in text
+
+
+def test_brief_is_empty_string_with_no_context_file():
+    root = _make({"item/draft.md": "---\ntitle: x\n---\n"})
+    assert DC.brief(root / "item", root=root) == ""
+
+
+# --------------------------------------------------------------------- sweep()
+def test_sweep_finds_a_contradicted_claim_in_a_multilevel_tree():
+    root = _make({
+        "context.txt": "source: FR estate\n",
+        "books/context.txt": "environment: smoker.\n",
+        "books/TEJ/draft.md": "---\ntitle: A Book\n---\nComes from a smoke-free home.\n",
+        "furniture/context.txt": "storage: attic, unclimatized.\n",
+        "furniture/chair/draft.md":
+            "---\ntitle: A Chair\n---\nClimate-controlled storage always.\n",
+        "clean/draft.md": "---\ntitle: Clean Item\n---\nNo estate concerns here.\n",
+    })
+    hits = DC.sweep(root=root)
+    dirs = {d for d, _line, _b in hits}
+    assert any(d.endswith("books/TEJ") for d in dirs)
+    assert any(d.endswith("furniture/chair") for d in dirs)
+    assert not any(d.endswith("clean") for d in dirs)
+    assert len(hits) == 2
+
+
+def test_sweep_is_empty_when_nothing_contradicts():
+    root = _make({
+        "context.txt": "source: FR estate\n",
+        "item/draft.md": "---\ntitle: x\n---\nAn ordinary description.\n",
+    })
+    assert DC.sweep(root=root) == []
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [(n, f) for n, f in sorted(globals().items())
+           if n.startswith("test_") and callable(f)]
+    bad = 0
+    for name, fn in fns:
+        try:
+            fn()
+            print(f"  ok   {name}")
+        except Exception:
+            bad += 1
+            print(f"  FAIL {name}")
+            traceback.print_exc()
+    teardown_module(None)
+    print(f"\n{len(fns) - bad}/{len(fns)} passed")
+    sys.exit(1 if bad else 0)

--- a/tests/test_dir_context.py
+++ b/tests/test_dir_context.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """lib/dir_context.py — key/prose parsing, cascade merge, and derived blocks.
 
-Written in response to the review on PR #51 (both the human scrutiny pass
-and Copilot): the module shipped with zero automated tests despite forbidding
+Written in response to review feedback (both the human scrutiny pass and
+Copilot): the module shipped with zero automated tests despite forbidding
 buyer-facing claims (smoke-free, pet-free, climate-controlled) on legal /
 disclosure grounds, where a silent regression in the negation or cascade
 logic is a real-world liability, not just a bug.
@@ -220,6 +220,22 @@ def test_sweep_is_empty_when_nothing_contradicts():
         "item/draft.md": "---\ntitle: x\n---\nAn ordinary description.\n",
     })
     assert DC.sweep(root=root) == []
+
+
+def test_sweep_does_not_raise_when_root_is_outside_repo():
+    """--root can point anywhere; sweep() must not assume REPO is an ancestor."""
+    outside_root = Path(tempfile.mkdtemp(prefix="dctx_outside_"))
+    _cleanup.append(outside_root)
+    (outside_root / "context.txt").write_text("environment: smoker.\n", encoding="utf-8")
+    item = outside_root / "item"
+    item.mkdir()
+    (item / "draft.md").write_text(
+        "---\ntitle: x\n---\nComes from a smoke-free home.\n", encoding="utf-8")
+
+    hits = DC.sweep(root=outside_root)
+    assert len(hits) == 1
+    d, _line, _b = hits[0]
+    assert d.endswith("item")
 
 
 if __name__ == "__main__":

--- a/tests/test_dir_context.py
+++ b/tests/test_dir_context.py
@@ -62,6 +62,16 @@ def test_key_block_parses_leading_keys_then_prose():
     assert cf.prose == "She smoked most of her life."
 
 
+def test_single_letter_key_is_recognized():
+    """The docstring promises keys are 'a single lowercase word', with no
+    stated minimum length — a one-letter key like 'x:' must parse like any
+    other, not silently fall through to prose."""
+    root = _make({"context.txt": "x: shorthand value\n"})
+    cf = DC.parse(root / "context.txt")
+    assert cf.keys == {"x": "shorthand value"}
+    assert cf.prose == ""
+
+
 def test_prose_line_ending_in_colon_is_not_swallowed_as_a_key():
     """The narrow key regex is the whole point: a prose sentence that
     happens to end in a colon must stay prose, not become a bogus key with


### PR DESCRIPTION
Scope items 1 and 5 of #46.

Items arrive as an **estate**, not one at a time. Everything under one sale directory shares a source, a decade and an environment — but that fact lived only in your head, so every stage re-derived (or failed to derive) the same background per item. The worst case was never the blank; it was a stage filling the blank optimistically because a book happened to look clean.

`lib/dir_context.py` walks `inventory/` down to an item dir, merges every `context.txt` nearest-wins, and returns the struct, the raw prose, and a derived list of claims the estate **forbids**.

```
python -m lib.dir_context inventory/ESTATES/FR/books/northern-summer
python -m lib.dir_context --sweep
```

## Design points

- **Prose is the payload**; `key: value` lines are the part tools read without guessing. The key regex is deliberately narrow (one lowercase word) so a prose line ending in a colon — `"Items that I've purchased from my neighbors:"` — stays prose.
- **Blocks are derived, not hand-listed.** FR's `smoker` + `attic … unclimatized` yields *smoke-free* and *climate-controlled*.
- **Negation is honoured.** FR does **not** block *pet-free*, because "No pets in the house" is an assertion, not a hazard. Blocking it would have cost a true selling point.
- **Background, never a claim upgrade** — it can forbid an assertion or supply a disclosure, never make a marble German. Same rail the specializations carry.
- **Absent file = today's behavior**, exactly.

## Verification

- `--sweep`: **143 drafts** sit under a blocking estate, **0 contradictions**. The detector was checked against a synthetic `"smoke-free home, climate controlled"` string and fires on both, so the zero is a real result rather than a dead code path.
- Cascade re-verified after the ESTATES re-org at depth 4.
- 292 passed (`python -m pytest tests/`).

## Not included

Wiring into IDENTIFY / PRICE / DRAFT / REVIEW (#46 items 2–4). `brief()` is the paste-ready entry point for that work.

Known follow-ups on the data side, not the code: `THRIFT/context.txt` sits one level too deep at `THRIFT/goodwill/`, and `GARAGE-SALES/context.txt` is missing a trailing newline and its spend figure.