### PR TITLE
PREP categories: extend the profile schema for per-category customization

### DIFF
--- a/lib/photo_prep/categories.py
+++ b/lib/photo_prep/categories.py
@@ -21,11 +21,12 @@ whole set once.
 WHAT A CATEGORY IS ALLOWED TO SET
 
 Only the inputs to a measurement, never the result of one. A category may say
-which detector to believe, which looks are worth rendering, and how tight the
-framing should be. It may NOT pre-approve a stage, assert an orientation, or
-choose a frame's crop box -- those are decided per frame, by measurement and by
-the operator at the gate. The four-stage order and the human gates are unchanged
-by any category (see prompts/prep.md).
+which detector to believe, which looks are worth rendering, how tight the
+framing should be, and which of the RENDERED looks to show first. It may NOT
+pre-approve a stage, assert an orientation, or choose a frame's crop box --
+those are decided per frame, by measurement and by the operator at the gate.
+The four-stage order and the human gates are unchanged by any category (see
+prompts/prep.md).
 
 WHY `looks` IS A FILTER AND NOT A CHOICE
 
@@ -35,18 +36,131 @@ one look is saying "the comparison is not live for this kind of item", which is
 true for printed media and is why the batch is six times faster; it is not
 saying "this look is approved".
 
+THE SCHEMA (issue #23 -- carrying more than `subject` + `looks`)
+
+The two shipped categories only needed a detector and a look filter, which is
+why that was the whole schema for a while. A category is a statement about the
+GOODS, though, and the goods also determine the framing and which of the
+rendered looks is worth showing first -- so the profile now carries those too.
+Every key below is optional; an absent one means "keep PREP's own default",
+which is what makes `default` and `printed` stay exactly as they were.
+
+  * `subject`, `looks` -- unchanged, see above.
+  * `aspect`, `pad` -- the same framing knobs `--aspect`/`--pad` already set
+    (see `center_crop.DEFAULT_ASPECT`-equivalent constants in `prep.py`). A
+    flat catalog and a ring do not want the same margin; this is an INPUT to
+    `plan_crop`, exactly like the flags it replaces, not a crop box.
+  * `default_look` -- which of the RENDERED looks the shoot defaults to,
+    replacing `color.default_preset_for`'s backdrop/warmth heuristic when set.
+    This is not a wider power than the heuristic already had: adopting a
+    default into `listing/` was already automatic (`run_apply`'s auto-pick),
+    already just a default, and already fully subordinate to a deliberate
+    `--pick` and to the approval gate. A category naming one look is doing the
+    same thing the heuristic does, on the same authority.
+  * `unskew` -- whether the (retired) unskew stage would apply to this kind of
+    goods, for a round or otherwise non-rectangular item that has no rectangle
+    to square. See UNSKEW below: this is currently inert everywhere, and is
+    carried so a revived stage would not have to re-litigate every category.
+  * `specialization` -- a cross-reference to the matching module under
+    `specializations/`, if one exists (validated at import time so it can
+    never point at a file that is not there). See SPECIALIZATIONS below: it is
+    read-only, and nothing in this module or in PREP acts on it.
+
+WHAT WAS DELIBERATELY LEFT OUT
+
+`pop`. The subject-pass strength is not a category field, because it is
+already not a free variable once a preset renders: every entry in
+`color.PRESETS` bakes in its own `pop` level (`studio` and `half` and `tenth`
+are "gentle", `punch` is "strong", `crisp` is "off"), and `color.correct` only
+reads its standalone `pop` argument when NO preset is given -- which is never,
+from `run_apply`. That is not a bug this module should paper over with a
+second knob that would either be silently overridden by the preset's own
+`pop` or would have to fight it. The `--pop` flag on the command line stays
+the standalone escape hatch for `color.correct` called without a preset (as
+several unit tests do); a category may not touch it. `_ALLOWED_KEYS` below
+enforces that a category profile setting `pop` is a loud failure at import
+time, not a silent no-op discovered later.
+
+UNSKEW -- WHY THE FIELD ABOVE HAS NO CODE PATH YET
+
+The unskew stage was retired repo-wide in 2026-08 (see `unskew.py`'s module
+docstring): there is no `plan()` any more, for ANY category, so "does unskew
+apply to this category" is already moot -- every shoot's answer is "the stage
+never runs" regardless of what a profile says. The field is carried anyway,
+purely as a forward-looking answer, so that if the stage is ever revived
+nobody has to go back and decide, category by category, whether a round item
+had a rectangle to square. `prep.py._unskewed` never reads it: that function
+replays a warp a shoot was ALREADY PUBLISHED with, and a category declaring
+itself unskew-inapplicable must not be able to retroactively un-publish a real
+historical decision. That is the same "never assert a result" rule as the
+crop box, applied to a stage that happens to be gone.
+
+SPECIALIZATIONS -- WHY THE HOOK IS READ-ONLY
+
+`specializations/` already carries per-category expertise for IDENTIFY --
+maker-mark vocabularies, value tiers, the inspection shots a specialist would
+ask for (see `specializations/README.md`). PREP and IDENTIFY are different
+phases run by different mechanisms (this module is code; IDENTIFY's is a
+prompt reading Markdown on demand), so `specialization` is deliberately just a
+name lookup: it tells a caller which file to go read, and validates that the
+file exists. It is never consulted by anything in this module or in `prep.py`
+that touches a pixel, a crop box, or an approval -- doing so would let an
+IDENTIFY-side judgement call (a maker guess, a value tier) reach into a
+measurement it has no business influencing.
+
+EXPLICIT, NOT INFERRED (the other open question in the issue)
+
+The issue also asks whether a category should be inferrable from the shoot
+path or the draft (e.g. anything under `more-mags-444/` is `printed`), with
+`--category` as an override. This module stays explicit-only: no path or
+draft sniffing. Two reasons, not one:
+
+  * the issue's own text already calls inference the riskier of the two -- "a
+    category invented from taste is a policy change... applied to hundreds of
+    frames before anyone notices it was a guess" applies just as much to an
+    inferred category as to an invented profile, and inference adds a second
+    way to be wrong (a bad match rule) on top of the first (a bad profile);
+  * this repo's own prior automated-triage passes on adjacent "should this be
+    inferred or explicit" questions (elsewhere in this issue tracker) have
+    landed on explicit every time a wrong guess would re-measure hundreds of
+    frames before a human sees it -- which is exactly this decision's shape.
+
+`--category` remains the one and only way a shoot gets a category, and it
+persists in the manifest so a later pass that omits the flag gets the same
+answer rather than silently falling back to `default` (see `prep.category_of`).
+
 ADDING ONE
 
 Keep it grounded. Every field should trace to something observed on a real
 shoot, and the docstring should say what. A category invented from taste is a
 policy change wearing a config file, and it will be applied to hundreds of
-frames before anyone notices it was a guess.
+frames before anyone notices it was a guess. That standard is why this module
+still ships only two categories: `jewelry`/`marbles`/`silverplate`-style
+profiles were considered for this issue and set aside, because most of their
+fields would have had nothing to trace to beyond "this seems reasonable" --
+which is precisely the failure mode this section exists to keep out. Extending
+the mechanism (this schema, and the wiring in `prep.py`) is the actual ask;
+a new profile is only worth adding once its fields are grounded the same way
+`printed`'s already are.
 """
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
 DEFAULT_CATEGORY = "default"
+
+# Every key a profile is allowed to carry. Anything else is a typo or a field
+# that was rejected on purpose (see `pop` in the module docstring) -- both are
+# a loud failure here rather than a silent no-op discovered downstream.
+_ALLOWED_KEYS = frozenset({
+    "label", "subject", "looks", "aspect", "pad", "default_look", "unskew",
+    "specialization",
+})
+
+# Where the specialization cross-reference is validated against. Repo root is
+# two parents up from lib/photo_prep/categories.py.
+_SPECIALIZATIONS_DIR = Path(__file__).resolve().parents[2] / "specializations"
 
 
 # Each profile is the *complete* set of overrides for its category. A key that
@@ -73,12 +187,65 @@ CATEGORIES: dict[str, dict] = {
     # already the standing practice (run_apply's docstring named it before this
     # module existed); the category makes it the default rather than a flag
     # someone has to remember on every shoot.
+    #
+    # No aspect/pad/default_look/unskew/specialization: nothing observed about
+    # a printed shoot says its framing, its default look among the ones it
+    # still renders (there is only one), or its unskew-applicability should
+    # differ from the generic case, and there is no specializations/ module
+    # keyed on "printed media" to point at.
     "printed": dict(
         label="flat printed goods — catalogs, magazines, sleeves",
         subject="paper",
         looks=("asshot",),
     ),
 }
+
+
+def _validate() -> None:
+    """Fail at import time, not three re-runs later on a real batch.
+
+    A profile is plain data, so a typo in it is not a syntax error -- it is a
+    shoot that renders nothing, references a preset that does not exist, or
+    (new in #23) points `specialization` at a file nobody wrote. All of that
+    is cheap to catch here and expensive to catch on a live shoot.
+    """
+    from . import color as colormod
+
+    for name, prof in CATEGORIES.items():
+        unknown = set(prof) - _ALLOWED_KEYS
+        if unknown:
+            raise ValueError(
+                f"category {name!r} sets unknown field(s) {sorted(unknown)!r}. "
+                f"'pop' in particular is deliberately not a category field -- "
+                f"see the module docstring's WHAT WAS DELIBERATELY LEFT OUT.")
+
+        look = prof.get("default_look")
+        if look is not None and look not in colormod.PRESETS:
+            raise ValueError(
+                f"category {name!r} sets default_look={look!r}, which is not "
+                f"a preset in color.PRESETS")
+        rendered = prof.get("looks")
+        if look is not None and rendered and look not in rendered:
+            raise ValueError(
+                f"category {name!r} sets default_look={look!r}, which its own "
+                f"looks={rendered!r} never renders -- a default has to be "
+                f"among the RENDERED set (see WHY `looks` IS A FILTER)")
+
+        pad = prof.get("pad")
+        if pad is not None and not (0.0 <= float(pad) < 1.0):
+            raise ValueError(
+                f"category {name!r} sets pad={pad!r}, outside [0, 1)")
+
+        spec = prof.get("specialization")
+        if spec is not None:
+            path = _SPECIALIZATIONS_DIR / f"{spec}.md"
+            if not path.is_file():
+                raise ValueError(
+                    f"category {name!r} points specialization at {spec!r}, "
+                    f"but {path} does not exist")
+
+
+_validate()
 
 
 def names() -> tuple:
@@ -107,9 +274,65 @@ def subject_for(name: Optional[str]) -> str:
     return profile(name).get("subject", "auto")
 
 
+def aspect_for(name: Optional[str]) -> Optional[str]:
+    """The category's preferred crop aspect ("W:H", or "orig"), or None.
+
+    None means "PREP's own default (`prep.DEFAULT_ASPECT`) applies" -- the same
+    convention `looks`/`subject` already use, and what keeps `default` and
+    `printed` byte-for-byte unchanged by this field existing.
+    """
+    return profile(name).get("aspect")
+
+
+def pad_for(name: Optional[str]) -> Optional[float]:
+    """The category's preferred crop margin, or None for `prep.DEFAULT_PAD`."""
+    pad = profile(name).get("pad")
+    return float(pad) if pad is not None else None
+
+
+def default_look_for(name: Optional[str]) -> Optional[str]:
+    """The look this category defaults to among the ones it renders, or None.
+
+    None means "fall back to `color.default_preset_for`'s backdrop/warmth
+    heuristic" -- exactly what happens today. See the module docstring for why
+    this is not a wider authority than that heuristic already had.
+    """
+    return profile(name).get("default_look")
+
+
+def unskew_applies_for(name: Optional[str]) -> bool:
+    """Whether the (retired) unskew stage would apply to this category.
+
+    Always True unless a profile says otherwise, and -- see UNSKEW in the
+    module docstring -- currently read by nothing that plans or replays a
+    warp. It exists so a revived stage would not start from zero.
+    """
+    return bool(profile(name).get("unskew", True))
+
+
+def specialization_for(name: Optional[str]) -> Optional[str]:
+    """The specializations/ module this category cross-references, or None.
+
+    Read-only. Nothing here or in `prep.py` acts on this value -- see
+    SPECIALIZATIONS in the module docstring for why an IDENTIFY-side
+    judgement must not reach into a PREP measurement.
+    """
+    return profile(name).get("specialization")
+
+
 def describe(name: Optional[str]) -> str:
     p = profile(name)
     looks = p.get("looks")
-    return (f"{name or DEFAULT_CATEGORY}: {p.get('label', '')} "
-            f"[subject={p.get('subject', 'auto')}, "
-            f"looks={'all' if not looks else '+'.join(looks)}]")
+    bits = [f"subject={p.get('subject', 'auto')}",
+            f"looks={'all' if not looks else '+'.join(looks)}"]
+    if p.get("aspect"):
+        bits.append(f"aspect={p['aspect']}")
+    if p.get("pad") is not None:
+        bits.append(f"pad={p['pad']}")
+    if p.get("default_look"):
+        bits.append(f"default_look={p['default_look']}")
+    if not p.get("unskew", True):
+        bits.append("unskew=n/a")
+    if p.get("specialization"):
+        bits.append(f"specialization={p['specialization']}")
+    return f"{name or DEFAULT_CATEGORY}: {p.get('label', '')} [{', '.join(bits)}]"

--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -955,6 +955,16 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
 
     aspect = _parse_aspect(m["settings"].get("aspect", DEFAULT_ASPECT))
     pad = float(m["settings"].get("pad", DEFAULT_PAD))
+    # NOT forwarded to colormod.correct below, and that is deliberate rather
+    # than the wart it looks like (#23). Every render here goes through a
+    # PRESET, and every preset in color.PRESETS already bakes in its own `pop`
+    # level -- `correct()`'s standalone `pop` argument is only ever read when
+    # NO preset is given, which run_apply never does. A category re-exposing
+    # this as a second knob would either be silently overridden by the
+    # preset's own `pop` or have to fight it, so categories.py refuses to let
+    # a profile set it at all (see its module docstring). This local stays
+    # only so it keeps showing up in the manifest's `settings` for the
+    # standalone `color.correct(..., preset=None)` path the unit tests use.
     pop = m["settings"].get("pop", "gentle")
     smode = subject_mode(m)
 
@@ -1102,19 +1112,32 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
             print(f"  kept the look already chosen for this shoot: {prior}")
         return m
 
-    default = colormod.default_preset_for(
-        shoot_class, warm_subject=warm, new_item=not _already_listed(shoot))
-    # Nothing else was rendered, so the backdrop's usual default cannot be shown
-    # or picked. Adopting it anyway would point listing/ at files that do not
-    # exist.
-    if only and default not in only:
-        default = only[0]
+    # A category's declared default_look (#23) replaces the backdrop/warmth
+    # heuristic outright rather than competing with it -- "for this kind of
+    # goods, THIS look is the one worth showing first" is the same authority
+    # the heuristic already had (a default, subordinate to --pick and to the
+    # approval gate either way), just stated per category instead of derived
+    # per shoot. Only honoured when it was actually rendered under `only`;
+    # otherwise fall through so a narrowed batch never adopts a look it never
+    # produced.
+    cat_default = catmod.default_look_for(category_of(m))
+    if cat_default and (not only or cat_default in only):
+        default = cat_default
+    else:
+        default = colormod.default_preset_for(
+            shoot_class, warm_subject=warm, new_item=not _already_listed(shoot))
+        # Nothing else was rendered, so the backdrop's usual default cannot be
+        # shown or picked. Adopting it anyway would point listing/ at files
+        # that do not exist.
+        if only and default not in only:
+            default = only[0]
     save_manifest(shoot, m)
     m = run_pick(shoot, default, quiet=True, auto=True)
     if not quiet:
         warm_note = (f", warm-metal subject (median R-B {shoot_rb:.0f})" if warm
                      else f" (median R-B {shoot_rb:.0f})")
-        print(f"  default look for a {shoot_class or 'mixed'} backdrop{warm_note}: "
+        source = "category default" if default == cat_default and cat_default else f"{shoot_class or 'mixed'} backdrop"
+        print(f"  default look for a {source}{warm_note}: "
               f"{default} (--pick {'|'.join(colormod.PRESETS)} to change)")
     return m
 
@@ -1622,7 +1645,14 @@ def _unskewed(img: np.ndarray, sm, sk) -> tuple:
     sheets — is looking at identical pixels.
 
     The unskew stage is gone. This exists so the frames that were published with
-    a warp recorded re-render to the pixels a buyer is already looking at."""
+    a warp recorded re-render to the pixels a buyer is already looking at.
+
+    Deliberately does not consult `categories.unskew_applies_for` (#23). That
+    field says whether a category's goods HAVE a rectangle worth squaring, were
+    the stage ever revived -- it says nothing about a warp a shoot was already
+    PUBLISHED with. A category declaring itself unskew-inapplicable must not be
+    able to retroactively un-publish a real historical decision; only the
+    per-frame recorded `Skew` decides whether this replays anything."""
     if not getattr(sk, "applied", False):
         return img, sm
     return (skewmod.apply(img, sk),
@@ -2187,8 +2217,17 @@ def main(argv=None) -> int:
     ap.add_argument("--decisions", action="store_true",
                     help="print the decision record and its digest, and report "
                          "any stage whose decisions have changed since sign-off")
-    ap.add_argument("--aspect", default=DEFAULT_ASPECT, help="target aspect W:H (default 1:1; 'orig' to keep)")
-    ap.add_argument("--pad", type=float, default=DEFAULT_PAD, help=f"margin around the subject, as a fraction of its own box (default {DEFAULT_PAD})")
+    # No hardcoded default here any more: None means "nothing explicit", and
+    # main() below resolves that to the CATEGORY's aspect/pad (categories.py
+    # #23) before falling back to DEFAULT_ASPECT/DEFAULT_PAD -- so an explicit
+    # flag still outranks the category, exactly like --subject already does.
+    ap.add_argument("--aspect", default=None,
+                    help=f"target aspect W:H (default {DEFAULT_ASPECT}, or the "
+                         f"category's own if it sets one; 'orig' to keep)")
+    ap.add_argument("--pad", type=float, default=None,
+                    help=f"margin around the subject, as a fraction of its own "
+                         f"box (default {DEFAULT_PAD}, or the category's own "
+                         f"if it sets one)")
     ap.add_argument("--category", default=None, choices=list(catmod.names()),
                     help="what KIND of goods this shoot is: sets the subject "
                          "detector and which looks are rendered, in one flag. "
@@ -2225,6 +2264,16 @@ def main(argv=None) -> int:
     subject = args.subject or (catmod.subject_for(args.category) if args.category
                                else stored_subject)
 
+    # Framing is category-shaped too (#23): a flat catalog and a ring do not
+    # want the same margin. Same precedence as --subject above -- an explicit
+    # flag always outranks the category, which is the one place a category may
+    # feed a MEASUREMENT (plan_crop's aspect/pad inputs), never its result.
+    cat_pad = catmod.pad_for(category)
+    aspect_s = args.aspect if args.aspect is not None else (
+        catmod.aspect_for(category) or DEFAULT_ASPECT)
+    pad = args.pad if args.pad is not None else (
+        cat_pad if cat_pad is not None else DEFAULT_PAD)
+
     # Changing either one re-measures every box downstream, so the sign-offs
     # those boxes earned are dropped HERE rather than silently carried over onto
     # different numbers. This is the invalidation issue #21 wants to make
@@ -2252,7 +2301,7 @@ def main(argv=None) -> int:
         _print_status(shoot, m)
         return 0
     if args.auto:
-        run_auto(shoot, args.aspect, args.pad, args.pop,
+        run_auto(shoot, aspect_s, pad, args.pop,
                  subject=subject, category=category, quiet=args.quiet)
         return 0
     if args.approve_auto:
@@ -2310,13 +2359,13 @@ def main(argv=None) -> int:
 
     if args.check or not args.apply:
         print(f"PREP check — {shoot}")
-        m = run_check(shoot, args.aspect, args.pad, args.pop, subject, category, quiet=args.quiet)
+        m = run_check(shoot, aspect_s, pad, args.pop, subject, category, quiet=args.quiet)
         _print_status(shoot, m)
         print(f"  rotation sheet: {shoot / '.prep' / 'rotation_sheet.jpg'}")
     if args.apply:
         print(f"PREP apply — {shoot}")
         if not load_manifest(shoot).get("photos"):
-            run_check(shoot, args.aspect, args.pad, args.pop, subject, category, quiet=True)
+            run_check(shoot, aspect_s, pad, args.pop, subject, category, quiet=True)
         m = run_apply(shoot, quiet=args.quiet, only=tuple(_pairs(getattr(args, 'only', None))))
         _print_status(shoot, m)
     return 0

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -19,6 +19,7 @@ download needed — the colour tests pass an explicit mask.
 Run:  python tests/test_prep.py
   or: pytest tests/test_prep.py
 """
+import contextlib
 import json
 import sys
 import tempfile
@@ -1633,3 +1634,227 @@ def test_gc_keeps_the_chosen_look_and_is_dry_by_default():
         assert left == [chosen], left
         # The shipped files are the point of the whole exercise.
         assert list((shoot / "listing").glob("*.jpg"))
+
+
+# ---------------------------------------------------------------------------
+# category profiles, extended schema (#23) — aspect/pad/default_look/unskew
+#
+# The two shipped categories (`default`, `printed`) must keep behaving exactly
+# as before: neither sets any of the new fields, so every one of these has to
+# fall back to PREP's own default. The new wiring is exercised with a
+# TEMPORARY third category, registered and torn down per test, so a mistake in
+# one of these tests can never leak a fake category into the real registry
+# that ships.
+# ---------------------------------------------------------------------------
+
+@contextlib.contextmanager
+def _temp_category(name: str, prof: dict):
+    """Register `name` -> `prof` in the live CATEGORIES table for one test.
+
+    Runs the same `_validate()` the real table runs at import time, so a test
+    fixture that would itself be rejected (an unknown key, a bad default_look)
+    fails loudly rather than silently exercising something invalid.
+    """
+    assert name not in CAT.CATEGORIES, f"{name!r} collides with a real category"
+    CAT.CATEGORIES[name] = prof
+    try:
+        CAT._validate()
+        yield
+    finally:
+        del CAT.CATEGORIES[name]
+
+
+def test_default_and_printed_carry_no_new_fields():
+    """Backward compatibility, stated as data rather than as an assertion
+    about behaviour: if either shipped category ever grows one of these
+    fields, it becomes a deliberate change to what already ships, not a
+    silent side effect of #23 landing."""
+    for name in ("default", "printed"):
+        assert CAT.aspect_for(name) is None, name
+        assert CAT.pad_for(name) is None, name
+        assert CAT.default_look_for(name) is None, name
+        assert CAT.unskew_applies_for(name) is True, name
+        assert CAT.specialization_for(name) is None, name
+
+
+def test_unknown_field_is_refused_at_validation_time():
+    """A typo in a profile is not a syntax error — catch it here, not three
+    re-runs later on a real batch (see categories._validate's docstring)."""
+    try:
+        with _temp_category("bogus_field_cat", dict(label="t", nonsense_key=1)):
+            pass
+    except ValueError as e:
+        assert "nonsense_key" in str(e)
+    else:
+        raise AssertionError("an unknown field was accepted")
+
+
+def test_pop_is_refused_even_though_it_looks_plausible():
+    """The one field candidate this issue deliberately rejected (see the
+    module docstring's WHAT WAS DELIBERATELY LEFT OUT): every preset already
+    bakes in its own subject-pass strength, so a category-level `pop` would
+    either be silently overridden or fight the preset's own value."""
+    assert "pop" not in CAT._ALLOWED_KEYS
+    try:
+        with _temp_category("popcat", dict(label="t", pop="strong")):
+            pass
+    except ValueError as e:
+        assert "pop" in str(e)
+    else:
+        raise AssertionError("a category-level pop override was accepted")
+
+
+def test_default_look_must_be_a_real_rendered_preset():
+    try:
+        with _temp_category("badlook", dict(label="t", default_look="cinematic")):
+            pass
+    except ValueError as e:
+        assert "cinematic" in str(e)
+    else:
+        raise AssertionError("a non-existent default_look was accepted")
+
+    try:
+        with _temp_category("narrowlook",
+                            dict(label="t", looks=("asshot",), default_look="studio")):
+            pass
+    except ValueError as e:
+        assert "never renders" in str(e)
+    else:
+        raise AssertionError("a default_look outside the category's own looks was accepted")
+
+
+def test_specialization_must_point_at_a_real_module():
+    """Read-only cross-reference to specializations/ (issue #23's IDENTIFY
+    hook) -- validated so it can never dangle."""
+    try:
+        with _temp_category("ghostspec", dict(label="t", specialization="unicorns")):
+            pass
+    except ValueError as e:
+        assert "unicorns" in str(e)
+    else:
+        raise AssertionError("a specialization with no matching file was accepted")
+
+    # marbles.md is a real file in specializations/ -- this must NOT raise.
+    with _temp_category("realspec", dict(label="t", specialization="marbles")):
+        assert CAT.specialization_for("realspec") == "marbles"
+
+
+def test_category_aspect_and_pad_flow_through_the_cli_and_an_explicit_flag_wins():
+    """Same precedence --subject already has: an explicit flag outranks the
+    category, and the category outranks PREP's own DEFAULT_ASPECT/DEFAULT_PAD."""
+    with _temp_category("hoopring", dict(label="t", subject="auto",
+                                         aspect="4:5", pad=0.05)):
+        with tempfile.TemporaryDirectory() as td:
+            shoot = _shoot(Path(td) / "s", n=1)
+            P.main([str(shoot), "--check", "--category", "hoopring", "--quiet"])
+            settings = P.load_manifest(shoot)["settings"]
+            assert settings["aspect"] == "4:5"
+            assert settings["pad"] == 0.05
+
+            # An explicit --aspect/--pad still wins over the category.
+            P.main([str(shoot), "--check", "--aspect", "1:1", "--pad", "0.3",
+                    "--quiet"])
+            settings = P.load_manifest(shoot)["settings"]
+            assert settings["aspect"] == "1:1"
+            assert settings["pad"] == 0.3
+
+
+def test_category_with_no_aspect_or_pad_still_gets_prep_defaults():
+    """The `printed` category sets neither -- confirming the CLI resolution
+    added for #23 does not disturb the case that carried no opinion."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=1)
+        P.main([str(shoot), "--check", "--category", "printed", "--quiet"])
+        settings = P.load_manifest(shoot)["settings"]
+        assert settings["aspect"] == P.DEFAULT_ASPECT
+        assert settings["pad"] == P.DEFAULT_PAD
+
+
+def test_apply_adopts_the_categorys_default_look_and_pick_still_overrides():
+    """A category's default_look replaces the backdrop/warmth heuristic, on
+    exactly the same authority the heuristic already had: a default, not a
+    pick, and --pick still overrides it (see run_apply's comment for #23)."""
+    with _temp_category("asshotfirst",
+                        dict(label="t", subject="auto",
+                             looks=("asshot", "crisp"), default_look="asshot")):
+        with tempfile.TemporaryDirectory() as td:
+            shoot = _shoot(Path(td) / "s", n=1)
+            P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle",
+                      category="asshotfirst", quiet=True)
+            P.run_approve_auto(shoot)
+            m = P.run_apply(shoot, quiet=True)
+
+            assert m["chosen_preset"] == "asshot"
+            assert m["preset_source"] == "default"
+            assert not m["preset_picked_by_operator"]
+
+            # The gate is still a separate yes, and --pick still overrides.
+            m = P.run_pick(shoot, "crisp", quiet=True)
+            assert m["chosen_preset"] == "crisp"
+            assert m["preset_picked_by_operator"]
+
+
+def test_default_look_is_ignored_when_only_never_rendered_it():
+    """A category default that was not actually produced under a narrowed
+    `--only` must not be adopted -- there is no file for `--pick` to find."""
+    with _temp_category("wideonly",
+                        dict(label="t", subject="auto", default_look="studio")):
+        with tempfile.TemporaryDirectory() as td:
+            shoot = _shoot(Path(td) / "s", n=1)
+            P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle",
+                      category="wideonly", quiet=True)
+            P.run_approve_auto(shoot)
+            m = P.run_apply(shoot, quiet=True, only=("asshot",))
+            assert m["chosen_preset"] == "asshot"
+
+
+def test_unskew_replay_does_not_consult_the_category():
+    """#23: `unskew_applies_for` is forward-looking metadata for a stage that
+    was already fully retired (see unskew.py and categories.py's UNSKEW
+    section) -- it must never suppress the replay of a warp a shoot was
+    ALREADY PUBLISHED with. `_unskewed`'s signature does not even take a
+    category, which is the structural half of that guarantee; this pins the
+    behavioural half."""
+    from lib.photo_prep import unskew as U
+    from lib.photo_prep import subject as S
+
+    with _temp_category("roundgoods", dict(label="t", subject="auto", unskew=False)):
+        assert CAT.unskew_applies_for("roundgoods") is False
+
+        img = np.full((100, 100, 3), 200, np.uint8)
+        mask = np.zeros((100, 100), np.uint8)
+        mask[10:90, 10:90] = 255
+        sm = S.describe(mask, "rembg+lab", 1.0, 1.0)
+        sk = U.from_dict({"applied": True, "reason": "legacy",
+                          "quad": [[0, 0], [100, 0], [100, 100], [0, 100]],
+                          "dst": [[0, 0], [60, 0], [60, 60], [0, 60]],
+                          "out_size": [60, 60]})
+
+        out_img, out_sm = P._unskewed(img, sm, sk)
+        assert out_img.shape[:2] == (60, 60), "the legacy warp did not replay"
+        assert out_sm.mask.shape[:2] == (60, 60)
+
+
+def test_changing_category_drops_crop_and_colour_signoff():
+    """Issue #21's guarantee, exercised for the trigger #23 adds fields to:
+    every box below the detector was measured against the OLD category (a
+    different subject mode, a different aspect/pad), so changing it has to
+    drop those sign-offs exactly like changing `--subject` already does."""
+    with _temp_category("switched", dict(label="t", subject="auto", aspect="4:5")):
+        with tempfile.TemporaryDirectory() as td:
+            shoot = _shoot(Path(td) / "s", n=1)
+            P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+            P.run_approve_auto(shoot)
+            m = P.load_manifest(shoot)
+            for st in m["stages"]:
+                m["stages"][st] = {"approved": True, "approved_at": "x"}
+            m["approved"] = True
+            P.save_manifest(shoot, m)
+
+            P.main([str(shoot), "--category", "switched", "--status"])
+
+            m = P.load_manifest(shoot)
+            assert m["stages"]["crop"]["approved"] is False
+            assert m["stages"]["color"]["approved"] is False
+            assert not m["approved"]
+            assert m["settings"]["category"] == "switched"


### PR DESCRIPTION
## The ask

`--category` (v3.1) only exposed two knobs, `subject` and `looks` — enough for `default` and `printed`, but not enough for the next category to be a data change instead of a code change. Issue #23 asked for the mechanism to carry the rest of what a category actually determines, without loosening the constraint that a category may only feed a *measurement*, never assert its *result*.

## What's new in the schema (`lib/photo_prep/categories.py`)

Every field is optional; an absent one keeps PREP's own default, which is what keeps `default` and `printed` byte-for-byte unchanged.

- **`aspect` / `pad`** — the same framing knobs `--aspect`/`--pad` already set. Wired into `prep.py main()` with the same precedence `--subject` already has: an explicit flag outranks the category, which outranks `DEFAULT_ASPECT`/`DEFAULT_PAD`.
- **`default_look`** — which of the *rendered* looks a shoot defaults to, replacing `color.default_preset_for`'s backdrop/warmth heuristic when set. This isn't a wider authority than the heuristic already had: adopting a default into `listing/` was already automatic, already just a default, and already fully subordinate to `--pick` and the approval gate. A category naming one look does the same thing on the same authority. Only honoured when the look was actually rendered under `--only`; otherwise falls through so a narrowed batch never adopts a look it never produced.
- **`unskew`** — carried for forward compatibility, but currently **inert everywhere**: the unskew stage was already fully retired repo-wide (no `plan()` exists for any category). `prep._unskewed` deliberately never reads this field — it replays a warp a shoot was *already published* with, and a category declaring itself unskew-inapplicable must never be able to retroactively un-publish a real historical decision. Test (`test_unskew_replay_does_not_consult_the_category`) pins that decoupling.
- **`specialization`** — a read-only, validated cross-reference to the matching module under `specializations/` (IDENTIFY's expertise, e.g. `jewelry.md`/`marbles.md`). Validated to exist at import time. Nothing in `categories.py` or `prep.py` acts on it — PREP and IDENTIFY are different phases (one code, one prompt-driven), and a category must not let an IDENTIFY-side judgement call reach into a PREP measurement.

All new fields are enforced by an `_ALLOWED_KEYS` check + `_validate()` that runs at import time (typo in a profile is a loud failure, not a shoot that silently renders wrong three re-runs later).

## Decisions from the issue's open list

- **`pop` is resolved as a documented no-op, not a category field.** Every entry in `color.PRESETS` already bakes in its own `pop` level (`studio`/`half`/`tenth` = "gentle", `punch` = "strong", `crisp` = "off"), and `color.correct`'s standalone `pop` argument is only read when *no* preset is given — which `run_apply` never does. A category-level override would either be silently clobbered by the preset's own value or have to fight it, so `categories.py` refuses to let a profile set `pop` at all (enforced, not just documented) — see the module docstring's "WHAT WAS DELIBERATELY LEFT OUT".
- **Explicit, not inferred**, for the "should a category be inferrable from the shoot path" question. No path/draft sniffing was added; `--category` stays the one and only way a shoot gets one. The issue's own text already flags inference as the riskier of the two, and a wrong guess re-measures hundreds of frames before a human sees it — the same shape of risk the "grounded, not invented" rule exists to prevent, just on the *selection* side instead of the *profile* side.
- **No `jewelry`/`marbles`-style category added.** I checked every candidate field against `subject.py`, `color.py`, and `specializations/` looking for something as concrete as `printed`'s grounding (subject.py's paper-detector reasoning, prep.md's "printed media renders asshot"). Most fields for a hypothetical new category would have had nothing to trace to beyond "this seems reasonable" — exactly the failure mode the module's own grounding rule exists to keep out. Extending the mechanism was the actual ask; a new profile is only worth adding once its fields are grounded the same way.

## Constraints kept

- A category still only feeds *inputs* to a measurement — `aspect`/`pad` feed `plan_crop` exactly like the flags they replace; nothing pre-approves a stage, asserts an orientation, or picks a crop box.
- `looks` still narrows what's *rendered*; `default_look` narrows only which of those rendered looks is *auto-adopted* — the colour gate and `--pick` are untouched (same authority the pre-existing heuristic had).
- The four-stage order and every human gate are unchanged.
- Changing a category still drops the downstream sign-offs (issue #21's mechanism) — exercised directly for the new fields' trigger in `test_changing_category_drops_crop_and_colour_signoff`.

## Testing

Extended `tests/test_prep.py` (new "category profiles, extended schema (#23)" section) rather than adding a new file, since the existing category tests already lived there. New coverage:

- schema validation: unknown-field rejection, `pop` refused specifically (with the message naming why), `default_look` must be a real preset *and* among the category's own `looks`, `specialization` must point at a real file (`marbles.md` accepted, a made-up name rejected)
- `default`/`printed` carry none of the new fields (explicit backward-compat pin)
- `--aspect`/`--pad` resolve from the category through the CLI, with an explicit flag still winning
- a category with neither `aspect` nor `pad` set (i.e. `printed`) still gets `DEFAULT_ASPECT`/`DEFAULT_PAD`
- `default_look` is adopted at `--apply` (`preset_source == "default"`) and `--pick` still overrides it afterward
- `default_look` is ignored when `--only` never rendered it
- the unskew-declaration/replay decoupling described above
- category change drops `crop`/`color` stage approval (#21)

New temporary categories are registered/torn down per test via a `_temp_category` context manager (running the real `_validate()`), so nothing leaks into the shipped registry.

```
python -m pytest tests/test_prep.py -v      # 99 passed
python -m pytest tests/ -q                  # 315 passed, 1 skipped (run twice, per CI's own convention)
python tests/run_all.py --fast              # test_prep: 99/99 passed
git ls-files '*.py' | xargs python -m py_compile   # OK
```

Closes #23.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01XwdFnWX1UPfhfkT35omPfg)_