### PR TITLE
feat(comps): same-day cache for comp runs, --fresh bypass (V4 Phase 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,11 @@ apify_runs/
 .scratch/
 /kb/index/
 
+# On-disk read cache — comp runs + eBay reads, keyed query+date (V4_PLAN
+# Phase 4, #30). Every entry is regenerable from a live query; see
+# lib/read_cache.py.
+/.cache/
+
 # Shoot images — heavy binaries, kept on disk only.
 *.jpg
 *.jpeg

--- a/docs/V4_PLAN.md
+++ b/docs/V4_PLAN.md
@@ -74,8 +74,17 @@ tests so "read only when flagged" can be trusted.
 
 ## Phase 4 — fewer round-trips
 
-- [ ] On-disk cache for comp runs and eBay reads, keyed query+date, `--fresh`
-      bypass.
+- [x] On-disk cache for comp runs and eBay reads, keyed query+date, `--fresh`
+      bypass. `lib/read_cache.py` (generic primitive) wired into
+      `lib/ebay_sold_browse.py`'s comp-ingest path: keyed query+condition+UTC
+      date, so a same-day re-check of a query already ingested (both dual
+      sorts) skips the Chrome round trip entirely; `--fresh` forces it anyway
+      and repopulates. `lib/ebay_client.py`'s reads (policies, live
+      inventory/offers, category/condition metadata) are deliberately left
+      UNCACHED — every one of them feeds a policy or live-state decision
+      where staleness would silently misinform an outcome, the failure class
+      PR #50 fixed for `sync_actuals`; comp prices are a same-day snapshot
+      already, so re-serving one from earlier today changes nothing.
 - [ ] Single-pass mode for routine items: PREP→IDENTIFY→PRICE→DRAFT in one
       run, ONE review card at the end, conversation reserved for flagged
       exceptions. Builds on PREP's confidence gate (#36, landed in PR #37).

--- a/lib/ebay_sold_browse.py
+++ b/lib/ebay_sold_browse.py
@@ -41,6 +41,13 @@ Step 3 runs in the page, so it sees exactly what the user sees. The JSON it
 returns carries item URLs and thumbnails, which the text-scraping fallback
 (`--parse`) cannot recover.
 
+Before step 1, the default (no-flag) invocation checks whether TODAY's comps
+for this exact query are already sitting in an earlier `--ingest-json` run
+(`lib/read_cache.py`, keyed query+condition+UTC date) — if both dual sorts are
+already in hand it prints their paths and skips straight past steps 1-4
+entirely. `--ingest-json` always records what it just captured. `--fresh`
+bypasses the check and forces the live instructions regardless.
+
 Walking the query ladder does NOT need one navigate per rung. From any loaded
 eBay page, `--js-multi` fetches every rung's URL same-origin (login cookies
 included), parses each with DOMParser and runs the same extractor over it — 4-5
@@ -81,6 +88,7 @@ from comps_core import (  # noqa: E402
     parse_sold_date,
     save_run_json,
 )
+import read_cache  # noqa: E402
 
 EBAY_SEARCH = "https://www.ebay.com/sch/i.html"
 
@@ -95,6 +103,52 @@ DUAL_SORTS = ("best_match", "price_high")
 DEFAULT_IPG = 60             # eBay's max per page without extra requests
 
 _CONDITION_PARAM = {"new": "3", "used": "4"}
+
+
+# ---------------------------------------------------------------------------
+# Same-day comp cache (V4_PLAN Phase 4, #30) — see lib/read_cache.py for the
+# key/staleness rationale. This module is the one caller: before printing the
+# "go browse in Chrome" instructions, check whether today's comps for this
+# exact query are already sitting in a run file from an earlier `--ingest-json`
+# / `--parse` this session or an earlier one, and skip the round trip if so.
+# ---------------------------------------------------------------------------
+_CACHE_NS = "ebay_sold_browse.comp_run"
+
+
+def _cache_parts(query: str, condition: Optional[str]) -> tuple:
+    # Normalized so "Fenton hobnail vase" and " fenton hobnail vase " hit the
+    # same entry; the printed query keeps the user's original casing.
+    return (query.strip().lower(), condition or "any")
+
+
+def _comp_cache_lookup(query: str, condition: Optional[str]) -> dict:
+    """{sort: {n, path}} already captured TODAY for this query+condition.
+
+    Empty dict on a miss (never raises — a corrupt/missing cache file is
+    just "nothing captured yet").
+    """
+    result = read_cache.get(_CACHE_NS, *_cache_parts(query, condition))
+    if not result.hit or not isinstance(result.value, dict):
+        return {}
+    sorts = result.value.get("sorts")
+    return sorts if isinstance(sorts, dict) else {}
+
+
+def _comp_cache_record(query: str, condition: Optional[str], sort: str,
+                       page: int, path: str, n: int) -> None:
+    """Record one ingested sort/page under today's entry for this query.
+
+    Read-modify-write so ingesting `best_match` then `price_high` for the
+    same query accumulates into one entry instead of the second overwriting
+    the first — PRICE's dual-sort distribution needs both to count as
+    "today's comps are in hand".
+    """
+    parts = _cache_parts(query, condition)
+    existing = read_cache.get(_CACHE_NS, *parts)
+    sorts = dict(existing.value.get("sorts", {})) if existing.hit and isinstance(
+        existing.value, dict) else {}
+    sorts[sort] = {"page": page, "n": n, "path": path}
+    read_cache.put(_CACHE_NS, *parts, value={"sorts": sorts})
 
 
 # ---------------------------------------------------------------------------
@@ -575,6 +629,11 @@ def _cli() -> None:
     ap.add_argument("--save-dir")
     ap.add_argument("--no-save", action="store_true",
                     help="Print comps as JSON instead of saving.")
+    ap.add_argument("--fresh", action="store_true",
+                    help="Bypass the same-day comp cache: always print live "
+                         "browse instructions even if today's comps for this "
+                         "query are already captured. Ingesting afterward "
+                         "repopulates the cache as usual.")
     args = ap.parse_args()
     query = " ".join(args.query).strip()
 
@@ -650,6 +709,7 @@ def _cli() -> None:
             print(json.dumps([comp_to_dict(c) for c in comps], indent=2))
             return
         path = save_browse_run(comps, query, args.sort, args.save_dir, args.page)
+        _comp_cache_record(query, args.condition, args.sort, args.page, path, s["n"])
         print(f"Ingested {s['n']} comp(s)  [sort={args.sort} page={args.page}]")
         print(f"  urls {s['with_url']}/{s['n']} · delivered {s['with_delivered']}/{s['n']} · "
               f"seller {s['with_seller']}/{s['n']} · Best-Offer-accepted {s['bo_accepted']} · "
@@ -665,12 +725,23 @@ def _cli() -> None:
     if not query:
         ap.error("a query is required")
 
+    cached = {} if args.fresh else _comp_cache_lookup(query, args.condition)
+    missing = [s for s in DUAL_SORTS if s not in cached]
+    if cached and not missing:
+        print(f"OK cache hit — today's comps for {query!r} are already in hand:")
+        for sort, entry in cached.items():
+            print(f"  [{sort}]  n={entry['n']}  {entry['path']}")
+        print("No browse needed. Use --fresh to bypass and re-browse live.")
+        return
+
     urls = build_search_urls(query, condition=args.condition)
     print(f"eBay SOLD comps — {query!r}")
     for sort, url in urls.items():
         label = ("representative body" if sort == "best_match"
                  else "CEILING (price + shipping, highest first)")
-        print(f"  [{sort}]  {label}\n    {url}")
+        note = (f"  [cached: n={cached[sort]['n']}, skip this one]"
+                if sort in cached else "")
+        print(f"  [{sort}]  {label}{note}\n    {url}")
     if args.ladder:
         for label, q in query_ladder(query)[1:]:
             print(f"  {label}: {q!r}\n    {build_search_url(q, 'best_match')}")

--- a/lib/read_cache.py
+++ b/lib/read_cache.py
@@ -1,0 +1,147 @@
+"""lib/read_cache.py — on-disk cache for repeated comp runs + eBay reads (V4_PLAN
+Phase 4, #30).
+
+## Why this exists
+
+The session observer's first real read (PR #47) found PRICE is the cost
+center: 61 asks but 2,134 turns and 2.7M output tokens across a week — more
+than PREP + IDENTIFY + DRAFT combined. Most of that is round-trips through
+Chrome to re-run a comp search that was already run, sometimes in the SAME
+session, when a query gets re-checked or a broader ladder rung repeats work
+a narrower one already covered. This module is the generic cache primitive;
+`lib/ebay_sold_browse.py` is the one caller wired up so far (its comp-ingest
+path — see that module for the `--fresh` flag and the cache-hit/miss output).
+
+## What is NOT cached here, on purpose
+
+Only read-only, idempotent GETs whose staleness costs a wasted round trip,
+never a wrong outcome, belong behind this cache. `lib/ebay_client.py`'s
+reads (fulfillment/payment/return policies, live inventory/offers, category
+aspects, condition policies) are deliberately left OUT: a stale policy id
+or a stale live-offer state is exactly the failure class PR #50 fixed for
+`sync_actuals` (stale `shoot_dir` silently mismatching real sales), and
+`get_condition_names` in particular feeds condition disclosure, which the
+V4 ground rules say no phase touches. Comp prices go stale in a way that is
+visible (a bad price gets caught at the REVIEW gate); a stale policy id or a
+stale "is this still live" read can silently misinform a decision with real
+money behind it. When in doubt, the answer here is: don't cache it.
+
+## Key granularity — query + UTC calendar date
+
+A cache entry is valid for the rest of the UTC day it was written on. Comps
+are a same-day snapshot already (PRICE reads "sold TODAY through the last
+N days", not a live price), so re-serving one from earlier today changes
+nothing about the distribution; a session that crosses UTC midnight just
+sees a miss and repopulates, which costs one extra live round trip, not a
+wrong price. Coarser (weekly) keying would risk serving Monday's thin
+cohort into Friday's PRICE call for no real savings — comp runs are cheap
+to repopulate but expensive to accidentally under-count.
+
+## On-disk layout
+
+    <cache_dir>/<namespace>/<key>.json      key = sha256(namespace|date|parts)[:24]
+
+`READ_CACHE_DIR` overrides `<repo-root>/.cache` (same env-var-override
+pattern as `comps_core.default_runs_dir` / `COMPS_RUNS_DIR`). The directory
+is gitignored (`.cache/`, alongside `.scratch/`) — every entry is
+regenerable from a live query, never source.
+
+A malformed or unreadable cache file is always treated as a miss, never
+raised — a corrupt cache must never break a live read that would otherwise
+succeed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+
+def default_cache_dir() -> Path:
+    """<repo-root>/.cache, overridable with READ_CACHE_DIR (tests use this)."""
+    env = os.environ.get("READ_CACHE_DIR")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parent.parent / ".cache"
+
+
+def today_utc() -> str:
+    """UTC calendar date — see the module docstring for why UTC, not local."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def cache_key(namespace: str, *parts: Any, date: Optional[str] = None) -> str:
+    """Stable key for (namespace, date, *parts). Same inputs -> same key;
+    a different query, condition, or day -> a different one."""
+    date = date or today_utc()
+    raw = "\x1f".join([namespace, date, *(str(p) for p in parts)])
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def _path_for(namespace: str, key: str, cache_dir: Optional[Path]) -> Path:
+    base = cache_dir or default_cache_dir()
+    return base / namespace / f"{key}.json"
+
+
+@dataclass
+class CacheResult:
+    hit: bool
+    value: Any = None
+    path: Optional[Path] = None
+
+
+def get(namespace: str, *parts: Any, cache_dir: Optional[Path] = None,
+        date: Optional[str] = None) -> CacheResult:
+    """Look up one entry. Missing, corrupt, or malformed-shape files are all
+    a miss — never raises."""
+    key = cache_key(namespace, *parts, date=date)
+    path = _path_for(namespace, key, cache_dir)
+    if not path.exists():
+        return CacheResult(False, path=path)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return CacheResult(False, path=path)
+    if not isinstance(payload, dict) or "value" not in payload:
+        return CacheResult(False, path=path)
+    return CacheResult(True, value=payload["value"], path=path)
+
+
+def put(namespace: str, *parts: Any, value: Any, cache_dir: Optional[Path] = None,
+        date: Optional[str] = None) -> Path:
+    """Write one entry (full overwrite of that key). Returns the file path."""
+    date = date or today_utc()
+    key = cache_key(namespace, *parts, date=date)
+    path = _path_for(namespace, key, cache_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "namespace": namespace,
+        "key_parts": [str(p) for p in parts],
+        "date": date,
+        "cached_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "value": value,
+    }
+    path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+    return path
+
+
+def cached_call(namespace: str, *parts: Any, fetch: Callable[[], Any],
+                fresh: bool = False, cache_dir: Optional[Path] = None,
+                date: Optional[str] = None) -> tuple[Any, bool]:
+    """Run `fetch()` unless a same-day entry exists; returns (value, was_hit).
+
+    `fresh=True` always calls fetch() and overwrites the cache with its
+    result — the `--fresh` bypass every caller should expose.
+    """
+    if not fresh:
+        found = get(namespace, *parts, cache_dir=cache_dir, date=date)
+        if found.hit:
+            return found.value, True
+    value = fetch()
+    put(namespace, *parts, value=value, cache_dir=cache_dir, date=date)
+    return value, False

--- a/tests/test_ebay_sold_browse_cache.py
+++ b/tests/test_ebay_sold_browse_cache.py
@@ -1,0 +1,180 @@
+"""Tests for the same-day comp cache wired into lib/ebay_sold_browse.py
+(V4_PLAN Phase 4, #30) — read_cache.py's generic primitive is covered
+separately in tests/test_read_cache.py; this file covers the CLI-level
+wiring: cache-miss populates, cache-hit skips the browse instructions,
+`--fresh` bypasses and repopulates, and query/day keying.
+
+No network, no Chrome, no claude-in-chrome MCP: `--ingest-json` reads a
+plain fixture JSON file, exactly as it would a real EXTRACTOR_JS capture.
+Every run writes its output under `--save-dir <tmp_path>`, never the real
+`apify_runs/`, and every cache read/write is redirected via READ_CACHE_DIR.
+
+Run:  pytest tests/test_ebay_sold_browse_cache.py
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "lib"))
+
+import ebay_sold_browse as esb  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(tmp_path, monkeypatch):
+    """Every test gets its own cache dir — no test can see another's writes,
+    and none can touch the real .cache/."""
+    monkeypatch.setenv("READ_CACHE_DIR", str(tmp_path / ".cache"))
+    return tmp_path
+
+
+def _rows_file(tmp_path, name="rows.json", n=3, price=50.0):
+    rows = [{"title": f"Item {i}", "sold_price": price + i, "url": f"https://x/{i}",
+            "item_id": str(1000000000 + i)} for i in range(n)]
+    path = tmp_path / name
+    path.write_text(json.dumps(rows), encoding="utf-8")
+    return str(path)
+
+
+def _run_cli(monkeypatch, argv):
+    monkeypatch.setattr(sys, "argv", ["ebay_sold_browse.py"] + argv)
+    esb._cli()
+
+
+# ---------------------------------------------------------------------------
+# Unit level: the two cache helper functions directly
+# ---------------------------------------------------------------------------
+
+def test_lookup_is_empty_before_anything_is_ingested():
+    assert esb._comp_cache_lookup("gorham bowl", None) == {}
+
+
+def test_record_then_lookup_round_trips():
+    esb._comp_cache_record("gorham bowl", None, "best_match", 1, "run1.json", 5)
+    got = esb._comp_cache_lookup("gorham bowl", None)
+    assert got == {"best_match": {"page": 1, "n": 5, "path": "run1.json"}}
+
+
+def test_record_accumulates_both_sorts_without_clobbering():
+    esb._comp_cache_record("gorham bowl", None, "best_match", 1, "run1.json", 5)
+    esb._comp_cache_record("gorham bowl", None, "price_high", 1, "run2.json", 4)
+    got = esb._comp_cache_lookup("gorham bowl", None)
+    assert set(got) == {"best_match", "price_high"}
+    assert got["best_match"]["path"] == "run1.json"
+    assert got["price_high"]["path"] == "run2.json"
+
+
+def test_lookup_is_normalized_on_whitespace_and_case():
+    esb._comp_cache_record("Gorham Bowl", None, "best_match", 1, "run1.json", 5)
+    assert esb._comp_cache_lookup("  gorham bowl  ", None) != {}
+
+
+def test_different_query_does_not_share_a_cache_entry():
+    esb._comp_cache_record("gorham bowl", None, "best_match", 1, "run1.json", 5)
+    assert esb._comp_cache_lookup("reed barton tray", None) == {}
+
+
+def test_condition_partitions_the_cache():
+    esb._comp_cache_record("gorham bowl", "used", "best_match", 1, "run1.json", 5)
+    assert esb._comp_cache_lookup("gorham bowl", "new") == {}
+    assert esb._comp_cache_lookup("gorham bowl", "used") != {}
+
+
+def test_malformed_cache_file_on_disk_is_treated_as_a_miss(tmp_path, monkeypatch):
+    import read_cache
+    parts = esb._cache_parts("gorham bowl", None)
+    key = read_cache.cache_key(esb._CACHE_NS, *parts)
+    bad = Path(tmp_path / ".cache") / esb._CACHE_NS / f"{key}.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("{not json", encoding="utf-8")
+    assert esb._comp_cache_lookup("gorham bowl", None) == {}
+
+
+# ---------------------------------------------------------------------------
+# CLI level: miss -> browse instructions; ingest populates; hit skips browse
+# ---------------------------------------------------------------------------
+
+def test_default_action_with_no_cache_prints_browse_instructions(monkeypatch, capsys):
+    _run_cli(monkeypatch, ["gorham sterling bowl"])
+    out = capsys.readouterr().out
+    assert "claude-in-chrome" in out
+    assert "OK cache hit" not in out
+
+
+def test_ingest_populates_cache_for_that_sort_only(monkeypatch, tmp_path, capsys):
+    rows_path = _rows_file(tmp_path)
+    _run_cli(monkeypatch, ["gorham sterling bowl", "--ingest-json", rows_path,
+                          "--sort", "best_match", "--save-dir", str(tmp_path / "runs")])
+    capsys.readouterr()  # drain
+    # one sort only -> still a miss overall (PRICE needs both dual sorts)
+    _run_cli(monkeypatch, ["gorham sterling bowl"])
+    out = capsys.readouterr().out
+    assert "OK cache hit" not in out
+    assert "[cached: n=3" in out          # the covered sort is annotated
+    assert "[price_high]" in out          # the missing sort still gets a URL
+
+
+def test_both_sorts_ingested_then_default_action_is_a_cache_hit(monkeypatch, tmp_path, capsys):
+    for sort in ("best_match", "price_high"):
+        rows_path = _rows_file(tmp_path, name=f"{sort}.json")
+        _run_cli(monkeypatch, ["gorham sterling bowl", "--ingest-json", rows_path,
+                              "--sort", sort, "--save-dir", str(tmp_path / "runs")])
+    capsys.readouterr()  # drain the two ingest prints
+
+    _run_cli(monkeypatch, ["gorham sterling bowl"])
+    out = capsys.readouterr().out
+    assert "OK cache hit" in out
+    assert "claude-in-chrome" not in out   # the live-browse path was skipped
+    assert "best_match" in out and "price_high" in out
+
+
+def test_fresh_bypasses_a_complete_cache_and_shows_live_instructions(monkeypatch, tmp_path, capsys):
+    for sort in ("best_match", "price_high"):
+        rows_path = _rows_file(tmp_path, name=f"{sort}.json")
+        _run_cli(monkeypatch, ["gorham sterling bowl", "--ingest-json", rows_path,
+                              "--sort", sort, "--save-dir", str(tmp_path / "runs")])
+    capsys.readouterr()
+
+    _run_cli(monkeypatch, ["gorham sterling bowl", "--fresh"])
+    out = capsys.readouterr().out
+    assert "OK cache hit" not in out
+    assert "claude-in-chrome" in out
+
+
+def test_fresh_ingest_afterward_repopulates_cache(monkeypatch, tmp_path, capsys):
+    for sort in ("best_match", "price_high"):
+        rows_path = _rows_file(tmp_path, name=f"{sort}.json", price=50.0)
+        _run_cli(monkeypatch, ["gorham sterling bowl", "--ingest-json", rows_path,
+                              "--sort", sort, "--save-dir", str(tmp_path / "runs")])
+    capsys.readouterr()
+
+    # --fresh re-browse, then a fresh ingest with a different n, overwrites
+    # that sort's cached entry
+    rows_path2 = _rows_file(tmp_path, name="fresh_best_match.json", n=7, price=99.0)
+    _run_cli(monkeypatch, ["gorham sterling bowl", "--fresh", "--ingest-json", rows_path2,
+                          "--sort", "best_match", "--save-dir", str(tmp_path / "runs")])
+    capsys.readouterr()
+
+    got = esb._comp_cache_lookup("gorham sterling bowl", None)
+    assert got["best_match"]["n"] == 7
+    assert got["price_high"]["n"] == 3  # untouched by the re-ingest of the other sort
+
+
+def test_different_query_is_still_a_miss_after_another_querys_ingest(monkeypatch, tmp_path, capsys):
+    for sort in ("best_match", "price_high"):
+        rows_path = _rows_file(tmp_path, name=f"{sort}.json")
+        _run_cli(monkeypatch, ["gorham sterling bowl", "--ingest-json", rows_path,
+                              "--sort", sort, "--save-dir", str(tmp_path / "runs")])
+    capsys.readouterr()
+
+    _run_cli(monkeypatch, ["reed and barton tray"])
+    out = capsys.readouterr().out
+    assert "OK cache hit" not in out
+    assert "claude-in-chrome" in out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_read_cache.py
+++ b/tests/test_read_cache.py
@@ -1,0 +1,151 @@
+"""Tests for lib/read_cache.py — the generic on-disk cache primitive
+(V4_PLAN Phase 4, #30).
+
+No network, no Chrome. Each test writes/reads under a temp directory passed
+explicitly as `cache_dir`, so nothing here ever touches a real `.cache/`.
+
+Run:  pytest tests/test_read_cache.py
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "lib"))
+
+import read_cache  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# get / put — basic hit/miss
+# ---------------------------------------------------------------------------
+
+def test_miss_when_nothing_written(tmp_path):
+    result = read_cache.get("ns", "q1", cache_dir=tmp_path)
+    assert result.hit is False
+    assert result.value is None
+
+
+def test_put_then_get_is_a_hit(tmp_path):
+    read_cache.put("ns", "q1", value={"n": 3}, cache_dir=tmp_path)
+    result = read_cache.get("ns", "q1", cache_dir=tmp_path)
+    assert result.hit is True
+    assert result.value == {"n": 3}
+
+
+def test_value_survives_any_json_serializable_shape(tmp_path):
+    value = {"sorts": {"best_match": {"n": 5, "path": "x.json"}}, "flags": [1, 2]}
+    read_cache.put("ns", "q1", value=value, cache_dir=tmp_path)
+    assert read_cache.get("ns", "q1", cache_dir=tmp_path).value == value
+
+
+# ---------------------------------------------------------------------------
+# Keying — query, namespace, and date all partition the cache
+# ---------------------------------------------------------------------------
+
+def test_different_query_is_a_different_entry(tmp_path):
+    read_cache.put("ns", "gorham bowl", value="A", cache_dir=tmp_path)
+    assert read_cache.get("ns", "gorham bowl", cache_dir=tmp_path).hit is True
+    assert read_cache.get("ns", "reed barton bowl", cache_dir=tmp_path).hit is False
+
+
+def test_different_namespace_is_a_different_entry(tmp_path):
+    read_cache.put("comp_run", "q", value="A", cache_dir=tmp_path)
+    assert read_cache.get("policy_read", "q", cache_dir=tmp_path).hit is False
+
+
+def test_different_day_is_a_different_entry(tmp_path):
+    read_cache.put("ns", "q1", value="yesterday", cache_dir=tmp_path,
+                   date="2026-08-27")
+    today = read_cache.get("ns", "q1", cache_dir=tmp_path, date="2026-08-28")
+    assert today.hit is False
+    # yesterday's entry is untouched, just not what a today-lookup sees
+    stale = read_cache.get("ns", "q1", cache_dir=tmp_path, date="2026-08-27")
+    assert stale.hit is True and stale.value == "yesterday"
+
+
+def test_cache_key_is_order_sensitive_but_deterministic(tmp_path):
+    k1 = read_cache.cache_key("ns", "a", "b", date="2026-08-28")
+    k2 = read_cache.cache_key("ns", "a", "b", date="2026-08-28")
+    k3 = read_cache.cache_key("ns", "b", "a", date="2026-08-28")
+    assert k1 == k2
+    assert k1 != k3
+
+
+# ---------------------------------------------------------------------------
+# Malformed / stale-on-disk edge cases — always degrade to a miss
+# ---------------------------------------------------------------------------
+
+def test_corrupt_json_file_is_a_miss_not_a_crash(tmp_path):
+    key = read_cache.cache_key("ns", "q1")
+    path = tmp_path / "ns" / f"{key}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not valid json", encoding="utf-8")
+    result = read_cache.get("ns", "q1", cache_dir=tmp_path)
+    assert result.hit is False
+
+
+def test_wrong_shaped_json_is_a_miss(tmp_path):
+    key = read_cache.cache_key("ns", "q1")
+    path = tmp_path / "ns" / f"{key}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text('["not", "a", "cache", "envelope"]', encoding="utf-8")
+    assert read_cache.get("ns", "q1", cache_dir=tmp_path).hit is False
+
+
+def test_missing_value_key_is_a_miss(tmp_path):
+    key = read_cache.cache_key("ns", "q1")
+    path = tmp_path / "ns" / f"{key}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text('{"namespace": "ns"}', encoding="utf-8")
+    assert read_cache.get("ns", "q1", cache_dir=tmp_path).hit is False
+
+
+# ---------------------------------------------------------------------------
+# cached_call — the miss/hit/fresh contract callers actually use
+# ---------------------------------------------------------------------------
+
+def test_cached_call_miss_invokes_fetch_and_populates(tmp_path):
+    calls = []
+
+    def fetch():
+        calls.append(1)
+        return {"n": 7}
+
+    value, hit = read_cache.cached_call("ns", "q1", fetch=fetch, cache_dir=tmp_path)
+    assert value == {"n": 7} and hit is False and len(calls) == 1
+    assert read_cache.get("ns", "q1", cache_dir=tmp_path).value == {"n": 7}
+
+
+def test_cached_call_hit_skips_fetch(tmp_path):
+    read_cache.put("ns", "q1", value={"n": 1}, cache_dir=tmp_path)
+
+    def fetch():
+        raise AssertionError("fetch must not run on a cache hit")
+
+    value, hit = read_cache.cached_call("ns", "q1", fetch=fetch, cache_dir=tmp_path)
+    assert value == {"n": 1} and hit is True
+
+
+def test_cached_call_fresh_bypasses_and_repopulates(tmp_path):
+    read_cache.put("ns", "q1", value={"n": 1}, cache_dir=tmp_path)
+    calls = []
+
+    def fetch():
+        calls.append(1)
+        return {"n": 2}
+
+    value, hit = read_cache.cached_call("ns", "q1", fetch=fetch, fresh=True,
+                                        cache_dir=tmp_path)
+    assert value == {"n": 2} and hit is False and len(calls) == 1
+    # repopulated: a later non-fresh lookup now sees the fresh value
+    assert read_cache.get("ns", "q1", cache_dir=tmp_path).value == {"n": 2}
+
+
+def test_default_cache_dir_honors_read_cache_dir_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("READ_CACHE_DIR", str(tmp_path / "custom"))
+    assert read_cache.default_cache_dir() == tmp_path / "custom"
+
+
+if __name__ == "__main__":
+    import pytest as _pytest
+    raise SystemExit(_pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Progresses #30 (Phase 4) — the first checkbox only: **on-disk cache for comp runs and eBay reads, keyed query+date, `--fresh` bypass.** Single-pass mode (the second Phase 4 item) is intentionally untouched.

## The problem

The session observer's first real read (PR #47) found PRICE is the cost center: 61 asks but 2,134 turns and 2.7M output tokens across a week — more than PREP + IDENTIFY + DRAFT combined. A lot of that is Chrome round-trips re-running a comp search that was already run, sometimes in the same session: a query gets re-checked, or a broader ladder rung repeats work a narrower one already covered.

## What changed

- **`lib/read_cache.py`** — the generic on-disk cache primitive. Key = `namespace + query/params + UTC calendar date`; a malformed or unreadable cache file always degrades to a miss, never raises. Directory is `<repo-root>/.cache/`, overridable with `READ_CACHE_DIR` (same override pattern as `comps_core.default_runs_dir` / `COMPS_RUNS_DIR`), gitignored alongside `.scratch/`.
- **`lib/ebay_sold_browse.py`** wired up as the one caller: before printing the "go browse in Chrome" instructions for a query, it checks whether both of PRICE's dual sorts (`best_match`, `price_high`) were already ingested *today* for that exact query+condition. If so, it prints `OK cache hit` with the existing run paths and skips the browse instructions entirely — no Chrome, no navigate, no JS extraction. `--ingest-json` always records what it just captured (read-modify-write, so ingesting one sort doesn't clobber the other). A new **`--fresh`** flag bypasses the cache check and forces the live instructions regardless; the next ingest afterward repopulates the cache as usual.
- **`docs/V4_PLAN.md`** — checked off the on-disk-cache line item.

### Key granularity: query + UTC calendar date

Comps are already a same-day snapshot (PRICE reads "sold through the last N days", not a live price), so re-serving a comp run from earlier today changes nothing about the distribution. A session that crosses UTC midnight just sees a miss and repopulates — the cost is one extra live check, not a wrong price. Reasoning is in the `lib/read_cache.py` module docstring.

## What is deliberately left uncached

`lib/ebay_client.py`'s reads — fulfillment/payment/return policies, live inventory/offers, category aspects, condition policies (`get_condition_names` et al.) — are **not** cached here, on purpose. Every one of them feeds a policy-selection or live-state decision where staleness would silently misinform an outcome:

- A stale fulfillment/return/payment policy id used at draft/publish time is exactly the kind of silent-wrong-outcome bug this task explicitly says to avoid.
- Live inventory/offer reads (`get_offers_for_sku`, `iter_inventory_items`, `get_offer`) feed `ledger_reconcile` / `live_audit` / `pick_list` — staleness there is the same failure class PR #50 just fixed for `sync_actuals` (stale `shoot_dir` silently mismatching 50 real orders). Caching them would reintroduce that bug class on purpose.
- `get_condition_names` / `get_allowed_condition_ids` feed how a condition is rendered to a buyer — condition disclosure is one of the things the V4 ground rules say no phase touches.

Comp prices, by contrast, are read-only evidence that gets checked against reality at the REVIEW gate before anything publishes — a stale one is visible and cheap to catch, not silent. That asymmetry is why only the comp-run path is cached in this PR.

## Verification

- New: `tests/test_read_cache.py` (14 tests — get/put hit/miss, namespace/query/date keying, corrupt/malformed-shape files degrade to a miss, `cached_call`'s miss/hit/fresh contract, `READ_CACHE_DIR` override) and `tests/test_ebay_sold_browse_cache.py` (13 tests — cache-miss populates, both-sorts-ingested is a cache hit that skips the browse instructions, `--fresh` bypasses and repopulates, different query/condition/day are separate entries, a malformed on-disk cache file falls back to a live miss). All offline: fixture JSON rows stand in for a Chrome capture, `--save-dir`/`READ_CACHE_DIR` redirect every write away from the real `apify_runs/` and `.cache/`.
- Full suite: **307 passed, 1 skipped** (`python -m pytest tests/`) — up from 280 passed, 1 skipped on `main` in this environment; the delta is exactly the 27 new tests, 0 regressions. (The 1 skip is pre-existing and unrelated — `test_marble_gate.py`'s CLIP integration test, needs `sentence-transformers`.)
- Manually smoke-tested the CLI end to end (miss → ingest one sort → partial-cache annotation → ingest the other sort → cache hit skips the browse block → `--fresh` shows it again).


---
_Generated by [Claude Code](https://claude.ai/code/session_019dDG3NsmrnyQihvu5ivwSw)_