### PR TITLE
chore: gitignore Claude Code agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,7 @@ desktop.ini
 
 # local working backups (ledger/sales/config) — never committed
 backups/
+
+# Claude Code agent worktrees — transient checkouts for background subagents
+# launched with worktree isolation; never repo content.
+/.claude/worktrees/


### PR DESCRIPTION
## Summary

A background subagent launched with worktree isolation checks out a full copy of the repo under `.claude/worktrees/<agent-id>/` while it works. That directory was untracked but not ignored, so a local repo-hygiene hook flagged it as uncommitted changes needing attention (this came up while running an automated issue-triage pass that launched a background agent).

Added `/.claude/worktrees/` to `.gitignore` so this transient, agent-managed checkout is never mistaken for repo content.

## Note

Open PR #53 already makes this identical one-line change from a different session/branch. Whichever lands first makes the other a no-op — feel free to close the redundant one.

## Test plan

- [x] `git status` no longer lists the worktree directory as untracked
- N/A — gitignore-only change, no code paths affected

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJk4n46xtJLco4Pw1G8gdF)_