### PR TITLE
Bucket ROI as a first-class report (#56)

### DIFF
--- a/lib/dir_context.py
+++ b/lib/dir_context.py
@@ -1,0 +1,147 @@
+"""dir_context — the directory-level context.txt chain (#46).
+
+Items live under a source directory ("bucket") that owns a single
+context.txt: a plain-language summary of where the items came from, with a
+few `key: value` lines up front for the things tools have to branch on
+without guessing prose.
+
+Bucket = the nearest ancestor directory (inclusive) that holds a context.txt.
+That is a property of the tree, not of how many slashes are in the path, so
+a re-org changes what a bucket contains, never how one is found — the same
+reason `rglob` replaced the depth-capped globs elsewhere in this repo (#50).
+
+    from dir_context import bucket_for, context_for
+
+    bucket = bucket_for(item_dir)          # Path | None
+    ctx = context_for(item_dir)            # merged keys + prose, cascade applied
+
+`ctx["keys"]` holds whatever `key:` lines were present, nearest-directory-
+wins. The economic keys tools branch on:
+
+    kind:     "event"   a single purchase with a real cost basis — ROI is
+                        meaningful, and a missing `spend:` is a data gap.
+              "channel" an ongoing source (thrifting, curb finds, gifts) —
+                        ROI is not meaningful, and a missing `spend:` is
+                        simply correct.
+    spend:    what the bucket cost. Parse with spend_amount(), not float():
+              "FREE" -> 0.0, absent -> None. Zero and "we don't know" are
+              different facts and must not collapse into each other.
+    acquired: a free-form date/period string, returned as-is.
+
+Every other key is passed through as a plain string, unknown keys included —
+a context.txt predates every consumer that will ever read it, so an unknown
+key is not an error.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+INVENTORY = REPO / "inventory"
+CONTEXT_FILE = "context.txt"
+
+# Leading contiguous `key: value` lines are the header; the first line that
+# doesn't match ends it, and everything from there on — blank lines included
+# — is prose. The header can only grow from the top of the file down, so a
+# sentence in the prose that happens to contain a colon is never mistaken
+# for a key.
+_KEY_LINE = re.compile(r"^([a-z_]+):\s*(.*)$")
+_FREE_RE = re.compile(r"^\s*free\s*$", re.I)
+_AMOUNT_RE = re.compile(r"\$?\s*([0-9][0-9,]*(?:\.[0-9]{1,2})?)")
+
+
+def spend_amount(raw: str | None) -> float | None:
+    """Parse a `spend:` (or `cost:`) value. None means "not recorded" — never 0."""
+    if raw is None:
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    if _FREE_RE.match(s):
+        return 0.0
+    m = _AMOUNT_RE.search(s)
+    return float(m.group(1).replace(",", "")) if m else None
+
+
+def parse_context_file(path: Path) -> dict:
+    """One context.txt -> {"keys": {...}, "prose": str, "path": path}.
+
+    Tolerates the three shapes on disk: empty, prose-only, and
+    keys-then-prose.
+    """
+    text = path.read_text(encoding="utf-8", errors="replace") if path.exists() else ""
+    lines = text.splitlines()
+    keys: dict[str, str] = {}
+    i = 0
+    while i < len(lines):
+        m = _KEY_LINE.match(lines[i])
+        if not m:
+            break
+        keys[m.group(1)] = m.group(2).strip()
+        i += 1
+    prose = "\n".join(lines[i:]).strip()
+    return {"keys": keys, "prose": prose, "path": path}
+
+
+def bucket_for(item_dir: Path, root: Path = INVENTORY) -> Path | None:
+    """Nearest ancestor of item_dir (inclusive) that owns a context.txt.
+
+    None if item_dir is not under root, or no ancestor up to root has one.
+    """
+    item_dir, root = item_dir.resolve(), root.resolve()
+    try:
+        item_dir.relative_to(root)
+    except ValueError:
+        return None
+    d = item_dir
+    while True:
+        if (d / CONTEXT_FILE).exists():
+            return d
+        if d == root:
+            return None
+        d = d.parent
+
+
+def chain_for(item_dir: Path, root: Path = INVENTORY) -> list[dict]:
+    """Every context.txt from root down to item_dir, root-most first.
+
+    A sub-bucket (inventory/ESTATES/FR/books/context.txt) refines its parent
+    without restating it, so the merge in context_for() takes nearest-wins —
+    but the chain itself stays in cascade order so a caller can see who said
+    what.
+    """
+    item_dir, root = item_dir.resolve(), root.resolve()
+    try:
+        rel = item_dir.relative_to(root)
+    except ValueError:
+        return []
+    chain = []
+    d = root
+    if (d / CONTEXT_FILE).exists():
+        chain.append(parse_context_file(d / CONTEXT_FILE))
+    for part in rel.parts:
+        d = d / part
+        if (d / CONTEXT_FILE).exists():
+            chain.append(parse_context_file(d / CONTEXT_FILE))
+    return chain
+
+
+def context_for(item_dir: Path, root: Path = INVENTORY) -> dict:
+    """Merged context for item_dir: nearest-wins keys, cascaded prose."""
+    chain = chain_for(item_dir, root)
+    keys: dict[str, str] = {}
+    for c in chain:
+        keys.update(c["keys"])                 # later (nearer) wins
+    prose = "\n\n".join(c["prose"] for c in chain if c["prose"])
+    return {"keys": keys, "prose": prose, "chain": chain}
+
+
+def is_backup_dir(path: Path) -> bool:
+    """True if a path segment marks it a staging/backup copy, not real stock.
+
+    `_prepped/` and `*.prior-run-bak` copies of a shoot sit inside the tree
+    during a run and must never be counted as inventory of their own.
+    """
+    return any(part == "_prepped" or part.endswith(".prior-run-bak")
+               for part in path.parts)

--- a/tests/test_dir_context.py
+++ b/tests/test_dir_context.py
@@ -1,0 +1,166 @@
+"""dir_context — bucket resolution and context.txt parsing (#46, #56).
+
+Fixtures are built per-test under tmp_path rather than checked-in sample
+directories: context.txt carries real acquisition cost and provenance, so no
+sample of it belongs in a public repo (see .gitignore's business-data rule).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+
+import dir_context as dc                                          # noqa: E402
+
+
+def _tree(root: Path, layout: dict[str, str]) -> None:
+    """layout: {"ESTATES/FR/context.txt": "kind: event\\nspend: 575\\n"}."""
+    for rel, text in layout.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text, encoding="utf-8")
+
+
+# --------------------------------------------------------------------- parse
+
+def test_parse_empty_file(tmp_path):
+    f = tmp_path / "context.txt"
+    f.write_text("", encoding="utf-8")
+    c = dc.parse_context_file(f)
+    assert c["keys"] == {} and c["prose"] == ""
+
+
+def test_parse_missing_file(tmp_path):
+    c = dc.parse_context_file(tmp_path / "context.txt")
+    assert c["keys"] == {} and c["prose"] == ""
+
+
+def test_parse_prose_only(tmp_path):
+    f = tmp_path / "context.txt"
+    f.write_text("Picked up at a garage sale, no idea whose.", encoding="utf-8")
+    c = dc.parse_context_file(f)
+    assert c["keys"] == {}
+    assert "garage sale" in c["prose"]
+
+
+def test_parse_keys_then_prose(tmp_path):
+    f = tmp_path / "context.txt"
+    f.write_text(
+        "kind: event\nspend: 575\nacquired: 2026-07\n\n"
+        "An estate sale in Social Circle Georgia.\n",
+        encoding="utf-8")
+    c = dc.parse_context_file(f)
+    assert c["keys"] == {"kind": "event", "spend": "575", "acquired": "2026-07"}
+    assert c["prose"] == "An estate sale in Social Circle Georgia."
+
+
+def test_key_line_inside_prose_is_not_a_key(tmp_path):
+    """Once prose starts, "word: word" in a sentence stays prose."""
+    f = tmp_path / "context.txt"
+    f.write_text("kind: event\n\nCost basis: unclear, ask later.\n", encoding="utf-8")
+    c = dc.parse_context_file(f)
+    assert c["keys"] == {"kind": "event"}
+    assert "Cost basis: unclear" in c["prose"]
+
+
+# -------------------------------------------------------------- spend_amount
+
+def test_spend_amount_none_and_blank_are_unrecorded():
+    assert dc.spend_amount(None) is None
+    assert dc.spend_amount("") is None
+    assert dc.spend_amount("   ") is None
+
+
+def test_spend_amount_free_is_zero_not_unrecorded():
+    assert dc.spend_amount("FREE") == 0.0
+    assert dc.spend_amount("free") == 0.0
+
+
+def test_spend_amount_parses_dollar_and_plain():
+    assert dc.spend_amount("$575") == 575.0
+    assert dc.spend_amount("575") == 575.0
+    assert dc.spend_amount("spent $650") == 650.0
+    assert dc.spend_amount("1,169.50") == 1169.50
+
+
+def test_spend_amount_unparseable_is_none():
+    assert dc.spend_amount("a house") is None
+
+
+# ----------------------------------------------------------------- bucket_for
+
+def test_bucket_for_finds_owning_ancestor(tmp_path):
+    root = tmp_path / "inventory"
+    _tree(root, {"ESTATES/SCJ/context.txt": "kind: event\nspend: 575\n"})
+    item = root / "ESTATES/SCJ/silver/tray-1"
+    item.mkdir(parents=True)
+    assert dc.bucket_for(item, root) == root / "ESTATES/SCJ"
+
+
+def test_bucket_for_sub_lot_resolves_to_parent_bucket(tmp_path):
+    """FREE/more-mags-444 is a sub-lot inside FREE, not its own bucket."""
+    root = tmp_path / "inventory"
+    _tree(root, {"FREE/context.txt": "kind: channel\n"})
+    item = root / "FREE/more-mags-444/lot-1"
+    item.mkdir(parents=True)
+    assert dc.bucket_for(item, root) == root / "FREE"
+
+
+def test_bucket_for_nested_bucket_wins_over_ancestor(tmp_path):
+    root = tmp_path / "inventory"
+    _tree(root, {
+        "ESTATES/FR/context.txt": "kind: event\nspend: 400\n",
+        "ESTATES/FR/books/context.txt": "these were in the damp basement\n",
+    })
+    item = root / "ESTATES/FR/books/TEJ"
+    item.mkdir(parents=True)
+    assert dc.bucket_for(item, root) == root / "ESTATES/FR/books"
+
+
+def test_bucket_for_no_context_anywhere_is_none(tmp_path):
+    root = tmp_path / "inventory"
+    item = root / "MINE/whatever"
+    item.mkdir(parents=True)
+    assert dc.bucket_for(item, root) is None
+
+
+def test_bucket_for_outside_root_is_none(tmp_path):
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    assert dc.bucket_for(outside, tmp_path / "inventory") is None
+
+
+# ------------------------------------------------------------- chain/context
+
+def test_context_for_merges_nearest_wins(tmp_path):
+    root = tmp_path / "inventory"
+    _tree(root, {
+        "ESTATES/FR/context.txt": "kind: event\nspend: 400\n\nSmoker in the house.\n",
+        "ESTATES/FR/books/context.txt": "spend: 40\n\nDamp basement books.\n",
+    })
+    item = root / "ESTATES/FR/books/TEJ"
+    item.mkdir(parents=True)
+    ctx = dc.context_for(item, root)
+    # spend refined by the sub-bucket; kind inherited unchanged from the parent
+    assert ctx["keys"]["spend"] == "40"
+    assert ctx["keys"]["kind"] == "event"
+    assert "Smoker in the house." in ctx["prose"]
+    assert "Damp basement books." in ctx["prose"]
+    assert len(ctx["chain"]) == 2
+
+
+def test_context_for_no_chain_is_empty(tmp_path):
+    root = tmp_path / "inventory"
+    item = root / "MINE/whatever"
+    item.mkdir(parents=True)
+    ctx = dc.context_for(item, root)
+    assert ctx["keys"] == {} and ctx["prose"] == "" and ctx["chain"] == []
+
+
+# ------------------------------------------------------------- is_backup_dir
+
+def test_is_backup_dir():
+    assert dc.is_backup_dir(Path("inventory/ESTATES/FR/_prepped/item"))
+    assert dc.is_backup_dir(Path("inventory/ESTATES/FR/2026-08-01.prior-run-bak/item"))
+    assert not dc.is_backup_dir(Path("inventory/ESTATES/FR/books/TEJ"))

--- a/tests/test_sales_report_by_source.py
+++ b/tests/test_sales_report_by_source.py
@@ -1,0 +1,140 @@
+"""sales_report — bucket ROI panel (#56).
+
+`by_source()` is the whole point of the issue: cost basis and ROI per
+context.txt-owned bucket, not per however-many-slashes-are-in-the-path. No
+network, no real ledger — everything is built under tmp_path so it never
+touches the gitignored business-data files this repo keeps locally.
+"""
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+
+import dir_context as dc                                          # noqa: E402
+import sales_report as sr                                         # noqa: E402
+
+
+def _row(shoot: str, gross: float, net: float) -> dict:
+    return {"shoot": shoot, "gross": gross, "net": net}
+
+
+def _inventory(tmp_path: Path) -> Path:
+    root = tmp_path / "inventory"
+    (root / "ESTATES/SCJ").mkdir(parents=True)
+    (root / "ESTATES/SCJ/context.txt").write_text("kind: event\nspend: 575\n",
+                                                   encoding="utf-8")
+    (root / "ESTATES/MAR").mkdir(parents=True)
+    (root / "ESTATES/MAR/context.txt").write_text("kind: event\n", encoding="utf-8")
+    (root / "FREE").mkdir(parents=True)
+    (root / "FREE/context.txt").write_text("kind: channel\n", encoding="utf-8")
+    (root / "ESTATES/GIFT").mkdir(parents=True)
+    (root / "ESTATES/GIFT/context.txt").write_text("kind: event\nspend: FREE\n",
+                                                    encoding="utf-8")
+    return root
+
+
+def test_by_source_computes_cost_profit_roi(tmp_path, monkeypatch):
+    monkeypatch.setattr(sr, "REPO", tmp_path)
+    monkeypatch.setattr(dc, "INVENTORY", _inventory(tmp_path))
+
+    rows = [
+        _row("inventory/ESTATES/SCJ/silver/tray-1", 200, 180),
+        _row("inventory/ESTATES/SCJ/silver/tray-2", 100, 90),
+        _row("inventory/FREE/more-mags-444/lot-1", 50, 45),
+        _row("inventory/ESTATES/MAR/item-1", 80, 70),
+        _row("", 30, 25),
+        _row("inventory/ESTATES/SCJ/_prepped/staged-item", 999, 999),
+    ]
+    out = sr.by_source(rows)
+    by_bucket = {b["bucket"]: b for b in out["buckets"]}
+
+    scj = by_bucket["ESTATES/SCJ"]
+    assert scj["n"] == 2 and scj["gross"] == 300 and scj["net"] == 270
+    assert scj["kind"] == "event" and scj["spend"] == 575 and not scj["basis_gap"]
+    assert scj["profit"] == 270 - 575
+    assert scj["roi"] == 270 / 575
+
+    mar = by_bucket["ESTATES/MAR"]
+    assert mar["kind"] == "event" and mar["spend"] is None and mar["basis_gap"]
+    assert mar["profit"] is None and mar["roi"] is None
+
+    free = by_bucket["FREE"]
+    assert free["kind"] == "channel" and not free["basis_gap"]
+    assert free["roi"] is None and free["profit"] is None       # never divide a channel
+
+    # buckets ordered by gross, descending
+    assert [b["bucket"] for b in out["buckets"]] == ["ESTATES/SCJ", "ESTATES/MAR", "FREE"]
+
+    assert out["unattributed"] == {"n": 1, "gross": 30, "net": 25}
+    assert out["excluded_backup"] == 1                            # never counted anywhere
+    total = 300 + 80 + 50 + 30
+    assert out["unattributed_pct"] == 30 / total * 100
+
+
+def test_zero_spend_event_bucket_suppresses_roi_not_a_gap(tmp_path, monkeypatch):
+    """spend: FREE on an event bucket is a real, recorded $0 basis — not a gap,
+    and not a divide-by-zero: ROI is undefined, not infinite."""
+    monkeypatch.setattr(sr, "REPO", tmp_path)
+    root = tmp_path / "inventory" / "ESTATES" / "GIFT"
+    root.mkdir(parents=True)
+    (root / "context.txt").write_text("kind: event\nspend: FREE\n", encoding="utf-8")
+    monkeypatch.setattr(dc, "INVENTORY", tmp_path / "inventory")
+
+    out = sr.by_source([_row("inventory/ESTATES/GIFT/item-1", 50, 45)])
+    b = out["buckets"][0]
+    assert b["spend"] == 0.0 and not b["basis_gap"]
+    assert b["profit"] == 45 and b["roi"] is None
+
+
+def test_by_source_reorg_does_not_change_grain(tmp_path, monkeypatch):
+    """A sub-lot without its own context.txt still rolls up to its bucket."""
+    monkeypatch.setattr(sr, "REPO", tmp_path)
+    root = _inventory(tmp_path)
+    monkeypatch.setattr(dc, "INVENTORY", root)
+
+    rows = [_row("inventory/FREE/more-mags-444/deep/nested/lot-9", 40, 35)]
+    out = sr.by_source(rows)
+    assert len(out["buckets"]) == 1
+    assert out["buckets"][0]["bucket"] == "FREE"
+
+
+def test_print_by_source_smoke(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(sr, "REPO", tmp_path)
+    monkeypatch.setattr(dc, "INVENTORY", _inventory(tmp_path))
+    rows = [_row("inventory/ESTATES/SCJ/tray-1", 200, 180)]
+    sr.print_by_source(sr.by_source(rows))
+    out = capsys.readouterr().out
+    assert "ESTATES/SCJ" in out and "unattributed" in out
+
+
+def test_dashboard_renders_by_source_panel(tmp_path, monkeypatch):
+    """Full gather() -> draw() wiring, from CSVs on disk to the HTML panel."""
+    monkeypatch.setattr(sr, "REPO", tmp_path)
+    monkeypatch.setattr(sr, "ADS_JSON", tmp_path / "reports" / "ebay_ads.json")
+    monkeypatch.setattr(dc, "INVENTORY", _inventory(tmp_path))
+
+    with (tmp_path / "sales_ledger.csv").open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=[
+            "sold_at", "title", "listing_id", "shoot_dir", "gross", "ebay_fee",
+            "net_before_postage", "listed_price", "pct_of_ask"])
+        w.writeheader()
+        w.writerow({"sold_at": "2026-07-01T00:00:00Z", "title": "Silver tray",
+                    "listing_id": "111", "shoot_dir": "inventory/ESTATES/SCJ/silver/tray-1",
+                    "gross": "200", "ebay_fee": "20", "net_before_postage": "180",
+                    "listed_price": "220", "pct_of_ask": "91"})
+        w.writerow({"sold_at": "2026-07-02T00:00:00Z", "title": "Gifted vase",
+                    "listing_id": "222", "shoot_dir": "inventory/ESTATES/GIFT/item-1",
+                    "gross": "50", "ebay_fee": "5", "net_before_postage": "45",
+                    "listed_price": "60", "pct_of_ask": "83"})
+
+    d = sr.gather(days=365)
+    html = sr.draw(d)                                   # must not raise
+    assert "Realised by source" in html
+    assert "ESTATES/SCJ" in html
+    assert "spend $575.00" in html                     # SCJ's recorded basis, not a gap
+    assert "NET BEFORE POSTAGE" in html.upper()
+    assert "ESTATES/GIFT" in html and "spend $0.00" in html    # $0 basis, still recorded

--- a/tools/price_vs_actual.py
+++ b/tools/price_vs_actual.py
@@ -75,7 +75,10 @@ def read_price(shoot: Path) -> dict:
 
 def gather() -> list[dict]:
     rows = []
-    with (REPO / "sales_ledger.csv").open(newline="", encoding="utf-8-sig") as fh:
+    ledger = REPO / "sales_ledger.csv"
+    if not ledger.exists():
+        return rows                            # fresh checkout, nothing sold yet
+    with ledger.open(newline="", encoding="utf-8-sig") as fh:
         for r in csv.DictReader(fh):
             shoot_rel = (r.get("shoot_dir") or "").strip()
             if not shoot_rel:

--- a/tools/sales_report.py
+++ b/tools/sales_report.py
@@ -233,15 +233,9 @@ def gather(days: int) -> dict:
             months[k]["gross"] += r["gross"]
     out["months"] = sorted(months.items())[-12:]
 
-    # by collection (top two path segments of the shoot dir)
-    coll = defaultdict(lambda: {"n": 0, "gross": 0.0, "net": 0.0})
-    for r in rows:
-        parts = [p for p in r["shoot"].replace("\\", "/").split("/") if p and p != "inventory"]
-        key = "/".join(parts[:2]) if len(parts) > 1 else (parts[0] if parts else "— untracked —")
-        coll[key]["n"] += 1
-        coll[key]["gross"] += r["gross"]
-        coll[key]["net"] += r["net"]
-    out["collections"] = sorted(coll.items(), key=lambda kv: -kv[1]["gross"])
+    # by source (#56) — bucket = the directory that owns a context.txt, not
+    # however many slashes happen to be in the shoot path.
+    out["by_source"] = by_source(rows)
 
     # promoted
     promoted = [r for r in rows if r["ad"]]
@@ -298,6 +292,63 @@ def gather(days: int) -> dict:
     return out
 
 
+def by_source(rows: list[dict]) -> dict:
+    """Bucket-level ROI (#56).
+
+    Bucket = the nearest ancestor of a sale's shoot dir that owns a
+    context.txt, resolved by `dir_context.bucket_for` — never path depth, so
+    a re-org changes which sales fall in a bucket, not what a bucket IS.
+
+    A bucket's `kind:` decides what a missing `spend:` means: on an `event`
+    bucket (a single purchase) it is a data gap and ROI is suppressed; on a
+    `channel` bucket (an ongoing source like FREE or THRIFT) it is simply
+    correct and ROI was never meaningful to begin with. Profit here is still
+    NET BEFORE POSTAGE — see the caption this feeds into the page with.
+    """
+    import dir_context as dc
+
+    buckets: dict[str, dict] = defaultdict(lambda: {"n": 0, "gross": 0.0, "net": 0.0})
+    unattributed = {"n": 0, "gross": 0.0, "net": 0.0}
+    excluded_backup = 0
+    for r in rows:
+        shoot = r["shoot"].replace("\\", "/").strip()
+        item_dir = (REPO / shoot) if shoot else None
+        if item_dir is not None and dc.is_backup_dir(item_dir):
+            excluded_backup += 1
+            continue
+        bucket = dc.bucket_for(item_dir, dc.INVENTORY) if item_dir else None
+        if bucket is None:
+            unattributed["n"] += 1
+            unattributed["gross"] += r["gross"]
+            unattributed["net"] += r["net"]
+            continue
+        rel = bucket.relative_to(dc.INVENTORY).as_posix()
+        b = buckets[rel]
+        b["n"] += 1
+        b["gross"] += r["gross"]
+        b["net"] += r["net"]
+
+    out = []
+    for rel, b in buckets.items():
+        ctx = dc.context_for(dc.INVENTORY / rel, dc.INVENTORY)
+        kind = ctx["keys"].get("kind", "event")
+        spend = dc.spend_amount(ctx["keys"].get("spend") or ctx["keys"].get("cost"))
+        profit = (b["net"] - spend) if spend is not None else None
+        roi = (b["net"] / spend) if (spend and kind == "event") else None
+        out.append({
+            "bucket": rel, "kind": kind, "spend": spend,
+            "basis_gap": kind == "event" and spend is None,
+            "profit": profit, "roi": roi, **b,
+        })
+    out.sort(key=lambda b: -b["gross"])
+    total_gross = sum(b["gross"] for b in out) + unattributed["gross"]
+    return {
+        "buckets": out, "unattributed": unattributed,
+        "excluded_backup": excluded_backup,
+        "unattributed_pct": (unattributed["gross"] / total_gross * 100) if total_gross else 0,
+    }
+
+
 def band_stats() -> dict:
     """Ask/realised against the Conservative-Recommended-Push-high band.
 
@@ -308,10 +359,12 @@ def band_stats() -> dict:
     """
     try:
         import price_vs_actual as pva
+        rows = pva.gather()
     except Exception:                                                # noqa: BLE001
+        # No sales_ledger.csv yet (fresh checkout) or price_vs_actual itself
+        # unavailable — degrade to "no band data", never crash the dashboard.
         return {"n": 0, "rows": [], "breaches": [], "cohorts": []}
 
-    rows = pva.gather()
     for r in rows:
         r["where"] = pva.classify(r)
     withceil = [r for r in rows if r["ask"] and r["ceiling"]]
@@ -569,17 +622,57 @@ def draw(d: dict) -> str:
             'settings problem, not a pricing one. A cohort well under 100% is the comp '
             'read needing a refit.</p></div></div>')
 
-    # collections
+    # by source (#56) — bucket ROI, resolved from context.txt, not path depth
+    src = d["by_source"]
+
+    def _roi_cell(b) -> str:
+        if b["basis_gap"]:
+            return '<td class="num warn">basis not recorded</td>'
+        if b["roi"] is None:                   # channel bucket, or a $0 basis
+            return '<td class="num dim">—</td>'
+        return f'<td class="num">{b["roi"]:.2f}x</td>'
+
+    def _profit_cell(b) -> str:
+        if b["profit"] is None:
+            return '<td class="num dim">—</td>'
+        cls = "ok" if b["profit"] >= 0 else "warn"
+        return f'<td class="num {cls}">{_money(b["profit"])}</td>'
+
     rows = "".join(
-        f'<tr><td>{_e(k)}</td><td class="num">{v["n"]}</td>'
-        f'<td class="num">{_money(v["gross"])}</td>'
-        f'<td class="num">{_money(v["net"])}</td></tr>'
-        for k, v in d["collections"][:16])
-    P.append('<div class="card"><div class="pad"><h2>Realised by collection</h2>'
-             '<div class="scroll"><table><tr><th>Collection</th><th class="num">Sold</th>'
-             f'<th class="num">Gross</th><th class="num">Net</th></tr>{rows}</table></div>'
-             f'<p class="note">{d["untracked"]} of {d["count"]} sales have no local '
-             'shoot folder — listed outside the pipeline.</p></div></div>')
+        f'<tr><td>{_e(b["bucket"])}'
+        f'<div class="dim" style="font-size:11.5px">{_e(b["kind"])}'
+        + (f' · spend {_money(b["spend"])}' if b["spend"] is not None else '') + '</div></td>'
+        f'<td class="num">{b["n"]}</td>'
+        f'<td class="num">{_money(b["gross"])}</td>'
+        f'<td class="num">{_money(b["net"])}</td>'
+        + _profit_cell(b) + _roi_cell(b) + '</tr>'
+        for b in src["buckets"][:20])
+    u = src["unattributed"]
+    P.append(
+        '<div class="card"><div class="pad"><h2>Realised by source</h2>'
+        '<div class="scroll"><table><tr><th>Bucket</th><th class="num">Sold</th>'
+        '<th class="num">Gross</th><th class="num">Net</th><th class="num">Profit</th>'
+        f'<th class="num">ROI</th></tr>{rows}'
+        f'<tr><td>— unattributed —<div class="dim" style="font-size:11.5px">'
+        f'no local shoot folder</div></td>'
+        f'<td class="num">{u["n"]}</td><td class="num">{_money(u["gross"])}</td>'
+        f'<td class="num">{_money(u["net"])}</td><td class="num dim">—</td>'
+        f'<td class="num dim">—</td></tr>'
+        '</table></div>'
+        f'<p class="note">{u["n"]} of {d["count"]} sales ({src["unattributed_pct"]:.0f}% of '
+        'gross) have no local shoot folder and cannot be attributed to a bucket. '
+        + (f'{src["excluded_backup"]} sale(s) in a <code>_prepped/</code> or '
+           '<code>.prior-run-bak</code> staging copy excluded from every count above. '
+           if src["excluded_backup"] else '')
+        + 'Bucket resolution is <code>context.txt</code> ownership, not path depth — a '
+        're-org changes this table\'s contents, never its correctness. '
+        '"basis not recorded" means an <code>event</code> bucket has no <code>spend:</code> '
+        'in its context.txt yet — treat it as a gap, not as free money. ROI is suppressed '
+        'for <code>channel</code> buckets (FREE, THRIFT — an ongoing source, not a single '
+        'purchase) since dividing by a basis that was never a basis is meaningless. '
+        '<b>Profit here is still net BEFORE POSTAGE</b> — actual postage is not yet a ledger '
+        'column, and for paper goods it typically runs 25-35% of the sale, so every profit '
+        'figure on this page is an overstatement until that column exists.</p></div></div>')
 
     # below ask
     rows = "".join(
@@ -613,10 +706,27 @@ def draw(d: dict) -> str:
             f'<style>{STYLE}</style>\n<div class="wrap">\n' + "\n".join(P) + "\n</div>\n")
 
 
+def print_by_source(src: dict) -> None:
+    """Terminal table for `--by-source` (#56) — the numbers with no HTML redraw."""
+    hdr = f'{"BUCKET":<28} {"KIND":<8} {"SOLD":>5} {"GROSS":>11} {"NET":>11} {"PROFIT":>11} {"ROI":>7}'
+    print(hdr)
+    for b in src["buckets"]:
+        profit = (_money(b["profit"]) if b["profit"] is not None
+                  else ("gap" if b["basis_gap"] else "—"))
+        roi = f'{b["roi"]:.2f}x' if b["roi"] is not None else "—"
+        print(f'{b["bucket"]:<28} {b["kind"]:<8} {b["n"]:>5} {_money(b["gross"]):>11} '
+              f'{_money(b["net"]):>11} {profit:>11} {roi:>7}')
+    u = src["unattributed"]
+    print(f'{"— unattributed —":<28} {"":<8} {u["n"]:>5} {_money(u["gross"]):>11} '
+          f'{_money(u["net"]):>11} {"—":>11} {"—":>7}')
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--days", type=int, default=365, help="order window (default 365)")
     ap.add_argument("--no-sync", action="store_true", help="draw from local data only")
+    ap.add_argument("--by-source", action="store_true",
+                     help="print the bucket ROI table (#56) and exit, no HTML redraw")
     ap.add_argument("--out", default=str(OUT_HTML))
     a = ap.parse_args()
 
@@ -624,6 +734,11 @@ def main() -> int:
     if not a.no_sync:
         sync(a.days)
     d = gather(a.days)
+
+    if a.by_source:
+        print_by_source(d["by_source"])
+        return 0
+
     out = Path(a.out)
     out.write_text(draw(d), encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Foundational slice of #56: source/provenance is now a real, reproducible dimension of the sales report instead of a throwaway regex over prose.

- **`lib/dir_context.py`** — the shared resolver #46 and #56 both need. `bucket_for(item_dir)` walks up to the nearest ancestor directory that owns a `context.txt` (semantic ownership, not path depth — a re-org changes a bucket's contents, never its correctness). `context_for(item_dir)` cascades the `context.txt` chain nearest-wins for `key:` lines (`kind:`, `spend:`, `acquired:`, ...) plus prose. `spend_amount()` parses `"$575"` / `"575"` / `"FREE"` → float, distinguishing "$0, confirmed" from "not recorded" (`None`), which the report depends on to avoid rendering a data gap as free profit.
- **`tools/sales_report.py`** — the old "Realised by collection" panel (grouped by the top two path segments — the exact bug #56 called out) is replaced by "Realised by source", grouped by `bucket_for`. Per bucket: sold count, gross, net, cost (from `context.txt`), profit, ROI.
  - A missing `spend:` on an `event` bucket renders as **"basis not recorded"**, never as profit.
  - ROI is suppressed (not 0, not ∞) for `channel` buckets (FREE, THRIFT — an ongoing source, not a purchase) and for a genuine `$0` basis.
  - `_prepped/` and `*.prior-run-bak` staging copies are excluded from every count.
  - Sales with no local shoot folder are reported as their own **"— unattributed —"** line (count + % of gross), never silently dropped.
  - The panel states outright that profit is still **net before postage**.
  - `--by-source` prints the same table to the terminal without a full HTML redraw.
- Fixed a latent crash: `band_stats()` → `price_vs_actual.gather()` raised `FileNotFoundError` on a fresh checkout with no `sales_ledger.csv` yet, taking the whole dashboard down with it. Now degrades gracefully, same as every other reader in this file.

## Not in this PR

The full acceptance list in #56 also asks for a `LIVE` / sell-through column per bucket and a `lib/cli.py report --by-source` verb. Per-bucket LIVE counts need cross-referencing live listings back to a local shoot dir (`inventory_sheet.csv` has no such field today), which is real plumbing on its own — didn't want to fake a number to check a box. The `--by-source` flag on the existing `sales-report` verb covers the "stable CLI command, no HTML draw" ask without inventing a second dispatch pattern alongside `lib/cli.py`'s flat verb table.

Also out of scope here: #46's DRAFT-side claim blocking and the REVIEW card line — this PR is `dir_context`'s reporting consumer, not its provenance/claims consumer.

## Test plan

- [x] `pytest tests/test_dir_context.py` — 17 tests: parsing (empty/prose-only/keys+prose, key-line-vs-prose ambiguity), `spend_amount` (None vs `$0` vs unparseable), `bucket_for` (owning ancestor, sub-lot rollup, nested bucket wins, outside-root, no-context), `context_for` cascade merge, `is_backup_dir`.
- [x] `pytest tests/test_sales_report_by_source.py` — 5 tests against synthetic `tmp_path` inventory trees (no real business data touched): cost/profit/ROI computation, re-org-proof grain, `$0`-basis vs missing-basis distinction (regression test that reproduces and catches a real `None.__format__` crash I hit and fixed in `_roi_cell`), terminal table smoke test, full `gather()` → `draw()` HTML wiring.
- [x] Full suite: `pytest tests/` — 106 passed, 1 pre-existing failure unrelated to this change (`test_formats.py`, missing `numpy` in this environment; confirmed failing identically on `main` before this branch).


---
_Generated by [Claude Code](https://claude.ai/code/session_011wUmYf35L8MhjrJoyoyHVV)_