### PR TITLE
docs: plan background dispatch for local-state-independent stages (#59)

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -172,6 +172,24 @@ live state, `--apply` to heal), `pick-list` (orders awaiting shipment),
 every flag documented for a tool works identically under `ebz`. The direct
 `python tools/<x>.py` / `python lib/<x>.py` invocations keep working.
 
+## Background dispatch (optional, #59)
+
+PRICE, IDENTIFY's non-photo research (maker/pattern lookups, forum
+cross-reference), DRAFT, and REVIEW's card-build touch no local state —
+each reads only the prior phase's file already written to the shoot dir.
+On a batch of shoots, dispatch these four as background agents (`Agent`
+tool, `run_in_background: true`) instead of blocking the foreground
+conversation, e.g. running item 2's PRICE/DRAFT while the operator is
+still in item 1's PREP. PREP and the REVIEW gate stay foreground: PREP
+reads/writes photo files and needs the operator looking at their own
+images; REVIEW is the human approval that authorizes publish (see the
+gate contract above — untouched by dispatch).
+
+If a dispatched stage turns out to need local state mid-run (e.g. IDENTIFY
+needs another photo angle), it surfaces the question back to the operator
+instead of failing — same as a foreground run would. Same prompts, same
+`_shared.md` rules, same gates; dispatch only changes where a stage runs.
+
 ## Locking a format
 
 Every artefact passed between phases carries a version stamp — `template_version`

--- a/docs/V4_PLAN.md
+++ b/docs/V4_PLAN.md
@@ -87,6 +87,23 @@ tests so "read only when flagged" can be trusted.
       token attribution, interaction hot spots, repeats.
 - [ ] Friction report → auto-filed `Idea:` issue, deduped against open ones.
 
+## Phase 6 — background dispatch (#59)
+
+Nothing here needs new infrastructure — the pipeline is already a Claude
+Code session running prompts, so "cloud dispatch" is the `Agent` tool's
+`run_in_background`, not a new service. PRICE, IDENTIFY's non-photo research,
+DRAFT, and REVIEW card-build touch no local state; PREP and the REVIEW
+approval gate do and stay foreground. Convention documented in RUN.md
+"Background dispatch". Priority among the four candidates should come from
+Phase 5's per-stage timing once it exists, not guessed up front.
+
+- [ ] Batch runner: when a shoot batch queues item N+1 while item N is still
+      in PREP, dispatch item N+1's PRICE/DRAFT as background agents instead
+      of waiting.
+- [ ] Verify a dispatched stage that hits a local-state need (e.g. IDENTIFY
+      wants another photo angle) surfaces as a question, not a silent
+      failure.
+
 ## Ground rules
 
 Honesty rules, condition disclosure, approval digests and the review gate on


### PR DESCRIPTION
## Summary

Scopes issue #59 ("dispatch pipeline stages to cloud agents when work is
local-machine-independent") as the next tracked phase, and documents the
convention it depends on.

- `docs/V4_PLAN.md`: adds Phase 6 — PRICE, IDENTIFY's non-photo research,
  DRAFT, and REVIEW's card-build read only prior-phase files already on
  disk, so they qualify for background dispatch; PREP and the REVIEW
  approval gate stay foreground. Priority among the four is left to Phase
  5's per-stage timing data rather than guessed.
- `RUN.md`: adds a "Background dispatch" section spelling out the
  convention for an operator session — dispatch via the `Agent` tool's
  `run_in_background`, fall back to a foreground question if a dispatched
  stage turns out to need local state, and the existing gates (review,
  PREP) are untouched.

No runtime code changes: per the issue, the "cloud agent" here is Claude
Code's own `Agent`/background tooling, which the operating session already
has access to — there's no separate dispatch service to build. This PR is
the planning/groundwork slice; the two Phase 6 checkboxes (batch-runner
dispatch, verifying the local-state fallback) are follow-up work.

## Test plan

- [x] `python -m pytest tests/test_formats.py` — 8 passed (1 pre-existing
      failure from `numpy` not being installed in this sandbox, unrelated
      to this change — `numpy` is a declared `requirements.txt` dependency)
- [x] Reviewed the diff — doc-only, no code paths touched
- [ ] Human review of the Phase 6 scoping and RUN.md wording

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExJMB2fVzDeFntmhdwpXa1)_

Closes #59
