### PR TITLE
Add cross-directory source/ROI reporting (report --by-source)

### DIFF
--- a/lib/cli.py
+++ b/lib/cli.py
@@ -40,6 +40,8 @@ COMMANDS = {
                      "comp JSON -> the thumbnail board (_shared.md hard rule)"),
     "sales-report": ("tools.sales_report",
                      "sales / fees / promotion dashboard"),
+    "report":       ("lib.source_report",
+                     "cross-directory bucket ROI — report --by-source [--html] (#56)"),
     "promote":      ("tools.promote",
                      "paid-placement planner — proposes; every write needs --confirm"),
     "voice":        ("lib.voice_check",

--- a/lib/source_report.py
+++ b/lib/source_report.py
@@ -1,0 +1,612 @@
+#!/usr/bin/env python3
+"""source_report — cross-directory bucket ROI, as a first-class report (#56).
+
+Provenance is a real dimension of this business — items live under
+`ESTATES/<name>/`, `FREE/`, `THRIFT/`, `GARAGE-SALES/`, `MINE/`, and each is a
+distinct acquisition with its own cost, its own sell-through, and its own
+answer to "was that worth buying." Every number of this shape produced before
+this file came from a throwaway scratchpad script — not reproducible, not
+tested, and gone the moment the session ended. This makes it a committed report
+in the house UI, following the `tools/sales_report.py` -> dashboard pattern:
+
+    python -m lib.cli report --by-source              # terminal table
+    python -m lib.cli report --by-source --html       # reports/source_report.html
+
+WHAT A "BUCKET" IS
+
+Not "the top two path segments of a shoot dir" — that grain broke the moment
+items moved under ESTATES/<name>/: `ESTATES/SCJ` is a real acquisition,
+`FREE/more-mags-444` is a sub-lot *inside* the `FREE` acquisition, and the two
+are not peers. A bucket is the semantic thing: the nearest ancestor directory
+that owns a `context.txt`. `bucket_for()` below is the one resolver — a re-org
+of the folders under it changes the report's contents, never its correctness.
+
+WHY COST BASIS COMES FROM context.txt KEYS, NOT PROSE
+
+`context.txt` already carries the story of an acquisition in prose ("An estate
+sale in Social Circle Georgia. ... Spend $575"), and that prose stays the
+payload. But recovering the spend by pattern-matching English is exactly the
+kind of number this file exists to stop producing. `spend:` / `kind:` /
+`acquired:` are real, explicit keys a tool can branch on without guessing.
+`kind` matters because the two axes aren't comparable: an `event` bucket (a
+single purchase — SCJ, MAR) has a real ROI; a `channel` bucket (an ongoing
+habit — FREE, THRIFT) does not, and treating it as one manufactures a number
+that means nothing. A missing `spend:` on an `event` bucket is a *data gap* —
+flagged. On a `channel` bucket it's *correct* — no ROI expected, no flag.
+
+WHAT THIS PAGE DOES NOT CLAIM
+
+`net_before_postage` is exactly that — before postage. `sales_ledger.csv` has
+no actual-postage column, so every "net" and "profit" figure here overstates
+what was actually kept. The page says so plainly rather than printing a number
+that quietly isn't a profit.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))       # sibling lib/ modules
+import report as _report                                        # noqa: E402  lib/report.py
+
+REPO = Path(__file__).resolve().parent.parent
+INVENTORY = REPO / "inventory"
+SALES_LEDGER = REPO / "sales_ledger.csv"
+REPORTS = REPO / "reports"
+OUT_HTML = REPORTS / "source_report.html"
+
+# Directories that exist only as a copy of something already counted elsewhere
+# — a pre-touch backup or a prior run's leftovers, never a source of new items.
+# Matched anywhere in the path so a nested backup (SCJ/item-9/_prepped) is
+# caught the same as a top-level one.
+_BACKUP_EXACT = {"_prepped", ".prior-run-bak"}
+
+
+def _norm(path_str: str) -> str:
+    return (path_str or "").replace("\\", "/").strip().strip("/")
+
+
+def _is_backup_path(path_str: str) -> bool:
+    """True if any component of `path_str` names a backup/generated dir.
+
+    A dot-prefixed component is treated the same as the two named exceptions
+    the issue calls out — every dot-dir this repo already produces under
+    `inventory/` (`.orig/`, `.orig-rot/`, `.scratch/`, `.tonecheck/`, `.comps/`)
+    is regenerable backup/scratch output, never a distinct source of items.
+    """
+    return any(p in _BACKUP_EXACT or p.startswith(".")
+               for p in _norm(path_str).split("/") if p)
+
+
+# --------------------------------------------------------------------------- #
+# bucket resolution — the directory that owns a context.txt
+# --------------------------------------------------------------------------- #
+
+def bucket_for(item_dir: Path, root: Optional[Path] = None) -> Optional[Path]:
+    """Nearest ancestor of `item_dir` (inclusive) that holds a context.txt.
+
+    Bounded to `root` (default INVENTORY) so the walk cannot climb out of the
+    inventory tree and accidentally match an unrelated context.txt higher up
+    the filesystem. Returns None if `item_dir` is not under `root`, or no
+    ancestor within it owns a context.txt.
+    """
+    root_r = (INVENTORY if root is None else Path(root)).resolve()
+    try:
+        cur = Path(item_dir).resolve()
+    except OSError:
+        return None
+    if cur != root_r and root_r not in cur.parents:
+        return None
+    while True:
+        if (cur / "context.txt").is_file():
+            return cur
+        if cur == root_r:
+            return None
+        cur = cur.parent
+
+
+def bucket_label(bucket_dir: Path, root: Optional[Path] = None) -> str:
+    """Display key for a bucket — its path relative to `root` (default INVENTORY)."""
+    root_r = (INVENTORY if root is None else Path(root)).resolve()
+    try:
+        rel = Path(bucket_dir).resolve().relative_to(root_r)
+        return rel.as_posix() if str(rel) != "." else bucket_dir.name
+    except ValueError:
+        return str(bucket_dir)
+
+
+# --------------------------------------------------------------------------- #
+# context.txt — tolerant of empty / prose-only / keyed-plus-prose
+# --------------------------------------------------------------------------- #
+
+_KEY_RE = re.compile(r"^\s*(kind|spend|acquired)\s*:\s*(.*?)\s*$", re.I)
+_KINDS = {"event", "channel"}
+
+
+def _to_float(v, default=None):
+    try:
+        return float(str(v).replace("$", "").replace(",", "").strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_context(text: str) -> dict:
+    """Pull `kind:` / `spend:` / `acquired:` out of a context.txt body.
+
+    Only an explicit `key: value` line counts — prose that happens to contain
+    "Spend $575" is deliberately NOT read as the spend field (that is the whole
+    point of #56: a real field, not English pattern-matching). Tolerates an
+    empty file, a prose-only file, and a file mixing key lines with prose in
+    any order — all three shapes already exist on disk under inventory/.
+    First occurrence of a key wins; a bare `kind:` value outside {event,
+    channel} is treated as unset rather than trusted verbatim.
+    """
+    kind = spend = acquired = None
+    for line in (text or "").splitlines():
+        m = _KEY_RE.match(line)
+        if not m:
+            continue
+        key, val = m.group(1).lower(), m.group(2).strip()
+        if not val:
+            continue
+        if key == "kind" and kind is None:
+            v = val.lower()
+            if v in _KINDS:
+                kind = v
+        elif key == "spend" and spend is None:
+            spend = _to_float(val)
+        elif key == "acquired" and acquired is None:
+            acquired = val
+    return {"kind": kind, "spend": spend, "acquired": acquired}
+
+
+def load_context(bucket_dir: Path) -> dict:
+    f = Path(bucket_dir) / "context.txt"
+    if not f.is_file():
+        return {"kind": None, "spend": None, "acquired": None}
+    try:
+        text = f.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {"kind": None, "spend": None, "acquired": None}
+    return parse_context(text)
+
+
+# --------------------------------------------------------------------------- #
+# ROI / gap rules
+# --------------------------------------------------------------------------- #
+
+def roi_for(net: float, spend: Optional[float], kind: Optional[str]) -> Optional[float]:
+    """net / spend for an `event` bucket with a positive recorded spend.
+
+    Suppressed (None — never 0, never inf) whenever ROI would not mean
+    anything: `kind` is not explicitly `event` (a `channel` bucket, or one
+    with no `kind:` at all, is not a single acquisition with a payback), or
+    spend is missing/zero (a real basis, not a divide-by-zero).
+    """
+    if kind != "event":
+        return None
+    if not spend or spend <= 0:
+        return None
+    return net / spend
+
+
+def is_basis_gap(kind: Optional[str], spend: Optional[float]) -> bool:
+    """True only for the case the issue calls a real data gap: an `event`
+    bucket with no recorded spend. A `channel` bucket (or unspecified kind)
+    missing spend is correct, not a gap — no ROI was ever expected there."""
+    return kind == "event" and spend is None
+
+
+def sell_through(sold_n: int, live_n: int) -> Optional[float]:
+    total = sold_n + live_n
+    return (sold_n / total * 100) if total > 0 else None
+
+
+# --------------------------------------------------------------------------- #
+# gather — read-only over sales_ledger.csv + local drafts/ledger
+# --------------------------------------------------------------------------- #
+
+def _sales_rows() -> list[dict]:
+    if not SALES_LEDGER.exists():
+        return []
+    with SALES_LEDGER.open(newline="", encoding="utf-8-sig") as fh:
+        return list(csv.DictReader(fh))
+
+
+def _collect_listings() -> list[dict]:
+    """Local drafts + listings_ledger.csv, merged (disk wins) — see lib/report.py.
+
+    Best-effort for LIVE/ask/pending: a CHOICE group listing (`draft_group.md`)
+    never reaches `listings_ledger.csv` (a known, documented gap in
+    lib/report.py, not introduced here), so its live/ended state is inferred
+    from the draft's own `published_at` plus whether it also shows up as a
+    sale — not from an authoritative eBay read. `tools/sales_report.py`'s
+    "shop right now" panel (drawn from the eBay-synced inventory_sheet.csv) is
+    the authoritative shop-wide LIVE count; this report's LIVE/ask columns are
+    for comparing buckets against each other, not as a replacement for it.
+    """
+    try:
+        return _report.collect()
+    except Exception:                                            # noqa: BLE001
+        return []
+
+
+def _new_bucket(bucket_dir: Path) -> dict:
+    ctx = load_context(bucket_dir)
+    return {
+        "path": bucket_dir, "key": bucket_label(bucket_dir),
+        "kind": ctx["kind"], "spend": ctx["spend"], "acquired": ctx["acquired"],
+        "sold_n": 0, "gross": 0.0, "fee": 0.0, "net": 0.0,
+        "ask_total": 0.0, "live_n": 0, "pending_n": 0,
+    }
+
+
+def gather() -> dict:
+    buckets: dict[Path, dict] = {}
+    unattributed = {"key": "— unattributed (no matching folder) —",
+                     "sold_n": 0, "gross": 0.0, "fee": 0.0, "net": 0.0}
+
+    def _bucket(bdir: Path) -> dict:
+        b = buckets.get(bdir)
+        if b is None:
+            b = _new_bucket(bdir)
+            buckets[bdir] = b
+        return b
+
+    sales = _sales_rows()
+    sold_listing_ids = {r.get("listing_id") for r in sales if r.get("listing_id")}
+
+    # ---- sold line items -----------------------------------------------
+    for r in sales:
+        shoot = _norm(r.get("shoot_dir") or "")
+        gross, fee, net = (_to_float(r.get("gross"), 0.0), _to_float(r.get("ebay_fee"), 0.0),
+                          _to_float(r.get("net_before_postage"), 0.0))
+        if shoot and _is_backup_path(shoot):
+            continue                                    # backup dir — excluded from counts
+        bdir = bucket_for(REPO / shoot) if shoot else None
+        if bdir is None:
+            unattributed["sold_n"] += 1
+            unattributed["gross"] += gross
+            unattributed["fee"] += fee
+            unattributed["net"] += net
+            continue
+        b = _bucket(bdir)
+        b["sold_n"] += 1
+        b["gross"] += gross
+        b["fee"] += fee
+        b["net"] += net
+
+    # ---- live + drafted/synced pending, from local drafts/ledger -------
+    for r in _collect_listings():
+        path = _norm(r.get("path") or "")
+        if not path or _is_backup_path(path):
+            continue
+        bdir = bucket_for((REPO / path).parent)
+        if bdir is None:
+            continue
+        b = _bucket(bdir)
+        published = bool(r.get("published_at"))
+        status = (r.get("status") or "").upper()
+        if not published:
+            b["pending_n"] += 1
+        elif status not in ("ENDED", "DELETED") and r.get("listing_id") not in sold_listing_ids:
+            b["live_n"] += 1
+            b["ask_total"] += _to_float(r.get("price"), 0.0)
+
+    rows = sorted(buckets.values(), key=lambda b: -b["net"])
+    for b in rows:
+        b["cost_known"] = b["spend"] is not None
+        b["profit"] = (b["net"] - b["spend"]) if b["cost_known"] else None
+        b["roi"] = roi_for(b["net"], b["spend"], b["kind"])
+        b["gap"] = is_basis_gap(b["kind"], b["spend"])
+        b["sell_through"] = sell_through(b["sold_n"], b["live_n"])
+
+    known = [b for b in rows if b["cost_known"]]
+    event_known = [b for b in known if b["kind"] == "event"]
+    total = {
+        "sold_n": sum(b["sold_n"] for b in rows) + unattributed["sold_n"],
+        "gross": sum(b["gross"] for b in rows) + unattributed["gross"],
+        "fee": sum(b["fee"] for b in rows) + unattributed["fee"],
+        "net": sum(b["net"] for b in rows) + unattributed["net"],
+        "ask_total": sum(b["ask_total"] for b in rows),
+        "live_n": sum(b["live_n"] for b in rows),
+        "pending_n": sum(b["pending_n"] for b in rows),
+        "cost": sum(b["spend"] for b in known),
+        "cost_bucket_n": len(known),
+        "profit": sum(b["profit"] for b in known) if known else None,
+    }
+    ev_net, ev_cost = sum(b["net"] for b in event_known), sum(b["spend"] for b in event_known)
+    total["roi"] = (ev_net / ev_cost) if ev_cost > 0 else None
+    total["sell_through"] = sell_through(total["sold_n"], total["live_n"])
+
+    return {
+        "buckets": rows,
+        "unattributed": unattributed,
+        "total": total,
+        "gaps": [b["key"] for b in rows if b["gap"]],
+        "missing_basis_channel": [b["key"] for b in rows
+                                  if b["cost_known"] is False and not b["gap"]],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# terminal table
+# --------------------------------------------------------------------------- #
+
+def _fmt_money(v) -> str:
+    return f"${v:,.0f}" if v is not None else "—"
+
+
+def _fmt_roi(v) -> str:
+    return f"{v:.2f}x" if v is not None else "—"
+
+
+def _fmt_pct(v) -> str:
+    return f"{v:.0f}%" if v is not None else "—"
+
+
+def render_table(d: dict) -> str:
+    cols = ("BUCKET", "LIVE", "ASK $", "SOLD", "GROSS $", "FEES", "NET $",
+            "COST", "PROFIT", "ROI", "SELL-THR", "PENDING")
+    widths = [22, 4, 8, 4, 9, 7, 9, 8, 9, 6, 8, 7]
+    lines = ["  ".join(c.ljust(w) for c, w in zip(cols, widths))]
+    lines.append("-" * (sum(widths) + 2 * (len(widths) - 1)))
+
+    def row(key, b) -> str:
+        gap = " *" if b.get("gap") else "  "
+        cost = _fmt_money(b["spend"]) + gap
+        vals = [key[:22], str(b["live_n"]), _fmt_money(b["ask_total"]),
+                str(b["sold_n"]), _fmt_money(b["gross"]), _fmt_money(b["fee"]),
+                _fmt_money(b["net"]), cost, _fmt_money(b["profit"]),
+                _fmt_roi(b["roi"]), _fmt_pct(b["sell_through"]), str(b["pending_n"])]
+        return "  ".join(v.ljust(w) for v, w in zip(vals, widths))
+
+    for b in d["buckets"]:
+        lines.append(row(b["key"], b))
+    u = d["unattributed"]
+    if u["sold_n"]:
+        lines.append(row(u["key"], {**u, "spend": None, "profit": None, "roi": None,
+                                    "gap": False, "ask_total": 0.0, "live_n": 0,
+                                    "sell_through": None, "pending_n": 0}))
+    t = d["total"]
+    lines.append("-" * (sum(widths) + 2 * (len(widths) - 1)))
+    lines.append(row("TOTAL", {**t, "spend": t["cost"] or None, "gap": False}))
+
+    out = ["\n".join(lines), ""]
+    if d["gaps"]:
+        out.append(f"* basis not recorded (event, missing spend:): {', '.join(d['gaps'])}")
+    out.append(f"cost/profit/ROI totals cover {t['cost_bucket_n']} bucket(s) with a "
+               f"recorded spend: — buckets missing a basis are excluded, never counted "
+               f"as zero cost or pure profit.")
+    out.append("ROI is shown only for `kind: event` buckets with a recorded spend: — "
+               "a `channel` bucket (an ongoing habit, not a single purchase) has no ROI "
+               "by design, not a missing one.")
+    out.append("NET is net_before_postage — sales_ledger.csv carries no actual-postage "
+               "column, so every NET/PROFIT figure here is before postage, not a final "
+               "take-home number.")
+    if u["sold_n"]:
+        out.append(f"{u['sold_n']} sale(s) have no matching local folder — reported as "
+                   f"their own line, not dropped.")
+    return "\n".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# HTML — house style, mirroring tools/sales_report.py
+# --------------------------------------------------------------------------- #
+
+STYLE = """
+:root{
+  --ground:#ECEDEF; --surface:#F8F8F9; --sunk:#E3E5E8;
+  --ink:#17181C; --muted:#6A6E76; --rule:#D7D9DD;
+  --accent:#6B5E8C; --ok:#3E7A5E; --warn:#A6702A;
+  --shadow:0 1px 2px rgba(20,22,26,.07), 0 14px 34px -22px rgba(20,22,26,.30);
+}
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){
+    --ground:#121316; --surface:#1A1C20; --sunk:#0D0E10;
+    --ink:#E9E9EC; --muted:#979BA3; --rule:#2A2D33;
+    --accent:#A99AC9; --ok:#63B189; --warn:#D3A05C;
+    --shadow:0 1px 2px rgba(0,0,0,.5), 0 14px 34px -22px rgba(0,0,0,.8);
+  }
+}
+:root[data-theme="dark"]{
+  --ground:#121316; --surface:#1A1C20; --sunk:#0D0E10;
+  --ink:#E9E9EC; --muted:#979BA3; --rule:#2A2D33;
+  --accent:#A99AC9; --ok:#63B189; --warn:#D3A05C;
+  --shadow:0 1px 2px rgba(0,0,0,.5), 0 14px 34px -22px rgba(0,0,0,.8);
+}
+*{box-sizing:border-box}
+body{margin:0;padding:26px 20px 60px;background:var(--ground);color:var(--ink);
+  font:15px/1.5 "IBM Plex Sans",ui-sans-serif,system-ui,sans-serif}
+.wrap{max-width:1120px;margin:0 auto;display:flex;flex-direction:column;gap:18px}
+.card{background:var(--surface);border:1px solid var(--rule);border-radius:4px;
+  box-shadow:var(--shadow);overflow:hidden}
+.hdr{padding:22px 24px 18px;border-bottom:1px solid var(--rule)}
+.eyebrow{font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);margin:0 0 7px}
+h1{font:600 21px/1.25 "IBM Plex Sans",sans-serif;margin:0}
+.ct{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11.5px;
+  color:var(--muted);margin-top:7px}
+h2{font:600 11px/1 "IBM Plex Sans",sans-serif;letter-spacing:.13em;
+  text-transform:uppercase;color:var(--muted);margin:0 0 14px}
+.pad{padding:22px 24px}
+.stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:1px;
+  background:var(--rule)}
+.stat{background:var(--surface);padding:18px 20px}
+.stat .amt{font:500 26px/1.1 "IBM Plex Mono",ui-monospace,monospace;
+  font-variant-numeric:tabular-nums;color:var(--accent)}
+.stat .lbl{font-size:11px;color:var(--muted);margin-top:6px;letter-spacing:.04em}
+.stat .sub{font-size:11.5px;color:var(--muted);margin-top:3px}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th{text-align:left;font:600 10.5px/1 "IBM Plex Sans",sans-serif;letter-spacing:.1em;
+  text-transform:uppercase;color:var(--muted);padding:0 10px 9px 0;
+  border-bottom:1px solid var(--rule);white-space:nowrap}
+td{padding:8px 10px 8px 0;border-bottom:1px solid var(--rule);vertical-align:top}
+tr.total td{font-weight:600;border-top:2px solid var(--rule)}
+tr:last-child td{border-bottom:0}
+.num{font-family:"IBM Plex Mono",ui-monospace,monospace;font-variant-numeric:tabular-nums;
+  text-align:right;white-space:nowrap}
+.dim{color:var(--muted)}
+.warn{color:var(--warn)}
+.ok{color:var(--ok)}
+a{color:var(--accent)}
+.scroll{overflow-x:auto}
+.note{font-size:12.5px;color:var(--muted);margin:14px 0 0;
+  padding-top:12px;border-top:1px solid var(--rule)}
+.pill{display:inline-block;font:600 10px/1 "IBM Plex Mono",monospace;
+  letter-spacing:.08em;padding:4px 7px;border-radius:3px;border:1px solid var(--rule);
+  color:var(--muted)}
+.pill.warn{color:var(--warn);border-color:var(--warn)}
+"""
+
+
+def _e(s) -> str:
+    return html.escape(str(s if s is not None else ""))
+
+
+def _money(v) -> str:
+    return f"${v:,.2f}" if v is not None else "—"
+
+
+def _stat(amt: str, lbl: str, sub: str = "") -> str:
+    return (f'<div class="stat"><div class="amt">{_e(amt)}</div>'
+            f'<div class="lbl">{_e(lbl)}</div>'
+            + (f'<div class="sub">{_e(sub)}</div>' if sub else "") + "</div>")
+
+
+def _bucket_row(key: str, b: dict, *, total: bool = False, is_bucket: bool = True) -> str:
+    kind = b.get("kind") or "unspecified"
+    gap_pill = ' <span class="pill warn">GAP</span>' if b.get("gap") else ""
+    cost = f'{_money(b["spend"])}' if b.get("cost_known", b.get("spend") is not None) else \
+        '<span class="dim">basis not recorded</span>'
+    profit_cls = "warn" if (b.get("profit") is not None and b["profit"] < 0) else ""
+    tr_open = '<tr class="total">' if total else '<tr>'
+    return (
+        f'{tr_open}<td>{_e(key)}'
+        + (f'<div class="dim" style="font-size:11.5px">{_e(kind)}'
+           + (f' · acquired {_e(b["acquired"])}' if b.get("acquired") else "") + '</div>'
+           if is_bucket and not total else "")
+        + gap_pill + '</td>'
+        f'<td class="num">{b["live_n"]}</td>'
+        f'<td class="num dim">{_money(b["ask_total"])}</td>'
+        f'<td class="num">{b["sold_n"]}</td>'
+        f'<td class="num">{_money(b["gross"])}</td>'
+        f'<td class="num dim">{_money(b["fee"])}</td>'
+        f'<td class="num">{_money(b["net"])}</td>'
+        f'<td class="num">{cost}</td>'
+        f'<td class="num {profit_cls}">{_money(b.get("profit"))}</td>'
+        f'<td class="num">{_fmt_roi(b.get("roi"))}</td>'
+        f'<td class="num">{_fmt_pct(b.get("sell_through"))}</td>'
+        f'<td class="num dim">{b["pending_n"]}</td></tr>'
+    )
+
+
+def draw(d: dict) -> str:
+    from datetime import datetime
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    t = d["total"]
+    rows_html = "".join(_bucket_row(b["key"], b) for b in d["buckets"])
+    u = d["unattributed"]
+    if u["sold_n"]:
+        rows_html += _bucket_row(u["key"], {
+            "kind": None, "spend": None, "cost_known": None, "profit": None, "roi": None,
+            "gap": False, "sell_through": None, "ask_total": 0.0, "live_n": 0,
+            "pending_n": 0, "sold_n": u["sold_n"], "gross": u["gross"], "fee": u["fee"],
+            "net": u["net"],
+        }, is_bucket=False)
+    total_row = _bucket_row("TOTAL", {
+        "kind": None, "spend": t["cost"], "cost_known": t["cost_bucket_n"] > 0,
+        "profit": t["profit"], "roi": t["roi"], "gap": False,
+        "sell_through": sell_through(t["sold_n"], t["live_n"]),
+        "ask_total": t["ask_total"], "live_n": t["live_n"], "pending_n": t["pending_n"],
+        "sold_n": t["sold_n"], "gross": t["gross"], "fee": t["fee"], "net": t["net"],
+    }, total=True)
+
+    gap_note = (f'<p class="note ok" style="border-top:0;padding-top:0">'
+               f'{len(d["gaps"])} bucket(s) flagged GAP — an <code>event</code> '
+               f'acquisition with no recorded <code>spend:</code>: '
+               f'{_e(", ".join(d["gaps"]))}.</p>' if d["gaps"] else "")
+
+    body = (
+        f'<div class="card"><div class="hdr">'
+        f'<p class="eyebrow">ebaybiz · source</p>'
+        f'<h1>Bucket ROI — realised by acquisition</h1>'
+        f'<div class="ct">built {_e(now)} local · read-only, local files only</div>'
+        f'</div>'
+        f'<div class="stats">'
+        + _stat(str(t["cost_bucket_n"]), "buckets with a recorded basis",
+                f'{len(d["buckets"]) - t["cost_bucket_n"]} without one')
+        + _stat(_money(t["cost"]) if t["cost_bucket_n"] else "—", "cost, known buckets only",
+                "excluded, not zeroed, where basis is missing")
+        + _stat(_fmt_roi(t["roi"]), "ROI, event buckets w/ basis",
+                "channel buckets carry no ROI by design")
+        + _stat(str(len(d["gaps"])), "GAP: event, no spend recorded",
+                "a real data gap, not free money")
+        + '</div></div>'
+    )
+
+    body += (
+        '<div class="card"><div class="pad"><h2>By bucket (context.txt ownership)</h2>'
+        f'{gap_note}'
+        '<div class="scroll"><table><tr><th>Bucket</th><th class="num">Live</th>'
+        '<th class="num">Ask $</th><th class="num">Sold</th><th class="num">Gross $</th>'
+        '<th class="num">Fees</th><th class="num">Net $</th><th class="num">Cost</th>'
+        '<th class="num">Profit</th><th class="num">ROI</th><th class="num">Sell-thr %</th>'
+        '<th class="num">Pending</th></tr>'
+        f'{rows_html}{total_row}</table></div>'
+        '<p class="note">A <strong>bucket</strong> is the nearest ancestor directory that '
+        'owns a <code>context.txt</code> — not path depth, so a re-org changes this table\'s '
+        'contents, never its correctness. <strong>NET is net_before_postage</strong>: '
+        '<code>sales_ledger.csv</code> carries no actual-postage column, so PROFIT here is '
+        'before postage, not a final take-home figure. <strong>ROI</strong> (net / cost) is '
+        'shown only for a <code>kind: event</code> bucket with a recorded <code>spend:</code> '
+        '— never 0, never infinite, and never computed for a <code>channel</code> bucket '
+        '(an ongoing habit has no single payback to measure). A bucket with '
+        '"basis not recorded" is a missing field, never rendered as pure profit. Backup/'
+        'scratch directories (<code>_prepped/</code>, <code>.prior-run-bak/</code> and other '
+        'dot-dirs) are excluded from every count.'
+        + (f' {u["sold_n"]} sale(s) matched no local folder — shown as their own line above, '
+           f'not dropped.' if u["sold_n"] else '')
+        + '</p></div></div>'
+    )
+
+    return ('<meta charset="utf-8">\n<title>Source Report</title>\n'
+            '<meta name="viewport" content="width=device-width,initial-scale=1">\n'
+            f'<style>{STYLE}</style>\n<div class="wrap">\n{body}\n</div>\n')
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="report", description="ebaybiz cross-directory source/ROI report (#56).")
+    ap.add_argument("--by-source", action="store_true",
+                    help="bucket ROI by context.txt-owning directory (the only report today)")
+    ap.add_argument("--html", action="store_true",
+                    help=f"also write {OUT_HTML.relative_to(REPO)} in the house style")
+    ap.add_argument("--out", default=str(OUT_HTML), help="HTML output path (with --html)")
+    args = ap.parse_args(argv)
+
+    if not args.by_source:
+        ap.error("choose a report: --by-source")
+
+    d = gather()
+    print(render_table(d))
+
+    if args.html:
+        REPORTS.mkdir(exist_ok=True)
+        out = Path(args.out)
+        out.write_text(draw(d), encoding="utf-8")
+        print(f"\n[OK] {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_source_report.py
+++ b/tests/test_source_report.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Regression tests for lib/source_report.py — bucket ROI reporting (#56).
+
+Covers the acceptance criteria that are unit-testable without a live account:
+bucket resolution by context.txt ownership (not path depth), the context.txt
+parser tolerating all three shapes seen on disk (empty / prose-only / keyed +
+prose), ROI suppression, the missing-basis-vs-channel-kind distinction, and
+end-to-end gather() wiring for backup-dir exclusion + unattributed sales.
+
+Run:  pytest tests/test_source_report.py
+"""
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "lib"))
+
+import source_report as sr  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# bucket_for — nearest ancestor holding a context.txt, not path depth
+# --------------------------------------------------------------------------
+
+def test_bucket_is_the_context_txt_owner_not_the_top_two_segments(tmp_path):
+    # ESTATES/SCJ owns context.txt directly -> it IS the bucket.
+    scj = tmp_path / "ESTATES" / "SCJ"
+    (scj / "item-1").mkdir(parents=True)
+    (scj / "context.txt").write_text("kind: event\nspend: 575\n")
+    assert sr.bucket_for(scj / "item-1", root=tmp_path) == scj
+    assert sr.bucket_for(scj, root=tmp_path) == scj
+
+
+def test_a_sub_lot_two_levels_deep_still_resolves_to_the_owning_bucket(tmp_path):
+    # FREE/more-mags-444 is a sub-lot INSIDE the FREE channel bucket, not a
+    # peer of it — this is exactly the grain the old "top two segments" read
+    # got wrong after the ESTATES re-org.
+    free = tmp_path / "FREE"
+    lot = free / "more-mags-444" / "nested"
+    lot.mkdir(parents=True)
+    (free / "context.txt").write_text("kind: channel\n")
+    assert sr.bucket_for(lot, root=tmp_path) == free
+
+
+def test_a_reorg_that_moves_folders_does_not_change_the_bucket_answer(tmp_path):
+    # Moving SCJ under a different parent doesn't change what "the bucket" is
+    # — it's still "the nearest ancestor with a context.txt", wherever that
+    # ancestor now lives.
+    old = tmp_path / "ESTATES" / "SCJ" / "item-1"
+    old.mkdir(parents=True)
+    (tmp_path / "ESTATES" / "SCJ" / "context.txt").write_text("kind: event\n")
+    new = tmp_path / "ARCHIVE" / "2026" / "SCJ" / "item-1"
+    new.mkdir(parents=True)
+    (tmp_path / "ARCHIVE" / "2026" / "SCJ" / "context.txt").write_text("kind: event\n")
+    assert sr.bucket_for(old, root=tmp_path).name == "SCJ"
+    assert sr.bucket_for(new, root=tmp_path).name == "SCJ"
+    assert sr.bucket_for(old, root=tmp_path) != sr.bucket_for(new, root=tmp_path)
+
+
+def test_no_context_txt_anywhere_up_to_root_is_unresolved(tmp_path):
+    orphan = tmp_path / "MYSTERY" / "item-1"
+    orphan.mkdir(parents=True)
+    assert sr.bucket_for(orphan, root=tmp_path) is None
+
+
+def test_walk_is_bounded_to_root_and_does_not_escape_it(tmp_path):
+    # A context.txt sitting ABOVE root must never be picked up — otherwise an
+    # unrelated file elsewhere on disk could silently become "the bucket".
+    (tmp_path / "context.txt").write_text("kind: event\n")
+    inv = tmp_path / "inventory"
+    orphan = inv / "MYSTERY" / "item-1"
+    orphan.mkdir(parents=True)
+    assert sr.bucket_for(orphan, root=inv) is None
+
+
+def test_bucket_label_is_relative_to_root(tmp_path):
+    scj = tmp_path / "ESTATES" / "SCJ"
+    scj.mkdir(parents=True)
+    assert sr.bucket_label(scj, root=tmp_path) == "ESTATES/SCJ"
+
+
+# --------------------------------------------------------------------------
+# context.txt parsing — empty / prose-only / keyed-plus-prose
+# --------------------------------------------------------------------------
+
+def test_empty_file_parses_to_all_none():
+    assert sr.parse_context("") == {"kind": None, "spend": None, "acquired": None}
+
+
+def test_prose_only_file_does_not_recover_spend_by_pattern_matching():
+    # The whole point of #56: "Spend $575" as ENGLISH must not become the
+    # spend field. Only an explicit `spend:` key line counts.
+    text = ("An estate sale in Social Circle Georgia. Loaded truck twice. "
+            "Spend $575 all told, worth every penny.")
+    got = sr.parse_context(text)
+    assert got == {"kind": None, "spend": None, "acquired": None}
+
+
+def test_keyed_lines_plus_prose_parses_the_keys_and_keeps_the_prose_intact():
+    text = (
+        "kind: event\n"
+        "spend: 575\n"
+        "acquired: 2026-07\n"
+        "\n"
+        "An estate sale in Social Circle Georgia. Loaded truck twice. "
+        "Spend $575 all told, worth every penny.\n"
+    )
+    got = sr.parse_context(text)
+    assert got == {"kind": "event", "spend": 575.0, "acquired": "2026-07"}
+
+
+def test_dollar_sign_and_commas_in_spend_are_tolerated():
+    assert sr.parse_context("spend: $1,250.50\n")["spend"] == 1250.50
+
+
+def test_unrecognised_kind_value_is_treated_as_unset():
+    assert sr.parse_context("kind: garage-sale\n")["kind"] is None
+
+
+def test_load_context_missing_file_is_all_none(tmp_path):
+    assert sr.load_context(tmp_path) == {"kind": None, "spend": None, "acquired": None}
+
+
+def test_load_context_reads_the_real_file(tmp_path):
+    (tmp_path / "context.txt").write_text("kind: channel\n")
+    assert sr.load_context(tmp_path)["kind"] == "channel"
+
+
+# --------------------------------------------------------------------------
+# ROI suppression + missing-basis-vs-channel-kind distinction
+# --------------------------------------------------------------------------
+
+def test_roi_computed_for_an_event_bucket_with_recorded_spend():
+    assert sr.roi_for(1169.0, 575.0, "event") == pytest.approx(1169 / 575)
+
+
+def test_roi_suppressed_not_zero_for_channel_kind_even_with_a_number_present():
+    # A channel bucket with SOME dollar figure recorded still gets no ROI —
+    # the axis is meaningless for an ongoing habit, not merely "zero".
+    assert sr.roi_for(910.0, 100.0, "channel") is None
+
+
+def test_roi_suppressed_not_infinite_when_basis_is_absent():
+    assert sr.roi_for(910.0, None, "event") is None
+
+
+def test_roi_suppressed_when_spend_is_zero_rather_than_a_real_basis():
+    assert sr.roi_for(910.0, 0.0, "event") is None
+
+
+def test_roi_suppressed_when_kind_is_unspecified():
+    assert sr.roi_for(500.0, 200.0, None) is None
+
+
+def test_missing_spend_on_an_event_bucket_is_flagged_a_gap():
+    assert sr.is_basis_gap("event", None) is True
+
+
+def test_missing_spend_on_a_channel_bucket_is_not_a_gap():
+    assert sr.is_basis_gap("channel", None) is False
+
+
+def test_missing_spend_with_unspecified_kind_is_not_asserted_a_gap():
+    # We don't know the intended kind, so this is not confidently flagged as
+    # a data gap — only an explicit `kind: event` triggers the flag.
+    assert sr.is_basis_gap(None, None) is False
+
+
+def test_recorded_spend_on_an_event_bucket_is_not_a_gap():
+    assert sr.is_basis_gap("event", 575.0) is False
+
+
+def test_sell_through_percentage():
+    assert sr.sell_through(sold_n=3, live_n=1) == 75.0
+    assert sr.sell_through(sold_n=0, live_n=0) is None
+
+
+# --------------------------------------------------------------------------
+# backup-dir exclusion
+# --------------------------------------------------------------------------
+
+def test_backup_dirs_are_recognised_by_name_or_dot_prefix():
+    assert sr._is_backup_path("inventory/FREE/_prepped/item-1")
+    assert sr._is_backup_path("inventory/ESTATES/SCJ/.prior-run-bak/item-1")
+    assert sr._is_backup_path("inventory/ESTATES/SCJ/.orig/foo.jpg")
+    assert not sr._is_backup_path("inventory/ESTATES/SCJ/item-1")
+
+
+# --------------------------------------------------------------------------
+# gather() — end-to-end wiring over a small fixture tree
+# --------------------------------------------------------------------------
+
+_SALES_FIELDS = [
+    "order_id", "sold_at", "listing_id", "sku", "title", "quantity", "sold_format",
+    "item_price", "buyer_shipping", "refunded", "gross", "ebay_fee",
+    "net_before_postage", "listed_price", "pct_of_ask", "shoot_dir", "matched_by",
+]
+
+
+def _sale(order_id, shoot_dir, *, gross, fee, net):
+    return {
+        "order_id": order_id, "sold_at": "2026-07-01", "listing_id": f"L{order_id}",
+        "sku": f"s{order_id}", "title": f"t{order_id}", "quantity": "1",
+        "sold_format": "FIXED_PRICE", "item_price": str(gross), "buyer_shipping": "0",
+        "refunded": "0", "gross": str(gross), "ebay_fee": str(fee),
+        "net_before_postage": str(net), "listed_price": str(gross), "pct_of_ask": "100",
+        "shoot_dir": shoot_dir, "matched_by": "listing_id" if shoot_dir else "unmatched",
+    }
+
+
+@pytest.fixture
+def fixture_repo(tmp_path, monkeypatch):
+    """A tiny inventory tree + sales_ledger.csv, wired into source_report's
+    (and its lib/report.py dependency's) module-level path constants."""
+    inv = tmp_path / "inventory"
+    (inv / "ESTATES" / "SCJ" / "item-1").mkdir(parents=True)
+    (inv / "ESTATES" / "SCJ" / "context.txt").write_text("kind: event\nspend: 575\n")
+    (inv / "FREE" / "more-mags-444").mkdir(parents=True)
+    (inv / "FREE" / "context.txt").write_text("kind: channel\n")
+    (inv / "FREE" / "_prepped" / "backup-item").mkdir(parents=True)
+
+    sales = tmp_path / "sales_ledger.csv"
+    rows = [
+        _sale("1", "inventory/ESTATES/SCJ/item-1", gross=100, fee=13, net=87),
+        _sale("2", "inventory/FREE/more-mags-444", gross=20, fee=3, net=17),
+        _sale("3", "", gross=15, fee=2, net=13),                      # unattributed
+        _sale("4", "inventory/FREE/_prepped/backup-item", gross=9, fee=1, net=8),
+    ]
+    with sales.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=_SALES_FIELDS)
+        w.writeheader()
+        w.writerows(rows)
+
+    monkeypatch.setattr(sr, "REPO", tmp_path)
+    monkeypatch.setattr(sr, "INVENTORY", inv)
+    monkeypatch.setattr(sr, "SALES_LEDGER", sales)
+    monkeypatch.setattr(sr._report, "REPO", tmp_path)
+    monkeypatch.setattr(sr._report, "INVENTORY", inv)
+    monkeypatch.setattr(sr._report, "LEDGER", tmp_path / "listings_ledger.csv")
+    return tmp_path
+
+
+def test_gather_buckets_sales_by_context_txt_ownership(fixture_repo):
+    d = sr.gather()
+    by_key = {b["key"]: b for b in d["buckets"]}
+    assert by_key["ESTATES/SCJ"]["sold_n"] == 1
+    assert by_key["ESTATES/SCJ"]["net"] == pytest.approx(87.0)
+    assert by_key["FREE"]["sold_n"] == 1
+    assert by_key["FREE"]["net"] == pytest.approx(17.0)
+
+
+def test_gather_excludes_backup_dirs_from_counts(fixture_repo):
+    d = sr.gather()
+    by_key = {b["key"]: b for b in d["buckets"]}
+    # Only the real FREE sale counts; the _prepped/ backup sale must not
+    # inflate FREE's sold count or gross.
+    assert by_key["FREE"]["sold_n"] == 1
+    assert by_key["FREE"]["gross"] == pytest.approx(20.0)
+
+
+def test_gather_reports_unattributed_sales_as_their_own_line(fixture_repo):
+    d = sr.gather()
+    assert d["unattributed"]["sold_n"] == 1
+    assert d["unattributed"]["net"] == pytest.approx(13.0)
+
+
+def test_gather_flags_event_bucket_gap_and_computes_roi_for_the_known_one(fixture_repo):
+    d = sr.gather()
+    by_key = {b["key"]: b for b in d["buckets"]}
+    assert by_key["ESTATES/SCJ"]["gap"] is False
+    assert by_key["ESTATES/SCJ"]["roi"] == pytest.approx(87 / 575)
+    assert by_key["FREE"]["gap"] is False          # channel, missing spend is correct
+    assert by_key["FREE"]["roi"] is None
+
+
+def test_gather_total_excludes_missing_basis_buckets_from_cost_not_zeros_it(fixture_repo):
+    d = sr.gather()
+    # Only ESTATES/SCJ has a recorded spend; FREE (channel, no spend) must not
+    # contribute 0 to the cost total or otherwise be counted as pure profit.
+    assert d["total"]["cost"] == pytest.approx(575.0)
+    assert d["total"]["cost_bucket_n"] == 1
+
+
+def test_render_table_states_the_postage_boundary(fixture_repo):
+    out = sr.render_table(sr.gather())
+    assert "postage" in out.lower()
+
+
+def test_render_table_never_shows_missing_basis_as_a_profit_number(fixture_repo):
+    d = sr.gather()
+    out = sr.render_table(d)
+    # FREE has no recorded spend and must render as a dash, not as its net
+    # figure standing in for profit.
+    by_key = {b["key"]: b for b in d["buckets"]}
+    assert by_key["FREE"]["profit"] is None
+    assert "basis not recorded" in out or "—" in out


### PR DESCRIPTION
## Summary

Every cross-directory ROI number produced so far came from a throwaway scratchpad script — not reproducible, not tested, gone the moment the session ended, and it already changed a real purchasing decision. This PR makes it a first-class, committed report in the house UI format, following the `tools/sales_report.py` → dashboard pattern:

```
python -m lib.cli report --by-source              # terminal table
python -m lib.cli report --by-source --html       # reports/source_report.html
```

New files:
- `lib/source_report.py` — bucket resolver, `context.txt` parser, gather/report/render logic, CLI entry point.
- `tests/test_source_report.py` — 31 tests.

Changed:
- `lib/cli.py` — registers the `report` verb in the command table.

`lib/dir_context.py` (issue #46) does not exist yet in this repo (checked before starting), so `bucket_for()` / `parse_context()` are self-contained in `lib/source_report.py` per #56's guidance — self-contained, not blocked on #46. A later PR can consolidate into #46's resolver without changing this report's behavior.

This is a **read-only reporting feature over local files**: no eBay API calls, `sales_ledger.csv` is never written to, and no publish/listing logic is touched.

## How each acceptance criterion is satisfied

- **Bucket resolution comes from context.txt ownership, not path depth.** `bucket_for(item_dir, root=INVENTORY)` walks up from an item's directory to the nearest ancestor (inclusive) that holds a `context.txt`, bounded to the inventory root. `ESTATES/SCJ` (owns `context.txt`) and `FREE/more-mags-444` (a sub-lot *inside* the `FREE` channel bucket) now resolve correctly instead of being read as path-depth peers. Covered by `test_bucket_is_the_context_txt_owner_not_the_top_two_segments`, `test_a_sub_lot_two_levels_deep_still_resolves_to_the_owning_bucket`, and `test_a_reorg_that_moves_folders_does_not_change_the_bucket_answer` (moving a bucket's folder elsewhere and re-pointing its `context.txt` still resolves to "the same semantic bucket").
- **`spend:` / `kind:` / `acquired:` parsed from context.txt; prose still works when absent.** `parse_context()` only reads an explicit `key: value` line — prose containing "Spend $575" is deliberately never pattern-matched into the `spend` field (that's the whole point of #56). Tolerates empty, prose-only, and keyed-plus-prose files (`test_empty_file_parses_to_all_none`, `test_prose_only_file_does_not_recover_spend_by_pattern_matching`, `test_keyed_lines_plus_prose_parses_the_keys_and_keeps_the_prose_intact`).
- **Missing basis never renders as profit; event vs channel distinction.** `is_basis_gap(kind, spend)` is `True` only for `kind == "event"` with `spend is None`; a `channel` bucket (or unspecified `kind`) missing spend is correct, not a gap. Cost/profit cells render `"basis not recorded"` (HTML) / `"—"` (terminal), never a rendered profit number. TOTAL row's cost/profit only sums buckets with a known basis — missing-basis buckets are excluded, never treated as $0 cost. (`test_missing_spend_on_an_event_bucket_is_flagged_a_gap`, `test_missing_spend_on_a_channel_bucket_is_not_a_gap`, `test_gather_total_excludes_missing_basis_buckets_from_cost_not_zeros_it`, `test_render_table_never_shows_missing_basis_as_a_profit_number`.)
- **ROI suppressed (not zero, not infinity) where basis is absent or kind: channel.** `roi_for(net, spend, kind)` returns `None` unless `kind == "event"` and `spend` is a positive recorded number. (`test_roi_suppressed_not_zero_for_channel_kind_even_with_a_number_present`, `test_roi_suppressed_not_infinite_when_basis_is_absent`, `test_roi_suppressed_when_spend_is_zero_rather_than_a_real_basis`, `test_roi_suppressed_when_kind_is_unspecified`.)
- **The page states plainly that profit excludes postage.** Both `render_table()`'s footer and `draw()`'s HTML note explicitly say NET is `net_before_postage` and that `sales_ledger.csv` carries no actual-postage column. (`test_render_table_states_the_postage_boundary`.)
- **Backup dirs excluded from counts.** `_is_backup_path()` matches `_prepped/`, `.prior-run-bak/`, and (generalized, since every other backup/scratch dir this repo already produces under `inventory/` — `.orig/`, `.scratch/`, `.tonecheck/`, `.comps/` — is dot-prefixed) any dot-prefixed component, applied to both sold-item paths and drafted/live listing paths before bucket attribution. (`test_backup_dirs_are_recognised_by_name_or_dot_prefix`, `test_gather_excludes_backup_dirs_from_counts`.)
- **Unattributed sales reported as their own line, not dropped.** A sale with no `shoot_dir`, or one that resolves to no bucket, accumulates into a synthetic `"— unattributed (no matching folder) —"` row shown in both outputs. (`test_gather_reports_unattributed_sales_as_their_own_line`.)
- **Reachable at a stable CLI verb, covered by tests.** `python -m lib.cli report --by-source` / `--html`, registered in `lib/cli.py`'s `COMMANDS` table; 31 tests in `tests/test_source_report.py`.

## Caveats / inferred design decisions

- **No real sample data was available to develop against.** `/inventory/` and `sales_ledger.csv` are gitignored (real business data) and don't exist in this worktree, so every `context.txt` shape and every sale row used during development is a hand-built fixture mirroring the shapes described in the issue. Please sanity-check the terminal/HTML output against real data before merging.
- **LIVE / ask $ / drafted-synced-pending are best-effort**, built from local `draft*.md` + `listings_ledger.csv` (via `lib/report.py`'s existing `collect()`), not a live eBay read. This inherits `lib/report.py`'s own documented gap: a CHOICE group listing (`draft_group.md`) never reaches `listings_ledger.csv`, so its live/ended state is inferred from the draft's own `published_at` plus whether it also appears in `sales_ledger.csv`. `tools/sales_report.py`'s "shop right now" panel (drawn from the eBay-synced `inventory_sheet.csv`) remains the authoritative shop-wide LIVE count; this report's LIVE/ask columns are for comparing buckets against each other, not a replacement for it. Documented in the module docstring and in `_collect_listings()`.
- **ROI = net / spend** (not gross / spend), matching the issue's own illustrative table (e.g. SCJ: 1169 net / 575 cost = 2.03x).
- **An unspecified `kind:`** (neither `event` nor `channel`, or the key absent) is treated like `channel` for ROI purposes (suppressed) but is *not* asserted as a gap even if spend is also missing — only an explicit `kind: event` triggers the GAP flag, since we can't confidently assume intent otherwise. This is a bit more conservative than the letter of the issue but consistent with its spirit ("kind matters because the two axes are not comparable").
- **Backup-dir exclusion is generalized to any dot-prefixed path component**, not just the two names the issue lists, since every other backup/scratch directory already in this repo's conventions is dot-prefixed. Happy to narrow this to an exact-match list if preferred.

## Test plan

- [x] `python -m pytest tests/ -q` — 311 passed, 1 skipped (the pre-existing CLIP gate test, same as CI), run twice per the CI workflow's own convention.
- [x] `python -m lib.cli report --by-source` and `... --html` manually smoke-tested against a hand-built fixture tree (bucket ROI, gap flag, channel suppression, backup-dir exclusion, unattributed line all verified) and against this (empty, since `/inventory/` isn't present) worktree — degrades to an all-zero table without error.
- [x] `git ls-files '*.py' | xargs python -m py_compile` — clean.

Closes #56


---
_Generated by [Claude Code](https://claude.ai/code/session_01KD2za7CqJ5Y6KgJL7QHZeQ)_