### PR TITLE
fix(sync): merge sales_ledger.csv instead of overwriting; SOLD-precedence tests (#30)

### DIFF
--- a/lib/sync_actuals.py
+++ b/lib/sync_actuals.py
@@ -315,15 +315,38 @@ def match_sale(row: dict, drafts: list[dict], ledger: list[dict]) -> tuple[str, 
 # --------------------------------------------------------------------------- #
 # writers
 # --------------------------------------------------------------------------- #
+def _sale_key(row: dict) -> tuple:
+    """(order_id, sku or listing_id) — stable across re-fetches of the same
+    order, and distinct per line item within a multi-SKU order."""
+    return (row.get("order_id", ""), row.get("sku") or row.get("listing_id", ""))
+
+
+def _load_sales_ledger() -> dict:
+    """sale_key -> row, for whatever sales_ledger.csv already holds."""
+    if not SALES_LEDGER.exists():
+        return {}
+    with SALES_LEDGER.open(encoding="utf-8-sig", newline="") as f:
+        return {_sale_key(r): r for r in csv.DictReader(f)}
+
+
 def write_sales_ledger(rows: list[dict]) -> None:
+    """Merge `rows` into sales_ledger.csv — never a wholesale overwrite.
+
+    `rows` only covers the current `--days` window; a plain rewrite would
+    drop every sale outside it. Existing rows survive untouched unless a
+    fetched row shares their (order_id, sku) key, in which case the fresh
+    fetch wins (it may carry a refund the earlier write didn't know about)."""
+    merged = _load_sales_ledger()
+    for r in rows:
+        out = dict(r)
+        for k in _MONEY_FIELDS:
+            out[k] = _money(r[k])
+        merged[_sale_key(out)] = out
     with SALES_LEDGER.open("w", newline="", encoding="utf-8") as f:
         w = csv.DictWriter(f, fieldnames=SALES_FIELDS, extrasaction="ignore")
         w.writeheader()
-        for r in sorted(rows, key=lambda x: x["sold_at"], reverse=True):
-            out = dict(r)
-            for k in _MONEY_FIELDS:
-                out[k] = _money(r[k])
-            w.writerow(out)
+        for r in sorted(merged.values(), key=lambda x: x["sold_at"], reverse=True):
+            w.writerow(r)
 
 
 def stamp_folder(row: dict) -> bool:

--- a/tests/test_ledger_reconcile.py
+++ b/tests/test_ledger_reconcile.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Regression tests for tools/ledger_reconcile.py's SOLD-vs-eBay precedence.
+
+The rule this module enforces is "the API is truth" — except for one carved-out
+case: a ledger row marked SOLD outranks the Inventory API reporting SYNCED,
+because the Inventory API has no concept of a sale (that's the Fulfillment
+API, reached through sales_ledger.csv). The first cut of this file got that
+wrong and would have flipped 42 real sales back to SYNCED. These tests lock
+the carve-out down: SOLD survives eBay's SYNCED, but not a real relist.
+
+Run:  pytest tests/test_ledger_reconcile.py
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "lib"))
+
+from tools.ledger_reconcile import _protected, _sold_skus  # noqa: E402
+
+
+def _row(status="SOLD"):
+    return {"sku": "abc123", "status": status}
+
+
+def _truth(status):
+    return {"sku": "abc123", "status": status}
+
+
+# --------------------------------------------------------------------------
+# _protected — the field must be "status", and only "status"
+# --------------------------------------------------------------------------
+def test_non_status_fields_are_never_protected():
+    # Price/offer_id/etc. always defer to eBay, even on a SOLD row — the
+    # carve-out is narrowly about status, not "SOLD rows are untouchable".
+    assert _protected(_row(), _truth("SYNCED"), "price", sold={"abc123"}) is False
+    assert _protected(_row(), _truth("SYNCED"), "offer_id", sold={"abc123"}) is False
+
+
+def test_non_sold_rows_are_never_protected():
+    for status in ("DRAFTED", "SYNCED", "PUBLISHED", "ENDED", ""):
+        assert _protected(_row(status), _truth("SYNCED"), "status", sold=set()) is False
+
+
+# --------------------------------------------------------------------------
+# the actual carve-out: SOLD beats eBay's SYNCED
+# --------------------------------------------------------------------------
+def test_sold_row_survives_ebay_reporting_synced():
+    # This is the 42-sales bug: eBay's Inventory API has no sale concept, so
+    # an unpublished-but-sold offer reads SYNCED there. That must not
+    # overwrite a real SOLD row.
+    assert _protected(_row("SOLD"), _truth("SYNCED"), "status", sold={"abc123"}) is True
+
+
+def test_sold_row_survives_ebay_reporting_ended():
+    assert _protected(_row("SOLD"), _truth("ENDED"), "status", sold={"abc123"}) is True
+
+
+def test_sold_row_survives_even_when_uncorroborated_by_an_order():
+    # Deliberately not gated on the `sold` set: an offline sale (mall case,
+    # direct buyer) the Fulfillment API never saw is more likely than a
+    # mistake, and silently clearing SOLD would resurrect it as listable
+    # stock. main() surfaces this case under REVIEW instead of correcting it.
+    assert _protected(_row("SOLD"), _truth("SYNCED"), "status", sold=set()) is True
+
+
+def test_a_real_relist_outranks_sold():
+    # eBay showing the SKU ACTIVE again (a genuine relist) is the one thing
+    # that beats a local SOLD row.
+    assert _protected(_row("SOLD"), _truth("PUBLISHED"), "status", sold={"abc123"}) is False
+
+
+# --------------------------------------------------------------------------
+# _sold_skus — reads sales_ledger.csv, tolerates it being absent
+# --------------------------------------------------------------------------
+def test_sold_skus_reads_the_sales_ledger(tmp_path, monkeypatch):
+    import tools.ledger_reconcile as LR
+    sales = tmp_path / "sales_ledger.csv"
+    sales.write_text("order_id,sku\n1-000,sku-a\n2-000,sku-b\n", encoding="utf-8")
+    monkeypatch.setattr(LR, "SALES", sales)
+    assert LR._sold_skus() == {"sku-a", "sku-b"}
+
+
+def test_sold_skus_empty_when_no_sales_ledger(tmp_path, monkeypatch):
+    import tools.ledger_reconcile as LR
+    monkeypatch.setattr(LR, "SALES", tmp_path / "does_not_exist.csv")
+    assert LR._sold_skus() == set()

--- a/tests/test_sync_actuals.py
+++ b/tests/test_sync_actuals.py
@@ -15,6 +15,7 @@ Order dicts are hand-built in the shape the Fulfillment API actually returns
 
 Run:  pytest tests/test_sync_actuals.py
 """
+import csv
 import sys
 from decimal import Decimal
 from pathlib import Path
@@ -177,3 +178,48 @@ def test_a_clear_title_winner_still_matches():
            "title": "McSpadden T34-W Mountain Dulcimer 1984 Walnut Scroll Headstock w/ Case"}
     shoot, ask, how = SA.match_sale(row, drafts, [])
     assert shoot == "inventory/dulcimer" and how.startswith("title~")
+
+
+# --------------------------------------------------------------------------
+# write_sales_ledger must merge, never overwrite — a narrow --days window
+# used to erase every older sale outright (measured: a plain rewrite with
+# the default --days 90 would have dropped anything sold before that).
+# --------------------------------------------------------------------------
+def _sale_row(order_id, sku, sold_at, item_price="10.00"):
+    return {"order_id": order_id, "sold_at": sold_at, "listing_id": f"L{sku}",
+            "sku": sku, "title": f"item {sku}", "quantity": "1",
+            "sold_format": "FIXED_PRICE", "item_price": Decimal(item_price),
+            "buyer_shipping": Decimal("0.00"), "refunded": Decimal("0.00"),
+            "gross": Decimal(item_price), "ebay_fee": Decimal("1.00"),
+            "net_before_postage": Decimal("9.00"), "listed_price": "10.00",
+            "pct_of_ask": "100%", "shoot_dir": "", "matched_by": "sku"}
+
+
+def test_write_sales_ledger_preserves_rows_outside_the_fetch_window(tmp_path, monkeypatch):
+    ledger = tmp_path / "sales_ledger.csv"
+    monkeypatch.setattr(SA, "SALES_LEDGER", ledger)
+
+    # An old sale, written in a prior --apply, is already on disk...
+    SA.write_sales_ledger([_sale_row("1-000", "old-sku", "2025-01-01T00:00:00Z")])
+    # ...then a new --apply with a narrow window only fetches a recent sale.
+    SA.write_sales_ledger([_sale_row("2-000", "new-sku", "2026-08-01T00:00:00Z")])
+
+    with ledger.open(encoding="utf-8") as f:
+        rows = {r["sku"]: r for r in csv.DictReader(f)}
+    assert set(rows) == {"old-sku", "new-sku"}, \
+        "the old sale must survive a later --apply that never re-fetched it"
+
+
+def test_write_sales_ledger_updates_a_row_thats_refetched(tmp_path, monkeypatch):
+    ledger = tmp_path / "sales_ledger.csv"
+    monkeypatch.setattr(SA, "SALES_LEDGER", ledger)
+
+    SA.write_sales_ledger([_sale_row("1-000", "sku-a", "2026-08-01T00:00:00Z", "10.00")])
+    # Same order+sku re-fetched later (e.g. a refund posted since) — must
+    # replace the row in place, not duplicate it.
+    SA.write_sales_ledger([_sale_row("1-000", "sku-a", "2026-08-01T00:00:00Z", "8.00")])
+
+    with ledger.open(encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    assert rows[0]["item_price"] == "8.00"


### PR DESCRIPTION
## What
Two of #30's untested/unfixed money-path resilience items:

1. **`write_sales_ledger()` was a silent data-loss bug.** It wrote *only* the rows fetched in the current `--apply` run, so a default `python lib/sync_actuals.py --apply` (90-day window) would overwrite `sales_ledger.csv` and drop every sale older than 90 days. Fixed to merge into whatever's already on disk, keyed by `(order_id, sku)` — a row re-fetched later (e.g. a refund posted since) still updates in place rather than duplicating.
2. **`tools/ledger_reconcile.py`'s SOLD-vs-eBay precedence had zero test coverage**, despite the module's own docstring describing a past incident where getting this wrong would have flipped 42 real sales back to SYNCED. Added `tests/test_ledger_reconcile.py` covering `_protected()`/`_sold_skus()`: a SOLD row outranks eBay reporting SYNCED/ENDED (even uncorroborated by an order — an offline sale is more likely than a mistake), but a genuine relist (PUBLISHED) still outranks SOLD.

## Not in scope
The issue's third money-path bullet ("Apify Stage B guard test") is obsolete — Apify was fully retired to `deprecated/` on 2026-08-15 in favor of the logged-in-browser Stage B (`lib/ebay_sold_browse.py`); there's no live Apify code path left to guard.

## Test plan
- [x] `pytest tests/test_ledger_reconcile.py tests/test_sync_actuals.py` — 21 passed
- [x] CI (`tests` workflow) green

🤖 Generated with [Claude Code](https://claude.ai/code)