### PR TITLE
docs+tool: conductor/workers concurrency shape, ebz status (#62)

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -157,6 +157,55 @@ queue — the user reads it when convenient instead of being interrupted.
 
 Load each prompt when you reach its phase.
 
+## Concurrency and delegation
+
+A multi-item batch is not one long conversation — it is one conductor plus
+one worker per item. The trigger is a **multi-item batch**; a single item, or
+an interactive back-and-forth about one piece, stays in the main thread.
+
+**Conductor (main thread) holds only:** the batch manifest (which items,
+which phase each is in), the gates, and ledger writes. It never holds
+photos, comp JSON, forum matches or per-item research — those are what
+blow the context window up.
+
+**One `Agent` worker per item**, ≤4 concurrent, covering IDENTIFY → PRICE →
+INVESTIGATE → DRAFT:
+
+- fresh context per worker; it reads `prompts/_shared.md` plus the phase
+  prompt it needs — not optional, see `_shared.md`'s standing rules;
+- writes outputs to the shoot dir exactly as a foreground run would
+  (`identify.txt`, `price.txt`, `comps.csv`, `investigate.txt`, `draft.md`);
+- returns a **compact verdict only** — item name, proposed title, price +
+  tier, the ⚠ list, and the path to `draft.md` — never its full reasoning.
+  `python -m lib.cli status <shoot-dir>` is the one call to check any
+  item's state (phase files, PREP gate, ledger row, next action) instead
+  of re-deriving it from `ls`/`cat`.
+- writes a short trace file into the item dir on failure, so a failed
+  worker is inspectable after the fact — a verdict alone isn't a transcript.
+
+**The gate queue, not a gate barrier.** REVIEW still stops and requires one
+explicit approval per item — that discipline doesn't weaken. What changes is
+that a finished item's card joins a queue instead of blocking every other
+item: answer gates whenever convenient while other workers keep running.
+
+**What may run in a worker vs. only in the conductor:**
+
+| writes | parallel-safe? |
+|---|---|
+| `identify.txt`, `price.txt`+`comps.csv`, `investigate.txt`, `draft.md` (per-item dirs) | ✅ disjoint dirs |
+| `.prep/`, `listing/` | ✅ disjoint dirs |
+| `listings_ledger.csv` via `list_edit.py --record` | ❌ one shared unlocked CSV — **conductor only, serialized** |
+| `--list --confirm` (publish) | ❌ conductor only, behind the REVIEW gate |
+
+Two workers calling `--record` at once can lose a row — every ledger-touching
+call belongs in the conductor.
+
+**Background anything over ~30s.** `prep --auto` and any other runner that
+takes tens of seconds (Apify comp hunts, Chrome browse) go to
+`run_in_background`; keep working the item (or another item) while it
+renders, collect the result when it lands. Don't block the whole run on one
+runner that nothing downstream is waiting on yet.
+
 ## Ops commands — one entry point
 
 Every account/ops tool runs through the `ebz` dispatcher (V4_PLAN Phase 3):
@@ -168,9 +217,11 @@ Every account/ops tool runs through the `ebz` dispatcher (V4_PLAN Phase 3):
 live state, `--apply` to heal), `pick-list` (orders awaiting shipment),
 `policy-sweep`, `price-audit` (asks above their own comp evidence),
 `sales-report`, `promote`, `voice` (in-hand linter, `--audit` for a tree),
-`listing` (the LIST/EDIT CLI), `prep`. Argv passes through untouched, so
-every flag documented for a tool works identically under `ebz`. The direct
-`python tools/<x>.py` / `python lib/<x>.py` invocations keep working.
+`listing` (the LIST/EDIT CLI), `prep`, `status` (one-call shoot state —
+phase files, PREP gate, ledger row, next action; see "Concurrency and
+delegation" above). Argv passes through untouched, so every flag documented
+for a tool works identically under `ebz`. The direct `python tools/<x>.py` /
+`python lib/<x>.py` invocations keep working.
 
 ## Locking a format
 

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -38,6 +38,8 @@ COMMANDS = {
                      "live listings still asking above their own comp evidence"),
     "comps-board":  ("tools.comps_board",
                      "comp JSON -> the thumbnail board (_shared.md hard rule)"),
+    "status":       ("tools.shoot_status",
+                     "one-call shoot status: phase files, prep gate, ledger row, next action"),
     "sales-report": ("tools.sales_report",
                      "sales / fees / promotion dashboard"),
     "promote":      ("tools.promote",

--- a/prompts/_shared.md
+++ b/prompts/_shared.md
@@ -51,6 +51,24 @@ not an acceptable way to show a comp. The `price.txt` / `comps.csv` artifacts
 are still written as specified in PRICE; this rule governs the CHAT layer, in
 every phase, on top of them.
 
+## Context discipline (keep the window small)
+
+Three standing rules — every phase loads this file, so they apply everywhere:
+
+- **Never `Read` a raw frame into the main thread.** Read the contact sheet
+  (`tools/prep_card.py`, `tools/prep_sheet_html.py`) instead, or delegate the
+  looking to a worker (`Agent`) that returns text. A full-resolution photo in
+  the main thread's context costs orders of magnitude more than the fact it
+  contains.
+- **Batch independent tool calls into one turn.** If two calls don't depend
+  on each other's result, issue them together rather than one-per-turn.
+- **Write a scratch `.py` and run it, rather than an inline heredoc**, for
+  anything beyond a one-liner. Heredoc quoting inside a shell call is a
+  routine, avoidable failure mode.
+
+See [RUN.md](../RUN.md) "Concurrency and delegation" for the conductor/worker
+shape a multi-item batch runs under.
+
 ## Confidence (commit, don't hedge)
 
 - **State the single best-supported call.** Make it; don't narrate the

--- a/tests/test_shoot_status.py
+++ b/tests/test_shoot_status.py
@@ -1,0 +1,88 @@
+"""tools/shoot_status.py — the one-call read a conductor uses instead of the
+ls/cat/grep chain (RUN.md, "Concurrency and delegation" / #62).
+
+Covers the progression through phase files + the PREP gate, the sku/ledger
+lookup, and that a malformed draft.md degrades to "no sku" rather than raising.
+"""
+import csv
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "lib"))
+
+import tools.shoot_status as S  # noqa: E402
+
+DRAFT = """---
+title: "Test Widget"
+meta:
+  ebay_inventory_sku: deadbeef
+---
+Body.
+"""
+
+
+def _shoot(tmp: Path, **files) -> Path:
+    shoot = tmp / "widget"
+    shoot.mkdir()
+    (shoot / "one.jpg").write_bytes(b"\xff\xd8\xff")  # not real jpeg bytes; find_images only checks suffix
+    for name, content in files.items():
+        (shoot / name).write_text(content, encoding="utf-8")
+    return shoot
+
+
+def test_no_files_yet_points_at_identify():
+    with tempfile.TemporaryDirectory() as d:
+        shoot = _shoot(Path(d))
+        s = S.status(shoot)
+        assert s["next_action"] == "run IDENTIFY"
+        assert not any(s["files"].values())
+        assert s["sku"] is None
+        assert s["ledger"] is None
+
+
+def test_identify_done_points_at_prep():
+    with tempfile.TemporaryDirectory() as d:
+        shoot = _shoot(Path(d), **{"identify.txt": "call: widget"})
+        s = S.status(shoot)
+        assert s["files"]["identify"] is True
+        assert s["next_action"] == "open PREP stage orientation"
+
+
+def test_full_chain_reads_sku_and_ledger_row(monkeypatch):
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        shoot = _shoot(tmp, **{
+            "identify.txt": "call: widget",
+            "price.txt": "working price: $19.99",
+            "investigate.txt": "confident assessment",
+            "draft.md": DRAFT,
+        })
+        ledger = tmp / "ledger.csv"
+        with ledger.open("w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=["sku", "status", "title"])
+            w.writeheader()
+            w.writerow({"sku": "deadbeef", "status": "DRAFTED", "title": "Test Widget"})
+        monkeypatch.setenv("EBAYBIZ_LISTINGS_LEDGER", str(ledger))
+
+        s = S.status(shoot)
+        assert s["sku"] == "deadbeef"
+        assert s["ledger"]["status"] == "DRAFTED"
+        # PREP was never approved, so DRAFT existing doesn't advance next_action
+        # past the still-open gate.
+        assert s["next_action"] == "open PREP stage orientation"
+
+
+def test_malformed_draft_degrades_to_no_sku():
+    with tempfile.TemporaryDirectory() as d:
+        shoot = _shoot(Path(d), **{"draft.md": "not frontmatter at all"})
+        s = S.status(shoot)
+        assert s["sku"] is None
+        assert s["ledger"] is None
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tools/shoot_status.py
+++ b/tools/shoot_status.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""One-call status for a shoot: phase files, prep approval, ledger row, next action.
+
+Replaces the ls/cat/grep chain a conductor used to run per item just to answer
+"where is this shoot right now" (see RUN.md, "Concurrency and delegation").
+Read-only; touches nothing.
+
+    python -m lib.cli status <shoot-dir>
+    python tools/shoot_status.py <shoot-dir> [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+for p in (str(ROOT), str(ROOT / "lib")):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from draft_io import parse_draft                     # noqa: E402
+from photo_prep.prep import find_images, load_manifest  # noqa: E402
+from photo_prep.stages import STAGES, stage_state     # noqa: E402
+
+PHASE_FILES = [
+    ("identify", "identify.txt"),
+    ("price", "price.txt"),
+    ("investigate", "investigate.txt"),
+    ("draft", "draft.md"),
+    ("review", "review_card.md"),
+]
+
+
+def _ledger_row(sku: str) -> dict | None:
+    if not sku:
+        return None
+    env = os.environ.get("EBAYBIZ_LISTINGS_LEDGER") or os.environ.get("EBAYBIZ_LISTINGS_LOG")
+    path = Path(env) if env else ROOT / "listings_ledger.csv"
+    if not path.exists():
+        return None
+    with path.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            if row.get("sku") == sku:
+                return row
+    return None
+
+
+def _prep_state(shoot: Path) -> dict:
+    m = load_manifest(shoot)
+    st = stage_state(m)
+    return {
+        "frames": len(m.get("photos") or {}),
+        "stages": {s: st[s]["approved"] for s in STAGES},
+        "approved": bool(m.get("approved")),
+    }
+
+
+def _next_action(files: dict, prep: dict, ledger: dict | None) -> str:
+    if not files["identify"]:
+        return "run IDENTIFY"
+    if not prep["approved"]:
+        pending = next((s for s in STAGES if not prep["stages"][s]), None)
+        if pending is None:
+            return "run PREP --auto"
+        return f"open PREP stage {pending}"
+    if not files["price"]:
+        return "run PRICE"
+    if not files["investigate"]:
+        return "run INVESTIGATE"
+    if not files["draft"]:
+        return "run DRAFT"
+    if not files["review"]:
+        return "run REVIEW"
+    if ledger and ledger.get("status") == "PUBLISHED":
+        return "done — live"
+    return "awaiting REVIEW approval"
+
+
+def status(shoot: Path) -> dict:
+    files = {name: (shoot / fname).exists() for name, fname in PHASE_FILES}
+    prep = _prep_state(shoot)
+    sku = ""
+    if files["draft"]:
+        try:
+            sku = str(parse_draft(shoot / "draft.md").get("meta.ebay_inventory_sku") or "")
+        except Exception:
+            sku = ""
+    ledger = _ledger_row(sku)
+    needs_review = shoot / "NEEDS_REVIEW.md"
+    return {
+        "shoot": shoot.name,
+        "frame_count": len(find_images(shoot)),
+        "files": files,
+        "prep": prep,
+        "sku": sku or None,
+        "ledger": ledger,
+        "needs_review_lines": needs_review.read_text(encoding="utf-8").count("\n")
+        if needs_review.exists() else 0,
+        "next_action": _next_action(files, prep, ledger),
+    }
+
+
+def render(s: dict) -> str:
+    lines = [f"{s['shoot']}  ({s['frame_count']} frames)"]
+    done = [name for name, ok in s["files"].items() if ok]
+    lines.append(f"  files:  {', '.join(done) if done else 'none yet'}")
+    prep = s["prep"]
+    stages = ", ".join(f"{k}{'✓' if v else ''}" for k, v in prep["stages"].items())
+    lines.append(f"  prep:   {stages}  (approved: {prep['approved']})")
+    if s["sku"]:
+        lg = s["ledger"]
+        lines.append(f"  sku:    {s['sku']}  ledger: {lg.get('status') if lg else 'no row'}")
+    if s["needs_review_lines"]:
+        lines.append(f"  needs_review: {s['needs_review_lines']} entries")
+    lines.append(f"  next:   {s['next_action']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("shoot", help="shoot directory (e.g. inventory/sand-dollars)")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args(argv)
+
+    shoot = Path(args.shoot)
+    if not shoot.is_dir():
+        ap.error(f"not a directory: {shoot}")
+
+    s = status(shoot)
+    print(json.dumps(s, indent=2) if args.json else render(s))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Scopes the "Concrete changes" section of #62 (execution model: conductor +
per-item workers, backgrounded runners, gates as a queue not a barrier) —
the runbook/prompt changes plus the one code addition it calls for. The
architecture proposal itself (why serial single-context runs cost `N ×`
everything) is #62's, this PR just lands what it asks to change.

- **`RUN.md`** — new "Concurrency and delegation" section: a multi-item batch
  fans out one `Agent` worker per item (≤4 concurrent) covering IDENTIFY →
  PRICE → INVESTIGATE → DRAFT; the conductor holds only the batch manifest,
  the gates, and ledger writes; `listings_ledger.csv` writes and the publish
  step stay conductor-only and serialized (the hard constraint — one shared
  unlocked CSV); `prep --auto` and other >30s runners go to
  `run_in_background`; REVIEW's gate becomes a **queue** workers don't block
  on, not a weaker gate — one explicit approval per item is unchanged.
- **`prompts/_shared.md`** — the three standing rules #62 asks for, since
  every phase already loads this file: never `Read` a raw frame into the
  main thread (read the contact sheet or delegate to a worker), batch
  independent tool calls into one turn, and write a scratch `.py` instead of
  an inline heredoc.
- **`lib/cli.py` + `tools/shoot_status.py`** — `ebz status <shoot-dir>`: one
  read-only call returning which phase files exist, the PREP gate's
  per-stage approval state, the shoot's ledger row (resolved via its
  `draft.md` sku), frame count, and the next action. This is the thing #62
  calls out to replace the `ls`/`cat`/`grep` chain a conductor previously
  ran per item just to answer "where is this shoot right now."

## Not in this PR

The acceptance metrics in #62 (mean context per turn, tool-calls-per-turn,
`run_in_background` share, etc.) come from re-running `.scratch/analyze*.py`
against real session logs after the new convention has actually been used
for a while — nothing to measure yet on a docs-only change plus one new
read-only tool. The optional ledger file-lock is also left for later, per
#62's own "Optional, later" framing.

## Test plan

- [x] `tests/test_shoot_status.py` (4 cases) — phase progression through the
      PREP gate, sku/ledger-row lookup via a synthetic `listings_ledger.csv`,
      and a malformed `draft.md` degrading to "no sku" rather than raising.
- [x] `python -m pytest tests/` (105 passed, 1 pre-existing skip) in this
      sandbox, excluding modules that fail to import here for missing
      `PIL`/`cv2`/`numpy` (unrelated to this change — same gap prior PRs in
      this repo have hit and noted).
- [x] `python -m lib.cli status <shoot-dir>` and `python tools/shoot_status.py
      <shoot-dir> --json` smoke-tested against a synthetic shoot dir at each
      point in the IDENTIFY→PREP→PRICE→INVESTIGATE→DRAFT→REVIEW chain.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J4tYu2Rj36Mvq1Fm6ASuC9)_