### PR TITLE
docs(prompts): runtime discipline + colour confidence gate

### DIFF
--- a/prompts/_shared.md
+++ b/prompts/_shared.md
@@ -51,6 +51,30 @@ not an acceptable way to show a comp. The `price.txt` / `comps.csv` artifacts
 are still written as specified in PRICE; this rule governs the CHAT layer, in
 every phase, on top of them.
 
+## Runtime discipline (every turn re-sends the whole conversation)
+
+A session-log audit (#61) found 89% of run cost going to re-sent context,
+not produced work — driven by one call per turn and ~300K tokens of that
+context being raw photos. Both are avoidable, in every phase:
+
+- **Batch independent tool calls into one turn.** Two `Read`s, a `Read` +
+  a `Grep`, several independent `Bash` calls — if none depends on another's
+  output, issue them together, not as serial single-call turns.
+- **Background anything that won't finish in a few seconds** (a `prep`
+  pass, any renderer) and keep working on the next item or phase while it
+  runs. Foreground only what the very next step actually depends on.
+- **Read the contact sheet, never the raw frames.** `prep_card.py` /
+  `prep_sheet_html.py` / `marble_triage` already build one sheet — read
+  that. Pulling individual `.jpg`/`.png` frames into the main thread is the
+  single largest source of wasted context in this pipeline; when a frame
+  truly needs full-resolution inspection, delegate that one look to a
+  subagent that returns text instead.
+- **A scratch `.py` file beats an inline heredoc or `python -c`.** Quoting
+  breaks it often enough to cost more than it saves.
+- **One command that reports everything beats a chain of `ls`/`cat`/`find`.**
+  Prefer whatever the tooling already exposes as a single status/summary
+  call over rebuilding the picture one thin read at a time.
+
 ## Confidence (commit, don't hedge)
 
 - **State the single best-supported call.** Make it; don't narrate the

--- a/prompts/prep.md
+++ b/prompts/prep.md
@@ -77,22 +77,28 @@ in code:
   `MIN_FRAME_KEPT` 0.55 floor: a crop trims edges and always leaves backdrop.
 
 Apply the pass, then **gate on confidence, not on the operator** (operator's
-call, 2026-08-27):
+call, 2026-08-27) — and this now covers colour too, not just orientation and
+crop:
 
 - **Every frame resolved, nothing guessed, every self-check clean** — the
-  normal case — run `--approve-auto` yourself (signs off orientation AND crop
-  together) and move straight to colour. Show ONE card
-  (`python tools/prep_card.py <shoot>`) of the revised frames as a record of
-  what shipped, not as a question; the run does not stop to wait.
-- **Anything guessed or flagged** — a `guessed: true` frame, a mask the
-  colour stage cannot trust, a crop the pipeline refused — ask about THOSE
-  frames only, by name, and approve the rest. The one question is about the
-  exception, never "may I continue".
+  normal case — run `--approve-auto` (orientation + crop), pick the look "The
+  looks → Defaults" already calls for that shoot (deterministic: `crisp` for
+  a new item, the published look for a relist, backdrop-led `punch`/`studio`
+  otherwise), and `--approve-stage color` it too. Show ONE card
+  (`python tools/prep_card.py <shoot>`) of the revised frames — including the
+  chosen colour look — as a record of what shipped, not as a question; the
+  run does not stop to wait.
+- **Anything guessed or flagged** — a `guessed: true` frame, low mask
+  coverage, a "colour pass touched item pixels" self-check flag, a crop the
+  pipeline refused, or a shoot the Defaults rule genuinely can't call (no
+  clear cloth colour, a look outside the three presets) — ask about THOSE
+  frames or that ONE look-choice only, and approve/apply the rest. The one
+  question is about the exception, never "may I continue".
 
 Auto-approval never buys a lower bar: `--auto` approves nothing by itself,
-`listing/` is still written only after sign-off, and `--approve-auto` stamps
-the same per-stage digest a sheet approval does — any later edit invalidates
-it the same way.
+`listing/` is still written only after sign-off, and `--approve-auto` /
+`--approve-stage color` stamp the same per-stage digest a sheet approval
+does — any later edit invalidates it the same way.
 
 ## The interactive review — the exception path, STAGED
 


### PR DESCRIPTION
## Summary

First slice of #61's fix list — the parts that are pure prompt/instruction changes, no new tooling required:

- **`prompts/_shared.md`** — new "Runtime discipline" section (loaded by every phase): batch independent tool calls into one turn instead of one call per turn, background any run over a few seconds instead of blocking foreground, read the contact sheet instead of pulling raw `.jpg`/`.png` frames into the main thread, and use a scratch `.py` file instead of an inline heredoc/`python -c` (the audit's #1, #3, #4, #8).
- **`prompts/prep.md`** — the confidence gate ("gate on confidence, not on the operator") already auto-approved orientation + crop for the clean case but always stopped to ask about colour, which the audit found is the single largest wall-clock sink (81h across 20 asks). Colour already has a deterministic default per shoot type ("The looks → Defaults": `crisp` for a new item, the published look for a relist, backdrop-led `punch`/`studio` otherwise) and the code already supports `--approve-stage color`, so this wires the same clean-case auto-approval through to colour. Ask only stays live for a genuinely flagged frame (`guessed`, low mask coverage, a colour self-check flag, a refused crop) or a shoot the default rule can't call.

Not attempted here: fanning items out to subagents (issue calls this a companion issue), a consolidated status CLI command, and the "one session per shoot" policy — those need actual tooling/workflow changes rather than a prompt edit.

## Test plan

- [x] `python -m pytest tests/ -q` — 286 passed, 1 skipped (unaffected; changes are prompt docs only)
- [ ] Next `list`/`full` run on a clean shoot confirms colour self-approves and the Frame Check colour page only surfaces on a genuinely flagged frame

Closes part of #61.

---
_Generated by [Claude Code](https://claude.ai/code/session_012NhLyeNDUpBKR6PW3BD6Zb)_