### PR TITLE
fix(test): sync shipping-policy mock with strict= kwarg (CI red on main)

### DIFF
--- a/tests/test_list_edit.py
+++ b/tests/test_list_edit.py
@@ -588,7 +588,7 @@ def _patch_sync_collaborators():
         L,
         _resolve_policies_and_location=lambda creds: (dict(_POLICIES), "LOC-1"),
         get_allowed_condition_ids=lambda *a, **kw: (set(), False),
-        _resolve_shipping_policy=lambda draft, policies, creds: (policies["fulfillment"], []),
+        _resolve_shipping_policy=lambda draft, policies, creds, strict=False: (policies["fulfillment"], []),
         _assert_photos_cleared=lambda paths: None,
         upload_site_hosted_picture=lambda data, picture_name=None, creds=None: f"https://eps/{picture_name}.jpg",
     )


### PR DESCRIPTION
CI has failed on \`main\`'s last 3 runs (since 5fcb02d). That commit added \`strict: bool = False\` to \`_resolve_shipping_policy\` and calls it with \`strict=True\` from \`create_or_update_listing\`, but \`tests/test_list_edit.py\`'s \`_patch_sync_collaborators()\` mocks the function with a 3-arg lambda that doesn't accept the new kwarg — \`TypeError: got an unexpected keyword argument 'strict'\`.

One-line fix: the mock now accepts (and ignores) \`strict\`, matching the real signature. \`pytest tests/test_list_edit.py\` — 19/19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)