### PR TITLE
Wire context.txt into IDENTIFY/PRICE/DRAFT/REVIEW, fix a PII leak (#46)

### DIFF
--- a/lib/dir_context.py
+++ b/lib/dir_context.py
@@ -35,7 +35,10 @@ WHAT IT DOES NOT DO (the clamps — same rails the specializations carry):
   * Negative constraints are HARD. A blocked claim is blocked, not "flagged" —
     DRAFT refuses to emit it, at any confidence.
   * No PII in buyer copy. The file may name the person for our own reference;
-    listing copy says "an estate" unless explicitly opted in.
+    listing copy says "an estate" unless explicitly opted in. Enforced here,
+    not left to callers: `MergedContext.public_keys` and `brief()` both drop
+    `source` unconditionally — read `.keys["source"]` directly for the
+    local-only case.
   * Absent file = today's behavior. No context.txt in the chain changes nothing.
 """
 from __future__ import annotations
@@ -110,6 +113,16 @@ class MergedContext:
     @property
     def sources(self) -> list[str]:
         return [c.rel for c in self.chain]
+
+    @property
+    def public_keys(self) -> dict[str, str]:
+        """`.keys` minus `source` — the PII guardrail. `source` may name a
+        person for local reference only (per the issue: "the parser should
+        treat source: as reference-only and never pass it into draft
+        copy"); nothing that reaches a stage's working notes, the review
+        card, or buyer-facing copy may include it. Use `.keys["source"]`
+        directly for the local-only case."""
+        return {k: v for k, v in self.keys.items() if k != "source"}
 
     def blocks(self, text: str) -> list[Blocked]:
         """Which forbidden claims does `text` actually make? (DRAFT/REVIEW)"""
@@ -204,7 +217,7 @@ def brief(item_dir: Path, root: Path = INVENTORY) -> str:
         return ""
     out = ["ESTATE CONTEXT (background only — never a claim upgrade)",
            f"  applied: {', '.join(ctx.sources)}"]
-    for k, v in ctx.keys.items():
+    for k, v in ctx.public_keys.items():          # never source: — PII guardrail
         out.append(f"  {k}: {v}")
     if ctx.blocked:
         out.append("  MUST NOT CLAIM:")

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -87,6 +87,7 @@ from draft_io import (Draft, parse_draft, resolve_photo_paths, set_photo_order,
 from verdict import emit as _verdict_emit
 from voice_check import check_voice
 from us_only import us_only_reasons
+from dir_context import load as load_dir_context
 from ebay_client import (
     DEFAULT_MARKETPLACE,
     EbayAPIError,
@@ -1313,11 +1314,36 @@ def build_review_card(draft_path: Path,
         intl_lines = ["  • eligible, not enabled (shipping.international: false). "
                       "Set true to offer it worldwide."]
 
+    # Estate context (GH #46) — which context.txt file(s) applied, what they
+    # supply, and what they forbid, so a reviewer can see the estate was
+    # actually consulted before approving a publish. `source:` never
+    # appears here — public_keys/brief() drop it (PII guardrail).
+    ctx = load_dir_context(shoot)
+    ctx_lines: list[str] = []
+    ctx_draft_hits = []
+    if ctx:
+        ctx_lines.append(f"  applied: {', '.join(ctx.sources)}")
+        for k, v in ctx.public_keys.items():
+            ctx_lines.append(f"  {k}: {v}")
+        if ctx.blocked:
+            ctx_lines.append("  MUST NOT CLAIM:")
+            for b in ctx.blocked:
+                ctx_lines.append(f"    - {' / '.join(b.phrases[:2])} — {b.why} ({b.source})")
+        _buyer_text = "\n".join([title, str(draft.get("condition_description") or ""),
+                                 str(draft.body or ""),
+                                 *(str(v) for v in (draft.get("item_specifics") or {}).values())])
+        ctx_draft_hits = ctx.blocks(_buyer_text)
+    else:
+        ctx_lines.append("  (no context.txt in chain — no change to behavior)")
+
     # Flags worth a human eye.
     flags: list[str] = []
+    for _hit in ctx_draft_hits:
+        flags.append(f"  • ⚠ draft asserts a claim the estate forbids: "
+                     f"'{_hit.phrases[0]}' — {_hit.why} ({_hit.source}). Rephrase before approving.")
     nr = shoot / "NEEDS_REVIEW.md"
     if nr.exists():
-        flags = ["  • " + ln.strip() for ln in nr.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        flags += ["  • " + ln.strip() for ln in nr.read_text(encoding="utf-8").splitlines() if ln.strip()]
     # Stale-meta check (GH #40): surface a meta/eBay disagreement at the gate
     # rather than in an audit months later. SOFT — an API failure never blocks
     # the card.
@@ -1401,6 +1427,8 @@ def build_review_card(draft_path: Path,
         *comps,
         "Condition detail:",
         f"  {cond_desc}",
+        "Context (estate background):",
+        *ctx_lines,
         f"Final photos - exactly what publishes ({len(photos)}):{prep_note}",
         *photo_lines,
         "⚠ Needs review / manual intervention:",

--- a/prompts/_shared.md
+++ b/prompts/_shared.md
@@ -95,6 +95,36 @@ prior identification. Visual similarity is not equivalence; markets
 shift. Re-derive every time. Never write "V1 said X" / "previously
 identified as Y".
 
+## Directory context (`context.txt` cascade)
+
+Items arrive as a batch — an estate, a sale — not one at a time. A parent
+directory under `inventory/` may carry a `context.txt` (household, era,
+storage, cost); every item under it inherits it. `lib/dir_context.py`
+walks from the inventory root down to the item dir and merges every
+`context.txt` on the way, nearest-wins:
+
+    python lib/dir_context.py <item-dir>     # brief() — paste into working notes
+    python lib/dir_context.py --sweep        # drafts asserting a blocked claim
+
+**Background, never a claim upgrade.** It narrows a prior (era, likely
+source) — it never makes a marble German or a book first-edition. Same
+rail the specializations carry: refine, don't override.
+
+**Blocks are hard.** A claim in `ctx.blocked` (smoke-free, pet-free,
+climate-controlled and variants) is forbidden, not flagged, at any
+confidence — even where photos alone would support it. DRAFT is the
+enforcement point (see draft.md); it also applies to IDENTIFY/
+INVESTIGATE/PRICE simply by never asserting it.
+
+**`source:` never leaves this file.** It may name a person for local
+reference; nothing downstream — chat, a stage's own output file, the
+review card, buyer-facing copy — repeats it. `brief()`/`public_keys`
+already omit it; don't read `.keys["source"]` into anything that isn't
+purely local.
+
+**Absent chain = today's behavior.** No `context.txt` anywhere in the
+chain changes nothing.
+
 ## Unit type and quantity
 
 Every item record carries `unit_type` + `quantity`.

--- a/prompts/draft.md
+++ b/prompts/draft.md
@@ -362,6 +362,27 @@ Hard rules: never include a claim absent from INVESTIGATE's listing-safe /
 observable lists; never anything INVESTIGATE marked NOT defensible; never
 IDENTIFY `[BEST-CASE]` language; honor unit-type phrasing.
 
+## Estate context — forbidden claims (`context.txt`, GH #46)
+
+Same rail as in-hand voice above: this governs buyer-visible copy, not
+the internal record. Read via `lib/dir_context.py` (`_shared.md` has the
+full contract).
+
+- **Blocked phrases are HARD.** Anything in `ctx.blocked` — smoke-free,
+  pet-free, climate-controlled and variants — may not appear in title,
+  body, `condition_description`, or item specifics, at any confidence,
+  even if the photos alone would support it. This is the final gate: if
+  INVESTIGATE somehow still carried a blocked phrase through, DRAFT
+  strips it here.
+- **Supply the disclosure, don't dramatize it.** Where a block applies,
+  add ONE neutral in-hand clause to the body — "From a home where
+  someone smoked; may carry a faint odor." — same restraint as ordinary
+  wear disclosure, no location map, no colour adjectives.
+- **`source:` never appears in copy.** Buyer-facing text says "an
+  estate", never a name — `ctx.public_keys` / `brief()` already omit it;
+  reading the raw `context.txt` to work around that is not allowed.
+- **No context.txt in the chain → nothing to enforce.**
+
 ## Constraints — enforce before write (the hardest rule)
 
 Limits come from the template's `_field_constraints` (authoritative; read
@@ -391,9 +412,10 @@ Walk every `_field_constraints` entry against the populated value:
 length ≤ max_len (rephrase if not) · required present (else flag) ·
 numeric parses positive (else flag, empty) · lookup canonical (else
 substitute + log). Also scan every buyer-visible field for camera-frame
-language (the in-hand-voice rule above) and rephrase any hit to the
-finding. Only then write draft.md. Re-read after write and confirm every
-constrained field fits and `_field_constraints` was copied verbatim.
+language (the in-hand-voice rule above) and estate-forbidden phrases (the
+rule above); rephrase or strip any hit. Only then write draft.md. Re-read
+after write and confirm every constrained field fits and
+`_field_constraints` was copied verbatim.
 
 ## meta.notes (DRAFT NOTES)
 

--- a/prompts/identify.md
+++ b/prompts/identify.md
@@ -271,6 +271,8 @@ Then one block per item, `--- Item <N> ---`, fields in this order:
   ≤65.
 - **Type** — specific descriptor. Same marker convention. ≤65.
 - **Era** — date/range. `[ASSUMPTION]` if inferred from styling. ≤65.
+  Directory context (`_shared.md`) may narrow the range — a household's
+  accumulation window is a prior, never a date on the item itself.
 - **Collectability** — collectable / vintage / antique / modern /
   `none (not for sale)`.
 - **Condition** — per [`condition-rubric.md`](condition-rubric.md):

--- a/prompts/investigate.md
+++ b/prompts/investigate.md
@@ -78,6 +78,9 @@ assessed (function untested, undersides unseen), map to one
     - <thing that cannot be claimed>
     REQUIRED. Common: specific maker w/o stamp, year w/o date, country
     w/o mark, working status w/o test evidence, material beyond visible.
+    Any directory-context block (`_shared.md`) goes here too — e.g. "smoke-
+    free home" — even where the photos alone are silent on it and would
+    otherwise support the claim.
 
     ## Listing-safe claims (DRAFT consumes)
     Title claims — 2–4, strongest first, EACH ≤80, with count:

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -48,6 +48,14 @@ price on a comp's item-only `sold_price`.
 
 State the basis (`delivered` / `item-only`) on the Distribution line.
 
+## Directory context (comp filter, never a floor)
+
+If `lib/dir_context.py` surfaces provenance (single-owner estate, not
+dealer stock), use it only to filter which comps are representative —
+never to justify a higher tier than the distribution supports. `cost:`
+is the margin basis for later profit math, not a floor on the ask; a
+$650 acquisition cost does not raise the price if the market says less.
+
 ## Silver — category override: rarity-check, exact comp, push HIGH
 
 Trigger: "silver" in ANY sense, regardless of content — sterling/.925, coin,

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -44,7 +44,11 @@ Present that card to the user **verbatim** and STOP. It contains:
     Preflight (condition · shipping)
     Comps (open to verify) — each with a URL
     Condition detail (every flagged defect, verbatim — never softened)
-    ⚠ Needs review / manual intervention (NEEDS_REVIEW.md lines)
+    Context (estate background) — which context.txt file(s) applied, any
+      supplied field, and any claim they forbid (never `source:` — see
+      `_shared.md`'s PII guardrail)
+    ⚠ Needs review / manual intervention (NEEDS_REVIEW.md lines, plus a
+      flag if the draft actually asserts a claim the estate forbids)
     → Approve publishes LIVE at $<price>, with the exact --list … --confirm command
 
 ## The card is a page — every time, no exceptions

--- a/tests/test_dir_context.py
+++ b/tests/test_dir_context.py
@@ -195,6 +195,29 @@ def test_brief_is_empty_string_with_no_context_file():
     assert DC.brief(root / "item", root=root) == ""
 
 
+# --------------------------------------------------- PII guardrail (source:)
+def test_public_keys_excludes_source_but_keeps_the_rest():
+    root = _make({"context.txt": "source: Frankie, estate, Greensboro NC\n"
+                                 "environment: smoker\n"})
+    ctx = DC.load(root, root=root)
+    assert "source" not in ctx.public_keys
+    assert ctx.public_keys["environment"] == "smoker"
+    assert ctx.keys["source"] == "Frankie, estate, Greensboro NC"  # still readable directly
+
+
+def test_brief_never_prints_source():
+    """The issue's own guardrail: source: may name a person for local
+    reference only. brief() is what a stage pastes into its working notes
+    (and, wired via list_edit's review card, what a human sees) — it must
+    never carry the name through, even though the raw parse keeps it."""
+    root = _make({"context.txt": "source: Frankie, estate, Greensboro NC\n"
+                                 "environment: smoker\n"})
+    text = DC.brief(root, root=root)
+    assert "Frankie" not in text
+    assert not any(ln.strip().lower().startswith("source:") for ln in text.splitlines())
+    assert "environment: smoker" in text
+
+
 # --------------------------------------------------------------------- sweep()
 def test_sweep_finds_a_contradicted_claim_in_a_multilevel_tree():
     root = _make({

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -266,6 +266,7 @@ CARD_SECTIONS = [
     "Preflight",
     "Comps (open to verify):",
     "Condition detail:",
+    "Context (estate background):",
     "Final photos",
     "⚠ Needs review / manual intervention:",
     "→ Approve publishes this LIVE",

--- a/tests/test_list_edit.py
+++ b/tests/test_list_edit.py
@@ -46,6 +46,7 @@ Run:  python tests/test_list_edit.py
 import contextlib
 import csv
 import os
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -634,6 +635,53 @@ def test_create_or_update_listing_idempotent_second_call_updates_not_creates():
     updates = [c for c in calls if c[0] == "PUT" and "/offer/OFFER-9" in c[1]]
     assert len(creates) == 1, "exactly one createOffer across both syncs"
     assert len(updates) == 1, "the second sync must PUT (update) the existing offer"
+
+
+# ---------------------------------------------------------------------------
+# build_review_card() — estate context wiring (GH #46)
+# ---------------------------------------------------------------------------
+
+def test_build_review_card_shows_estate_context_and_flags_a_blocked_claim():
+    """`_BODY` (the shared draft fixture) already says "climate-controlled
+    space" — pairing it with an estate context.txt that records unclimatized
+    storage should make the card show the block AND flag that the draft
+    itself asserts the forbidden claim (defense-in-depth past DRAFT)."""
+    import dir_context as DC
+    DC.INVENTORY.mkdir(parents=True, exist_ok=True)
+    tmp = Path(tempfile.mkdtemp(prefix="dctx_", dir=str(DC.INVENTORY)))
+    try:
+        (tmp / "context.txt").write_text(
+            "source: Frankie, estate, Greensboro NC\n"
+            "storage: attic, unclimatized\n", encoding="utf-8")
+        draft_path = _write_single_draft(tmp)
+        with _patched(L, preflight_listing=lambda *a, **kw: ["category: 12345"],
+                     resolve_draft_state=lambda *a, **kw:
+                         {"stale": False, "offer_id": "", "meta_offer_id": ""}), \
+             _ledger_at(tmp):
+            card, _path = L.build_review_card(draft_path, creds=_Creds())
+
+        assert "Context (estate background):" in card
+        assert "climate-controlled" in card          # in MUST NOT CLAIM
+        assert "MUST NOT CLAIM" in card
+        assert any("draft asserts a claim the estate forbids" in ln
+                  for ln in card.splitlines()), "the flag list must catch the leaked claim"
+        assert "Frankie" not in card, "source: must never reach the card (PII guardrail)"
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_build_review_card_context_section_is_quiet_with_no_context_txt():
+    with tempfile.TemporaryDirectory() as td:
+        draft_path = _write_single_draft(Path(td))
+        with _patched(L, preflight_listing=lambda *a, **kw: ["category: 12345"],
+                     resolve_draft_state=lambda *a, **kw:
+                         {"stale": False, "offer_id": "", "meta_offer_id": ""}), \
+             _ledger_at(Path(td)):
+            card, _path = L.build_review_card(draft_path, creds=_Creds())
+
+    assert "Context (estate background):" in card
+    assert "no context.txt in chain" in card
+    assert "estate forbids" not in card
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Completes #46. #51 already landed the parser side (`lib/dir_context.py`'s `chain_for`/`load`/`brief`/`sweep`/`_derive_blocks`, verified against `ESTATES/FR/` with 0 contradictions). This PR is the consumer side: wiring the read into the stage prompts and the review card, plus a real bug found while doing it.

## What's here

- **PII fix (real bug):** `brief()` — the function stages are told to paste into working notes — dumped `.keys` verbatim, including `source:`, directly contradicting the issue's own guardrail ("the parser should treat `source:` as reference-only and never pass it into draft copy"). Added `MergedContext.public_keys` (excludes `source`) and switched `brief()` to it. Regression tests added (`test_public_keys_excludes_source_but_keeps_the_rest`, `test_brief_never_prints_source`).
- **`lib/list_edit.py` — `build_review_card()`:** now shows a `Context (estate background):` section — which `context.txt` file(s) applied, any supplied field (never `source:`), and any blocked claim. Also checks the draft's actual buyer-visible text (title + body + condition_description + item specifics) against `ctx.blocks()` and flags it under "Needs review" if a blocked phrase slipped through DRAFT — defense-in-depth, same idea as the stale-meta check already there.
- **`prompts/_shared.md`:** one shared section explaining the cascade + the three guardrails (background-only, hard blocks, PII), that every phase prompt points back to instead of restating.
- **`prompts/identify.md` / `investigate.md` / `price.md` / `draft.md` / `review.md`:** terse per-phase pointers — Era as a prior not a date, forbidden claims belong in NOT-defensible even where photos are silent, provenance as a comp filter (`cost:` is margin basis, never a floor), DRAFT's block list + one-clause disclosure (the actual enforcement point, mirrors the existing in-hand-voice section right above it), and the card's new field.
- **`tests/test_formats.py`:** `"Context (estate background):"` added to the review card's locked `CARD_SECTIONS` list (additive, per the file's own stated rule for safe format changes).
- **`tests/test_list_edit.py`:** two new `build_review_card` cases — a real blocked-claim end-to-end (context.txt says unclimatized storage, the shared draft fixture's body already says "climate-controlled space", card shows the block AND flags it, `source:` never appears) and the no-`context.txt` no-op case.

## Verification

`pytest tests/` — 424 passed, 2 failed. Both failures are pre-existing and untouched by this change (confirmed by running them on `main` before this branch's commit):
- `test_chain_for_walks_root_to_item_outermost_first` — Windows path-separator vs. a hardcoded forward-slash string in the test itself; doesn't affect CI (`ubuntu-latest`).
- `test_create_or_update_listing_idempotent_second_call_updates_not_creates` — an unrelated `strict=` kwarg mismatch between `create_or_update_listing` and a test mock, predates this branch.

## Not in this PR (scope note)

A parallel draft, #66, independently reimplemented the parser side with a different API (`load_context`/`DirContext`/`forbidden_claims`) before #51 merged — it's now a stale duplicate of what's already on `main` and should be closed as superseded rather than merged, to avoid two competing `dir_context.py` APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)