### PR TITLE
feat(prep): default to headless — assume upright, apply crisp, skip the compare

### DIFF
--- a/lib/photo_prep/categories.py
+++ b/lib/photo_prep/categories.py
@@ -53,12 +53,16 @@ DEFAULT_CATEGORY = "default"
 # is absent means "keep PREP's own default", so a profile stays readable as the
 # short list of ways this category actually differs.
 CATEGORIES: dict[str, dict] = {
-    # The unchanged pipeline: believe both detectors, render every look so the
-    # operator can compare at the colour gate.
+    # `crisp` only: camera colour kept, backdrop cleaned, item sharpened hard —
+    # the one look that cannot misrepresent the goods (color.default_preset_for
+    # already picks it for every new item; this just stops rendering the other
+    # five nobody was going to pick instead). Rendering all six cost ~25s/frame
+    # EACH for a comparison that was almost never used — `--filters` at --apply
+    # time renders every look when a shoot genuinely wants the comparison.
     "default": dict(
-        label="no category — every look rendered for comparison",
+        label="crisp only — the house default, auto-applied; --filters for the full comparison",
         subject="auto",
-        looks=None,          # None = all of color.PRESETS
+        looks=("crisp",),
     ),
 
     # Catalogs, magazines, record sleeves, printed ephemera.

--- a/lib/photo_prep/orientation.py
+++ b/lib/photo_prep/orientation.py
@@ -18,18 +18,30 @@ half comes from, in order:
                 whole frame; a magazine cover in a 4096px bedspread shot reads
                 as "too few characters"). Objective, and it covers a large share
                 of this inventory: catalogs, magazines, boxes, cartons, labels.
-                Below `OSD_MIN_CONF` it counts as no answer.
+                Below `OSD_MIN_CONF` it counts as no answer. Only run at all
+                when the caller opts in (`--check-rotation`) — see `assumed`.
   2. `vision` — someone looked and said so, either through PREP's own
                 `--rotate` or through the sibling `orient.py` tool's
                 `orientation.json`. A recorded 0 is a real answer — "confirmed
                 upright" — not the absence of one.
-  3. `ask`    — nobody has answered. The frame keeps its camera rotation only,
-                is marked unresolved, and CANNOT pass the gate.
+  3. `ask`    — nobody has answered AND the caller asked for a check. The frame
+                keeps its camera rotation only, is marked unresolved, and
+                CANNOT pass the gate.
+  4. `assumed`— the shoot convention: items are shot right-side up, so a frame
+                with no `vision` answer and no OSD check is left at 0 rather
+                than sent to the operator. This is the DEFAULT now that PREP
+                is no longer asked to run OSD on every frame — it is what
+                `resolve(..., assume_upright=True)` records when there is
+                nothing else to go on. It is a standing assumption about how
+                the shoot was taken, not a measurement, and `--check-rotation`
+                (which drives `assume_upright=False`) turns the OSD/ask path
+                back on for a shoot where that assumption might not hold.
 
-The rule that makes this trustworthy is the last one. Nothing here infers
-"probably upright" from an aspect ratio and ships it. Round items with no
-defined upright are resolved the same way as everything else — by someone
-looking once and confirming 0.
+The rule that makes `ask` trustworthy is that it never guesses. Nothing here
+infers "probably upright" from an aspect ratio and ships it — `assumed` is a
+declared default, recorded and visible in the notes, not an inference. Round
+items with no defined upright, or any shoot where the convention might not
+hold, still go through `ask` by passing `--check-rotation`.
 
 Angle convention throughout: degrees CLOCKWISE to apply to the stored pixels to
 make them upright. 0 / 90 / 180 / 270 only.
@@ -274,13 +286,23 @@ def _osd_once(bgr: np.ndarray, long_side: int) -> tuple[Optional[int], float, st
 def resolve(name: str,
             exif_tag: Optional[int],
             osd: tuple[Optional[int], float, str],
-            vision: Optional[int] = None) -> OrientVerdict:
+            vision: Optional[int] = None,
+            assume_upright: bool = False) -> OrientVerdict:
     """Compose the camera half and the subject half into one applied angle.
 
     `osd` is measured on the subject AFTER the EXIF bake, so it reports the
     subject half directly. `vision` is a recorded look, also expressed as the
     subject half, and it outranks OSD — a person who looked at the frame beats
     an inference from glyph shapes, including when they disagree.
+
+    `assume_upright` governs the ONLY case where there is neither: no recorded
+    look and no OSD answer (because it wasn't run, or was run and found
+    nothing). False (the default for this function) sends the frame to `ask`
+    — the historical, safe-by-default behaviour, and what every direct caller
+    of `resolve` still gets unless it opts in. `prep.run_check` passes True
+    unless the operator asked for `--check-rotation`, because the shoot
+    convention is now "shot right-side up" and running OSD on every frame to
+    confirm that costs real time for an answer that is almost always 0.
     """
     v = OrientVerdict(name=name, exif_tag=exif_tag)
     osd_a, osd_c, osd_n = osd
@@ -308,6 +330,18 @@ def resolve(name: str,
     elif osd_a is not None:
         v.subject_angle = osd_a
         v.source = "exif+osd" if v.exif_angle else "osd"
+    elif assume_upright:
+        # Nothing to read and nobody asked for a check: fall back to the
+        # shoot convention (shot right-side up) rather than spending an OSD
+        # pass — and an ask — to confirm what almost every frame already is.
+        # This is a declared default, not an inference: it is recorded in the
+        # notes and in `source`, and `--rotate` / `--check-rotation` both
+        # override it the moment either says otherwise.
+        v.subject_angle = 0
+        v.source = "exif+assumed" if v.exif_angle else "assumed"
+        v.needs_ask = False
+        v.notes.append("rotation check skipped — assumed upright per shoot "
+                       "convention (pass --check-rotation to verify instead)")
     else:
         # No objective read of the subject and nobody has looked. The camera
         # half is still applied (it is independently true), but the frame is

--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -779,8 +779,19 @@ def plan_geometry(shoot: Path, quiet: bool = False,
 def run_check(shoot: Path, aspect_s: str, pad: float, pop: str,
               subject: Optional[str] = None,
               category: Optional[str] = None,
-              quiet: bool = False) -> dict:
-    """Analyse every frame; write the manifest, rotation sheet and ask panels."""
+              quiet: bool = False,
+              check_rotation: bool = False) -> dict:
+    """Analyse every frame; write the manifest, rotation sheet and ask panels.
+
+    `check_rotation` is opt-in. The shoot convention is now "shot right-side
+    up", so by default no OSD pass runs at all — the most time-consuming part
+    of `--check` on a multi-frame shoot — and every frame with no recorded
+    look (`--rotate` / `orient.py`) is left at 0 with `source: assumed` (see
+    `orientation.resolve`). Pass `check_rotation=True` (CLI: `--check-rotation`)
+    for a shoot where that assumption might not hold — a mixed box of catalogs
+    shot at whatever angle they landed, say — to get the old OSD + ask-panel
+    behaviour back.
+    """
     from .center_crop import _parse_aspect
 
     images = find_images(shoot)
@@ -798,7 +809,7 @@ def run_check(shoot: Path, aspect_s: str, pad: float, pop: str,
     prior = m.get("photos", {})
     photos: dict = {}
 
-    osd_on = orientmod.osd_available()
+    osd_on = check_rotation and orientmod.osd_available()
     looks = orientmod.recorded_looks(shoot)
     thumbs = []
     ask_dir = shoot / ".prep" / "ask"
@@ -817,8 +828,12 @@ def run_check(shoot: Path, aspect_s: str, pad: float, pop: str,
         # before reading it (see orient.osd_angle).
         cam = orientmod.rotate_bgr(bgr, orientmod.EXIF_ROT.get(exif_tag or 1, 0))
         sm = mask_for(cam, subject)
-        osd = (orientmod.osd_angle(_subject_region(cam, sm.bbox))
-               if osd_on else (None, 0.0, "tesseract not installed"))
+        if osd_on:
+            osd = orientmod.osd_angle(_subject_region(cam, sm.bbox))
+        else:
+            note = ("tesseract not installed" if check_rotation else
+                    "rotation check off — assumed upright (pass --check-rotation to verify)")
+            osd = (None, 0.0, note)
 
         # A recorded look for this frame survives a re-run. The sibling
         # orient.py tool stores the same quantity (degrees CW on top of the EXIF
@@ -828,7 +843,8 @@ def run_check(shoot: Path, aspect_s: str, pad: float, pop: str,
         vision = prev.get("orientation", {}).get("vision_angle")
         if vision is None:
             vision = looks.get(key) or looks.get(path.name)
-        v = orientmod.resolve(path.name, exif_tag, osd, vision)
+        v = orientmod.resolve(path.name, exif_tag, osd, vision,
+                              assume_upright=not check_rotation)
 
         # Segmentation is rotation-invariant — turn the mask with the image.
         upright = orientmod.rotate_bgr(cam, v.subject_angle)
@@ -940,12 +956,15 @@ def _already_listed(shoot: Path) -> bool:
 def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
     """Render listing/ from the manifest's decisions + the review sheet.
 
-    `only` restricts which presets are rendered. Rendering all six exists so the
-    operator can compare looks at the gate; a batch that has already decided —
-    printed media is always `asshot` — spends five sixths of its time producing
-    images nothing will read. At ~64s per frame per preset that is the
-    difference between a 3-hour run and a 17-hour one. The gate is unchanged for
-    anyone who does not pass this: default is still every preset.
+    `only` restricts which presets are rendered. The default category now
+    narrows this to `("crisp",)` — the house default for new items anyway
+    (`color.default_preset_for`) — so a shoot renders and auto-picks ONE look
+    unless something says otherwise: `--only NAME...` for specific looks
+    (`--only asshot` to skip colour correction entirely), or `--filters` to
+    render every preset in `color.PRESETS` for a side-by-side comparison. At
+    ~64s per frame per preset, that comparison is expensive on purpose to skip
+    by default — it is the difference between a 3-hour run and a 17-hour one on
+    a batch that was never going to look at five of the six looks anyway.
     """
     from .center_crop import _parse_aspect
 
@@ -1486,7 +1505,7 @@ def run_stage(shoot: Path, stage: str, quiet: bool = False) -> dict:
 
 def run_auto(shoot: Path, aspect_s: str, pad: float, pop: str,
              subject: Optional[str] = None, category: Optional[str] = None,
-             quiet: bool = False) -> dict:
+             quiet: bool = False, check_rotation: bool = False) -> dict:
     """The FIRST PASS: turn every frame and plan every crop, asking nothing.
 
     The staged review is what PREP is for, and it is also a lot of the
@@ -1516,7 +1535,7 @@ def run_auto(shoot: Path, aspect_s: str, pad: float, pop: str,
     only after the gate, and the gate still wants a human.
     """
     m = run_check(shoot, aspect_s, pad, pop, subject=subject,
-                  category=category, quiet=quiet)
+                  category=category, quiet=quiet, check_rotation=check_rotation)
 
     guessed = []
     for key, rec in m["photos"].items():
@@ -2176,7 +2195,11 @@ def main(argv=None) -> int:
                     help="actually write draft.md for --repoint-draft")
     ap.add_argument("--approve", action="store_true", help="stamp approval (explicit operator yes only)")
     ap.add_argument("--rotate", action="append", nargs="+", metavar="NAME=DEG", help="record a looked-at orientation answer (DEG is RELATIVE to what the sheet shows)")
-    ap.add_argument("--only", action="append", nargs="+", metavar="PRESET", help="render ONLY these presets (batch use; default renders all for comparison)")
+    ap.add_argument("--only", action="append", nargs="+", metavar="PRESET", help="render ONLY these presets (default: just `crisp` — the house default; --filters for every preset)")
+    ap.add_argument("--filters", action="store_true",
+                    help="render every preset in color.PRESETS for a side-by-side "
+                         "comparison, instead of just `crisp` (default). Overridden "
+                         "by an explicit --only.")
     ap.add_argument("--set-rotate", action="append", nargs="+", metavar="NAME=DEG", dest="set_rotate", help="record the ABSOLUTE subject angle — idempotent, use this in generated commands")
     ap.add_argument("--gc", action="store_true",
                     help="list the regenerable byproducts an APPROVED shoot is still holding "
@@ -2200,6 +2223,11 @@ def main(argv=None) -> int:
                          "item. Persists in the manifest.")
     ap.add_argument("--pop", default="gentle", choices=["off", "gentle", "strong"],
                     help="subject pass: saturation/contrast/unsharp (default gentle)")
+    ap.add_argument("--check-rotation", action="store_true", dest="check_rotation",
+                    help="run the OSD rotation check + ask panel for frames it "
+                         "can't read (default: OFF — items are shot right-side "
+                         "up, so every frame with no recorded --rotate answer "
+                         "is assumed upright and no OSD pass runs at all)")
     ap.add_argument("--quiet", action="store_true")
     args = ap.parse_args(argv)
 
@@ -2253,7 +2281,8 @@ def main(argv=None) -> int:
         return 0
     if args.auto:
         run_auto(shoot, args.aspect, args.pad, args.pop,
-                 subject=subject, category=category, quiet=args.quiet)
+                 subject=subject, category=category, quiet=args.quiet,
+                 check_rotation=args.check_rotation)
         return 0
     if args.approve_auto:
         run_approve_auto(shoot)
@@ -2310,14 +2339,21 @@ def main(argv=None) -> int:
 
     if args.check or not args.apply:
         print(f"PREP check — {shoot}")
-        m = run_check(shoot, args.aspect, args.pad, args.pop, subject, category, quiet=args.quiet)
+        m = run_check(shoot, args.aspect, args.pad, args.pop, subject, category,
+                      quiet=args.quiet, check_rotation=args.check_rotation)
         _print_status(shoot, m)
         print(f"  rotation sheet: {shoot / '.prep' / 'rotation_sheet.jpg'}")
     if args.apply:
         print(f"PREP apply — {shoot}")
         if not load_manifest(shoot).get("photos"):
-            run_check(shoot, args.aspect, args.pad, args.pop, subject, category, quiet=True)
-        m = run_apply(shoot, quiet=args.quiet, only=tuple(_pairs(getattr(args, 'only', None))))
+            run_check(shoot, args.aspect, args.pad, args.pop, subject, category,
+                      quiet=True, check_rotation=args.check_rotation)
+        # An explicit --only always wins. --filters is the "show me every look"
+        # escape hatch for a shoot whose category would otherwise narrow to one.
+        only = tuple(_pairs(getattr(args, 'only', None)))
+        if not only and args.filters:
+            only = tuple(colormod.PRESETS)
+        m = run_apply(shoot, quiet=args.quiet, only=only)
         _print_status(shoot, m)
     return 0
 

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -1289,14 +1289,16 @@ def test_printed_is_paper_and_asshot():
     assert CAT.looks_for("printed") == ("asshot",)
 
 
-def test_default_category_still_renders_everything():
-    """A filter that narrowed the generic case would be a silent policy change.
+def test_default_category_renders_only_crisp():
+    """The generic case narrows to the one look that ships automatically.
 
-    `looks_for` returns empty, not None, because that is what `run_apply`'s
-    `only` already treats as 'render them all'.
+    `crisp` is what `color.default_preset_for` already picks for every new
+    item, so rendering the other five by default cost real time for a
+    comparison almost nobody opened. `--filters` at --apply time (or an
+    explicit `--only`) is the escape hatch back to the full set.
     """
-    assert CAT.looks_for(None) == ()
-    assert CAT.looks_for("default") == ()
+    assert CAT.looks_for(None) == ("crisp",)
+    assert CAT.looks_for("default") == ("crisp",)
     assert CAT.subject_for(None) == "auto"
 
 

--- a/tools/prep_run.py
+++ b/tools/prep_run.py
@@ -96,12 +96,13 @@ def _with_retry(fn, note_fn):
 def _worker(job):
     """One shoot. Imports live at module scope in the worker after first call,
     so the model load is amortised across every shoot this worker handles."""
-    shoot_s, mode, aspect, pad, pop = job
+    shoot_s, mode, aspect, pad, pop, check_rotation, filters = job
     shoot = Path(shoot_s)
     t0 = time.monotonic()
     try:
         sys.path.insert(0, str(ROOT))
         from lib.photo_prep import prep as P
+        from lib.photo_prep import color as colormod
 
         if mode == "check":
             def _ask(m):
@@ -110,10 +111,12 @@ def _worker(job):
                           if r["orientation"]["needs_ask"])
                 return f"{n} frames, {ask} ASK"
             m, note = _with_retry(
-                lambda: P.run_check(shoot, aspect, pad, pop, quiet=True), _ask)
+                lambda: P.run_check(shoot, aspect, pad, pop, quiet=True,
+                                    check_rotation=check_rotation), _ask)
         else:
+            only = tuple(colormod.PRESETS) if filters else ()
             m, note = _with_retry(
-                lambda: P.run_apply(shoot, quiet=True),
+                lambda: P.run_apply(shoot, quiet=True, only=only),
                 lambda m: f"{len(m.get('photos', {}))} frames, "
                           f"preset {m.get('chosen_preset')}")
         return dict(shoot=shoot_s, ok=True, note=note, secs=round(time.monotonic() - t0, 1))
@@ -139,6 +142,12 @@ def main() -> int:
     ap.add_argument("--aspect", default="1:1")
     ap.add_argument("--pad", type=float, default=0.12)
     ap.add_argument("--pop", default="gentle")
+    ap.add_argument("--check-rotation", action="store_true", dest="check_rotation",
+                    help="run the OSD rotation check + ask panel per shoot "
+                         "(default: off — assumes every frame is shot right-side up)")
+    ap.add_argument("--filters", action="store_true",
+                    help="render every colour preset per shoot instead of just "
+                         "`crisp` (default: off)")
     ap.add_argument("--force", action="store_true", help="redo shoots already done")
     args = ap.parse_args()
 
@@ -164,7 +173,8 @@ def main() -> int:
     if not todo:
         return 0
 
-    jobs = [(str(s), mode, args.aspect, args.pad, args.pop) for s in todo]
+    jobs = [(str(s), mode, args.aspect, args.pad, args.pop, args.check_rotation, args.filters)
+            for s in todo]
     done = fail = 0
     t0 = time.monotonic()
     # 'spawn' is the only start method on Windows; maxtasksperchild keeps a

--- a/tools/prep_sheet_html.py
+++ b/tools/prep_sheet_html.py
@@ -232,13 +232,27 @@ def _cards_color(shoot, m):
 
 BLURB = {
     "orientation": ("Every frame turned the way it will ship. Pick a different turn to "
-                    "override it. Nothing was guessed — a frame with no readable text "
-                    "gets no automatic answer, so it was looked at by hand."),
+                    "override it. Nothing was guessed — a frame flagged here got no "
+                    "automatic answer and needs a look."),
     "crop": ("How each frame will be framed. A frame that refuses a crop says why; "
              "those refusals are deliberate, and a detail macro with no studio behind "
              "it is supposed to refuse. You can force one anyway."),
     "color": ("One look ships for the whole shoot. Compare on any frame; the pick "
               "applies everywhere."),
+}
+# What each stage shows when there is nothing to decide — every frame assumed
+# upright, or `crisp` auto-applied — and no one asked for the picker. See
+# `--interactive-rotation` / `--interactive-color` on this tool's CLI.
+READONLY_BLURB = {
+    "orientation": ("Rotation check is off — every frame below is assumed shot "
+                    "right-side up (the shoot convention), so there is nothing to "
+                    "pick. Run with --interactive-rotation to open this as a picker, "
+                    "or answer a specific frame with --rotate NAME=DEG / "
+                    "--check-rotation if one of these looks wrong."),
+    "color": ("`crisp` applied automatically — camera colour kept, backdrop cleaned, "
+              "item sharpened. Run with --interactive-color (after re-running --apply "
+              "--filters, so the other looks exist to compare) to pick a different "
+              "one, or --only asshot to ship uncorrected."),
 }
 FLAG = {"orientation": "--set-rotate", "crop": "--crop", "color": "--pick"}
 SLUG = {"orientation": "o", "crop": "c", "color": "k"}
@@ -252,7 +266,7 @@ def _esc(v) -> str:
     return html.escape(str(v), quote=True)
 
 
-def _card_html(stage: str, card: dict, idx: int) -> str:
+def _card_html(stage: str, card: dict, idx: int, readonly: bool = False) -> str:
     """One card.
 
     Each picture's bytes appear ONCE, as a CSS custom property on the card, and
@@ -260,8 +274,39 @@ def _card_html(stage: str, card: dict, idx: int) -> str:
     alike. Writing the data URI at each of those three places instead pushed a
     fourteen-frame shoot to 15 MB, against a 16 MB ceiling — the colour stage,
     with three pictures per frame, would not have fit at all.
+
+    `readonly` drops the option chips and the picking radios: there is exactly
+    one picture (the one that will ship) and a note, nothing to choose between.
+    Used when a stage was decided by default (assumed-upright rotation, the
+    auto-applied `crisp` look) rather than by a person, so the page does not
+    dress a settled answer up as an open question. The zoom-to-full-size view
+    still works — it needs no radio, only the checkbox already used for it.
     """
     fid = f"{SLUG[stage]}{idx}"
+
+    if readonly:
+        chosen = next((o for o in card["options"] if o["value"] == card["chosen"]),
+                      card["options"][0] if card["options"] else None)
+        spin = (f"transform:rotate({chosen['spin']}deg);"
+                if chosen and chosen.get("spin") else "")
+        pic = (f'<div class="v ro" style="background-image:url({chosen["img"]});'
+               f'{spin}display:block"></div>' if chosen and chosen.get("img") else
+               '<div class="v ro nopic">No preview.</div>')
+        why = f' · {_esc(card["why"])}' if card["why"] else ""
+        return f'''<div class="card ro" id="card_{fid}">
+  <input type="checkbox" class="zoomin" id="zoom_{fid}" aria-label="Open {_esc(card["name"])} full size">
+  <div class="cap"><span class="nm">{_esc(card["name"])}</span>
+    <span class="tag {card["status"]} t-auto">{card["status"]}</span></div>
+  <label class="stage" for="zoom_{fid}" title="Open full size">{pic}
+    <span class="zoom" aria-hidden="true">&#10530;</span></label>
+  <div class="note">{_esc(card["note"])}{why}</div>
+  <div class="big" id="big_{fid}">
+    <label class="shut" for="zoom_{fid}">Close</label>
+    <div class="bigwrap">{pic}</div>
+    <div class="bigcap">{_esc(card["name"])}</div>
+  </div>
+</div>'''
+
     vars_, pics, opts, radios = [], [], [], []
     for j, o in enumerate(card["options"]):
         on = o["value"] == card["chosen"]
@@ -322,16 +367,34 @@ def _card_html(stage: str, card: dict, idx: int) -> str:
 
 
 def _panel(stage: str, cards: list, ready: bool, locked: str, preview: bool,
-           shoot: str) -> str:
+           shoot: str, card_readonly: list | None = None) -> str:
+    """`card_readonly` is a per-card bool list (default: every card interactive).
+
+    A stage decided by default — assumed-upright rotation, auto-applied
+    `crisp` — has nothing for most cards to pick between, so those cards drop
+    their options. If EVERY card in the panel is readonly there is also
+    nothing to accept: the Accept/Send controls only exist to turn a picked
+    override into a command, and a panel with no pickers has no override to
+    turn into one. A frame that still needs a look (orientation's `needs_ask`)
+    stays interactive regardless, mixed in with the rest — see `build()`.
+    """
     if not ready:
         return (f'<section class="panel" id="panel-{stage}">'
                 f'<p class="lede">{_esc(BLURB[stage])}</p>'
                 f'<div class="locked">{_esc(locked)}</div></section>')
 
+    ro = card_readonly if card_readonly is not None else [False] * len(cards)
+    body = "".join(_card_html(stage, c, i, readonly=ro[i]) for i, c in enumerate(cards))
+
+    if cards and all(ro):
+        return f'''<section class="panel" id="panel-{stage}">
+  <p class="lede">{_esc(READONLY_BLURB.get(stage, BLURB[stage]))}</p>
+  <div class="grid">{body}</div>
+</section>'''
+
     notice = ('<div class="notice"><b>Preview.</b> The stage before this one is not '
               'approved yet, so this is drawn from the current plan and will be redrawn '
               'if that changes. Answer the earlier tab first.</div>') if preview else ""
-    body = "".join(_card_html(stage, c, i) for i, c in enumerate(cards))
     return f'''<section class="panel" id="panel-{stage}">
   <p class="lede">{_esc(BLURB[stage])}</p>
   {notice}
@@ -360,19 +423,33 @@ def _panel(stage: str, cards: list, ready: bool, locked: str, preview: bool,
 </section>'''
 
 
-def build(shoot: Path, out: Path) -> Path:
+def build(shoot: Path, out: Path,
+          interactive_rotation: bool = False, interactive_color: bool = False) -> Path:
+    """`interactive_rotation` / `interactive_color` force the full per-frame
+    picker open for a stage that would otherwise render read-only — see
+    `READONLY_BLURB` and `_card_html`'s `readonly` doc. A frame orientation
+    still needs a human look for (`needs_ask`) stays a picker regardless; the
+    flag only affects frames that already have a settled answer.
+    """
     m = load_manifest(shoot)
     st = stagemod.stage_state(m)
     approved = {s: bool(st[s]["approved"]) for s in stagemod.STAGES}
     sp = shoot.as_posix()
 
+    orient_cards = _cards_orientation(shoot, m)
+    orient_ro = [not interactive_rotation and c["status"] != "held" for c in orient_cards]
+
     color_cards, rendered = _cards_color(shoot, m)
+    color_ro = [not interactive_color for _ in color_cards]
+
+    READONLY_OF = {"orientation": orient_ro, "color": color_ro}
+
     built = {
-        "orientation": (True, _cards_orientation(shoot, m), ""),
+        "orientation": (True, orient_cards, ""),
         "crop": (True, _cards_crop(shoot, m), ""),
         "color": (rendered > 0, color_cards if rendered else [],
                   "The looks are not rendered yet. Approve crop, then run --apply, "
-                  "and this tab fills with as shot / studio / punch side by side."),
+                  "and this tab fills with `crisp` (or --filters for the full set)."),
     }
 
     first = next((s for s in stagemod.STAGES if not approved[s] and built[s][0]),
@@ -394,7 +471,8 @@ def build(shoot: Path, out: Path) -> Path:
             f'<span class="st {kind}">{word}</span></label>')
         prev = stagemod.STAGES[i - 1] if i else None
         panels.append(_panel(s, cards, ready, locked,
-                             bool(prev) and not approved[prev], sp))
+                             bool(prev) and not approved[prev], sp,
+                             card_readonly=READONLY_OF.get(s)))
 
     page = (TEMPLATE
             .replace("__SHOOT__", _esc(sp))
@@ -522,6 +600,13 @@ main{max-width:1500px;margin:0 auto;padding:20px 20px 40px}
   background-position:center}
 .opt .mini.nopic{font-size:16px;padding:0}
 /* chip highlighting is generated per index in __PICKRULES__ */
+
+/* A readonly card: one picture, no chips, no radios — the stage was decided
+   by default and there is nothing here to pick between. `.v.ro` is shown by
+   an inline style, not a generated rule, since there is no radio to drive it. */
+.card.ro{padding-bottom:2px}
+.v.ro{width:100%;height:100%}
+.v.ro.nopic{display:grid;place-items:center;color:var(--muted);font-size:12px}
 
 .note{padding:8px 11px;font-size:11.5px;color:var(--muted);border-top:1px solid var(--rule)}
 .say{display:block;padding:0 11px 11px}
@@ -670,9 +755,20 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("shoot", type=Path)
     ap.add_argument("-o", "--out", type=Path)
+    ap.add_argument("--interactive-rotation", action="store_true",
+                    dest="interactive_rotation",
+                    help="show every frame's rotation as a picker, even the ones "
+                         "with a settled (assumed-upright) answer — default: "
+                         "read-only for those, picker only for frames still asking")
+    ap.add_argument("--interactive-color", action="store_true",
+                    dest="interactive_color",
+                    help="show colour as a compare-and-pick panel instead of the "
+                         "read-only 'crisp applied' summary — needs --apply --filters "
+                         "run first so the other looks exist to compare")
     a = ap.parse_args()
     out = a.out or (a.shoot / ".prep" / "review.html")
-    p = build(a.shoot, out)
+    p = build(a.shoot, out, interactive_rotation=a.interactive_rotation,
+             interactive_color=a.interactive_color)
     print(f"{p}  ({p.stat().st_size / 1e6:.1f} MB)")
 
 


### PR DESCRIPTION
Closes #72.

## Summary
- Rotation check is off by default: no OSD pass, no ask panel — every frame with no recorded look is assumed upright (`source: assumed`). `--check-rotation` opts back into the old OSD + ask-panel behaviour.
- Colour defaults to `crisp` only (was: all six `color.PRESETS` looks), auto-picked. `--only asshot` skips correction; `--filters` renders every look for a side-by-side compare.
- The Frame Check page (`tools/prep_sheet_html.py`) shows orientation/colour as read-only (image + note, no picker) once there's nothing to decide; a genuinely unresolved frame always keeps its picker regardless. `--interactive-rotation` / `--interactive-color` force it open.
- `tools/prep_run.py` gets `--check-rotation` / `--filters` passthrough for batch runs.

An explicit `--rotate`/`--set-rotate` answer, or a genuinely unresolved frame, always wins over the default — this only removes the check when there was nothing to check.

## Test plan
- [x] `pytest tests/test_prep.py tests/test_prep_sheet_html.py tests/test_prep_run_retry.py` — 107 passed
- [x] `pytest tests/` (full suite) — 307 passed
- [x] Manual smoke test: `run_auto` → `run_approve_auto` → `run_apply` on a synthetic shoot renders only `crisp`, auto-picks it, and the built Frame Check page shows both stages read-only
- [x] Manual check: a frame with `needs_ask: True` still renders as an interactive picker with no flags passed, and stays interactive under `--interactive-rotation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)