### PR TITLE
chore: gitignore Claude Code agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ venv/
 Thumbs.db
 desktop.ini
 
+# Claude Code agent tooling — isolated git worktrees for background subagents.
+/.claude/worktrees/
+
 # Historical business working data that predates the /inventory/ convention.
 # Removed from tracking 2026-08-15: real listing drafts, prices, eBay draft ids,
 # and the seller ZIP. Kept on disk; not for a public repo.


### PR DESCRIPTION
## Summary

- Background subagents launched with worktree isolation check out a full copy of the repo under `.claude/worktrees/<agent-id>/` while they work. That directory was untracked but not ignored, so a local repo-hygiene hook flagged it as uncommitted changes needing attention.
- Added `/.claude/worktrees/` to `.gitignore` so this transient, agent-managed checkout is never mistaken for repo content.

## Test plan

- [x] `git status` is clean of the worktree directory after the change
- N/A — no code paths affected, gitignore-only change

---
_Generated by [Claude Code](https://claude.ai/code/session_019dDG3NsmrnyQihvu5ivwSw)_