### PR TITLE
feat: land #62's execution-model guidance + #61's economics tool

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -64,6 +64,58 @@ shoot directory, so phases compose without re-deriving.
 
 ---
 
+## Concurrency and delegation (#61/#62)
+
+**Trigger: a multi-item batch** — "run everything in `<folder>`", a plan-mode
+estate scene with several saleable items, a backlog sweep. A single item, or
+an interactive back-and-forth about one piece, stays in the main thread; fan
+out only earns its overhead across several items. Measured cost of *not*
+doing this: mean 291,787 tokens of accumulated context per turn, 1.00 tool
+calls per assistant turn, one "run all" session that took 725 turns for a
+single folder (#61).
+
+**Main thread = conductor.** It holds only: the batch manifest (which items,
+what phase each is in), the **gates**, and any write that touches shared
+state. It never holds a raw photo, a comp JSON, forum matches, or a worker's
+full reasoning — those are what make the window huge.
+
+**One worker (`Agent` tool) per item**, covering IDENTIFY→PRICE→
+INVESTIGATE→DRAFT, **capped at 4 concurrent** (PRICE hits Apify/eBay Browse;
+more trips rate limits). Each worker starts on a fresh context, reads
+[`prompts/_shared.md`](prompts/_shared.md) plus the phase prompt it needs —
+not optional, the honesty rules and in-hand voice live only in the prompt
+files — writes its outputs to the shoot dir exactly as a normal run would,
+and returns a **compact verdict only**: item name, proposed title, price +
+tier, the ⚠ list, and the path to `draft.md`. The filesystem is the handoff;
+the conductor never needs a worker's reasoning, only its verdict.
+
+**The ledger is the one hard constraint.** `listings_ledger.csv` is a single
+unlocked CSV — `list_edit.py --record` / `--sync` / `--list --confirm` all
+read-modify-write it, and two callers at once lose a row. Every ledger-
+touching call runs in the conductor, serialized, never inside a worker —
+which is also where it already belongs, since it follows the gate.
+
+**Gates become a queue, not a barrier.** A finished item's review card joins
+a queue instead of stopping the run; the user answers gates whenever they're
+next at the machine, and other workers keep going the whole time. The gates
+themselves do not weaken — REVIEW still publishes on one explicit
+per-item approval, never inferred, never batched into "approve all" — they
+just stop being a global stall. (Measured: 229h blocked across 229 asks,
+mean 1h each; colour alone was 81h against a confidence gate `prep.md`
+already specifies — see PREP's `--auto`/`--approve-auto` above.)
+
+**Background anything over ~30s.** `prep --auto` renders images and nothing
+else in the run depends on it finishing — kick it off with
+`run_in_background`, run PRICE Stage A/B while it renders, collect it when
+it lands. The same applies to any other foreground call in that range.
+
+**`ebz status <shoot>`** (`python -m lib.cli status <shoot-dir>`) replaces
+the `ls`/`cat`/`grep` sequence for "where is this item": phase files
+present, PREP's approval state, frame count, ledger row, and the next
+action — one call instead of several.
+
+---
+
 ## The gate contract (the whole point of headless)
 
 Reclassify every "ask the user" moment as HARD or SOFT.
@@ -171,9 +223,13 @@ live state, `--apply` to heal), `pick-list` (orders awaiting shipment),
 `listing` (the LIST/EDIT CLI), `prep`, `single-pass` (gate-check
 IDENTIFY→PREP→PRICE→INVESTIGATE→DRAFT for a routine item; see
 [prompts/single_pass.md](prompts/single_pass.md)), `observe` (session
-transcripts -> friction report; read-only, `--report` to print it). Argv
-passes through untouched, so every flag documented for a tool works
-identically under `ebz`. The direct `python tools/<x>.py` /
+transcripts -> friction report; read-only, `--report` to print it,
+`--economics` for the #61 run-cost table — context/turn, tool-call
+batching, image Read payload, gate wall-clock by name — the standing
+version of the one-off `.scratch/analyze*.py` audit), `status` (one-shot
+shoot state: phase files, PREP gate, frames, ledger row, next action —
+#61/#62). Argv passes through untouched, so every flag documented for a
+tool works identically under `ebz`. The direct `python tools/<x>.py` /
 `python lib/<x>.py` invocations keep working.
 
 **Single-pass mode (routine items, V4_PLAN Phase 4, #30).** For an item

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -52,6 +52,8 @@ COMMANDS = {
                      "PREP photo pipeline: --auto --check --apply --approve ..."),
     "single-pass":  ("lib.single_pass",
                      "gate-check IDENTIFY->PREP->PRICE->INVESTIGATE->DRAFT; one card when clean"),
+    "status":       ("lib.status",
+                     "one-shot shoot state: phase files, PREP gate, frames, ledger, next action (#61)"),
 }
 
 

--- a/lib/status.py
+++ b/lib/status.py
@@ -1,0 +1,131 @@
+"""ebz status — one-shot shoot-directory state (#61/#62 concurrency prep).
+
+Replaces the `ls`/`cat`/`grep` sequence an operator runs by hand to answer
+"where is this item": which phase files exist, PREP's approval/pending
+state, the frame count, the ledger row if it's been drafted, and the next
+action. Measured at 2,638 such calls costing 13.4h across 114 sessions
+(#61) — this is one call instead of six.
+
+Read-only: never writes, never calls eBay. Reuses `lib/single_pass.py`'s
+own STAGE_OUTPUT/STAGE_CHECK so a stage only has one definition of "done"
+anywhere in the codebase.
+
+    python -m lib.cli status <shoot-dir>
+    python -m lib.cli status <shoot-dir> --json
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from single_pass import STAGE_CHECK, STAGE_ORDER, STAGE_OUTPUT  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+LEDGER = REPO / "listings_ledger.csv"
+
+_FRAME_EXT = {".jpg", ".jpeg", ".png", ".heic", ".tiff", ".webp"}
+_SKU_RE = re.compile(r'ebay_inventory_sku:\s*"?([0-9a-zA-Z\-]{6,})"?', re.M)
+
+
+def _frame_count(shoot: Path) -> int:
+    return sum(1 for p in shoot.iterdir() if p.is_file() and p.suffix.lower() in _FRAME_EXT)
+
+
+def _sku_from_draft(shoot: Path) -> str:
+    draft = shoot / "draft.md"
+    if not draft.exists():
+        return ""
+    m = _SKU_RE.search(draft.read_text(encoding="utf-8", errors="ignore"))
+    return m.group(1) if m else ""
+
+
+def _ledger_row(sku: str) -> Optional[dict]:
+    if not sku or not LEDGER.exists():
+        return None
+    with LEDGER.open(encoding="utf-8-sig", newline="") as f:
+        for row in csv.DictReader(f):
+            if row.get("sku") == sku:
+                return row
+    return None
+
+
+def gather(shoot: Path) -> dict:
+    """The whole state of one shoot dir, one read pass. Each stage's
+    'pending' list is empty iff that stage is fully done — STAGE_CHECK
+    itself is the single source of truth for that (unwritten file, an
+    interactive gate's own HARD stop, everything)."""
+    stages: dict = {}
+    next_action = None
+    for stage in STAGE_ORDER:
+        pending = [a.detail for a in STAGE_CHECK[stage](shoot)]
+        out_file = shoot / STAGE_OUTPUT[stage]
+        file_repr = None
+        if out_file.exists():
+            try:
+                file_repr = str(out_file.resolve().relative_to(REPO))
+            except ValueError:
+                file_repr = str(out_file)
+        stages[stage] = {"file": file_repr, "pending": pending}
+        if next_action is None and pending:
+            next_action = f"{stage}: {pending[0]}"
+
+    sku = _sku_from_draft(shoot)
+    ledger = _ledger_row(sku)
+
+    return {
+        "shoot": str(shoot),
+        "frames": _frame_count(shoot),
+        "stages": stages,
+        "sku": sku or None,
+        "ledger_status": ledger.get("status") if ledger else None,
+        "listing_id": (ledger or {}).get("listing_id") or None,
+        "next_action": next_action or "all stages clear — ready for REVIEW",
+    }
+
+
+def summary(state: dict) -> str:
+    lines = [f"{state['shoot']}  ({state['frames']} frame(s))"]
+    for stage in STAGE_ORDER:
+        s = state["stages"][stage]
+        if not s["file"]:
+            mark = "·"          # not started
+        elif s["pending"]:
+            mark = "⚠"          # written, but blocked on something
+        else:
+            mark = "✓"
+        lines.append(f"  {mark} {stage}")
+    if state["sku"]:
+        lines.append(f"  sku {state['sku']}  ledger={state['ledger_status'] or '(no row)'}"
+                      + (f"  {state['listing_id']}" if state["listing_id"] else ""))
+    lines.append(f"→ {state['next_action']}")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list] = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="status",
+        description="One-shot shoot-directory state: phase files, PREP's "
+                     "gate, frame count, ledger row, next action.")
+    ap.add_argument("shoot_dir", help="the shoot directory (inventory/<name>)")
+    ap.add_argument("--json", action="store_true",
+                     help="machine-readable result instead of the summary")
+    a = ap.parse_args(argv)
+
+    shoot = Path(a.shoot_dir)
+    if not shoot.is_dir():
+        ap.error(f"no such shoot directory: {shoot}")
+
+    state = gather(shoot)
+    print(json.dumps(state, indent=2) if a.json else summary(state))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prompts/_shared.md
+++ b/prompts/_shared.md
@@ -19,6 +19,30 @@ Default to terse. A phase that finishes well says so in a few lines.
   reference adds information.
 - When in doubt, cut.
 
+### Execution discipline (#61/#62)
+
+Three rules that hold in every phase, because they're what the session-log
+audit (#61) found costing the most tokens and wall-clock:
+
+1. **Never `Read` a raw photo frame into the main thread.** Read the
+   contact sheet (`tools/prep_card.py`, `tools/prep_sheet_html.py`,
+   `tools/marble_triage.py`) or delegate frame-level looking to a worker
+   subagent that returns text. Measured: 99.4% of all `Read` payload
+   across 114 sessions was photos, at ~0.68 MB a frame, sitting in context
+   for every later turn of that session.
+2. **Batch independent tool calls into one turn.** If two calls don't
+   depend on each other's result, issue them together rather than one
+   call per turn. Measured: 1.00 tool calls per assistant turn on average,
+   and ~55% of tool turns immediately followed a same-tool turn that could
+   have shipped with it.
+3. **Write a scratch `.py` file and run it, rather than an inline
+   `python -c` or a heredoc.** Quoting inside a heredoc is the single
+   largest cause of avoidable Bash failures (46 measured cases — this rule
+   included, on the first attempt at writing it down).
+
+See [RUN.md](../RUN.md) "Concurrency and delegation" for the multi-item
+fan-out pattern these rules feed into.
+
 ### Showing comps to the user — HARD RULE (never optional)
 
 Any time you surface eBay comps / sold listings to the user in chat — in

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -14,7 +14,8 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from tools.session_observer import (  # noqa: E402
-    _classify, _clean_prompt, _ts, _tool_signature, parse_session, report,
+    _classify, _clean_prompt, _ts, _tool_signature, _turn_context,
+    economics_report, parse_economics, parse_session, report,
     transcripts_dir,
 )
 
@@ -255,3 +256,141 @@ def test_a_transcript_with_non_string_timestamps_still_parses():
     p.write_text("\n".join(json.dumps(r) for r in recs), encoding="utf-8")
     s = parse_session(p)                          # must not raise
     assert s["asks"] == 1
+
+
+# ---------------------------------------------------------------------------
+# economics (#61) — context/turn, tool-call batching, Read payload, gate wait
+# ---------------------------------------------------------------------------
+def _at(iso: str) -> str:
+    return iso
+
+
+def _tool_use_msg(ts, tools, usage=None):
+    content = [{"type": "tool_use", "id": tid, "name": name, "input": inp}
+               for tid, name, inp in tools]
+    return {"type": "assistant", "timestamp": _at(ts),
+            "message": {"role": "assistant", "model": "claude-opus-5",
+                        "content": content,
+                        "usage": usage or {"input_tokens": 1, "output_tokens": 10,
+                                            "cache_read_input_tokens": 100,
+                                            "cache_creation_input_tokens": 0}}}
+
+
+def _tool_result_msg(ts, tool_use_id, body, is_error=False):
+    block = {"type": "tool_result", "tool_use_id": tool_use_id, "content": body}
+    if is_error:
+        block["is_error"] = True
+    return {"type": "user", "timestamp": _at(ts),
+            "message": {"role": "user", "content": [block]}}
+
+
+def _write_economics(records) -> Path:
+    d = Path(tempfile.mkdtemp())
+    p = d / "0000abcd-0000-0000-0000-000000000000.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    return p
+
+
+def test_turn_context_sums_the_three_token_fields():
+    assert _turn_context({"input_tokens": 1, "cache_creation_input_tokens": 5,
+                          "cache_read_input_tokens": 100}) == 106
+    assert _turn_context({}) == 0
+
+
+def test_parse_economics_records_context_and_tool_count_per_turn():
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z",
+                      [("t1", "Bash", {"command": "ls"}),
+                       ("t2", "Bash", {"command": "pwd"})],
+                      usage={"input_tokens": 1, "cache_creation_input_tokens": 5,
+                             "cache_read_input_tokens": 100, "output_tokens": 10}),
+        _tool_result_msg("2026-08-27T10:00:01Z", "t1", "a"),
+        _tool_result_msg("2026-08-27T10:00:01Z", "t2", "b"),
+    ])
+    e = parse_economics(p)
+    assert e["context_per_turn"] == [106]
+    assert e["tools_per_turn"] == [2]
+
+
+def test_parse_economics_flags_consecutive_same_tool_calls():
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z", [("t1", "Bash", {"command": "ls"})]),
+        _tool_result_msg("2026-08-27T10:00:01Z", "t1", "a"),
+        _tool_use_msg("2026-08-27T10:00:02Z", [("t2", "Bash", {"command": "pwd"})]),
+        _tool_result_msg("2026-08-27T10:00:03Z", "t2", "b"),
+        _tool_use_msg("2026-08-27T10:00:04Z", [("t3", "Read", {"file_path": "x.py"})]),
+        _tool_result_msg("2026-08-27T10:00:05Z", "t3", "c"),
+    ])
+    e = parse_economics(p)
+    # Bash -> Bash is adjacent (1); Bash -> Read is not.
+    assert e["same_tool_adjacent"] == 1
+
+
+def test_parse_economics_sizes_read_payload_by_extension():
+    body = [{"type": "text", "text": "x" * 1000}]
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z",
+                      [("t1", "Read", {"file_path": "inventory/x/photo.jpg"})]),
+        _tool_result_msg("2026-08-27T10:00:01Z", "t1", body),
+    ])
+    e = parse_economics(p)
+    assert e["read_calls"] == {".jpg": 1}
+    assert e["read_bytes"][".jpg"] == len(json.dumps(body))
+
+
+def test_parse_economics_flags_bash_over_30_seconds():
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z",
+                      [("t1", "Bash", {"command": "python long_thing.py"})]),
+        _tool_result_msg("2026-08-27T10:00:45Z", "t1", "done"),
+    ])
+    e = parse_economics(p)
+    assert e["bash_over30"] == 1
+    assert e["bash_over30_secs"] == 45.0
+    assert e["bash_total"] == 1
+    assert e["bg_bash"] == 0
+
+
+def test_parse_economics_backgrounded_bash_is_counted():
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z",
+                      [("t1", "Bash", {"command": "long", "run_in_background": True})]),
+        _tool_result_msg("2026-08-27T10:00:01Z", "t1", "started"),
+    ])
+    e = parse_economics(p)
+    assert e["bg_bash"] == 1
+
+
+def test_parse_economics_tracks_ask_wait_by_gate_header():
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z",
+                      [("t1", "AskUserQuestion",
+                        {"questions": [{"header": "Colour", "question": "which look?"}]})]),
+        _tool_result_msg("2026-08-27T11:00:00Z", "t1", "punch"),
+    ])
+    e = parse_economics(p)
+    assert e["ask_count"] == {"Colour": 1}
+    assert e["ask_wait_secs"]["Colour"] == 3600.0
+
+
+def test_economics_report_aggregates_across_sessions_and_names_the_gate():
+    p1 = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z", [("t1", "Bash", {"command": "ls"})]),
+        _tool_result_msg("2026-08-27T10:00:01Z", "t1", "a"),
+    ])
+    p2 = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z",
+                      [("t1", "AskUserQuestion",
+                        {"questions": [{"header": "Publish", "question": "go?"}]})]),
+        _tool_result_msg("2026-08-27T10:30:00Z", "t1", "yes"),
+    ])
+    out = economics_report([p1, p2])
+    assert "2 session(s)" in out
+    assert "context/turn:" in out
+    assert "tool calls/turn:" in out
+    assert "Publish" in out
+
+
+def test_economics_report_on_no_sessions_does_not_crash():
+    out = economics_report([])
+    assert "0 session(s)" in out

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,140 @@
+"""tests/test_status.py — `ebz status` (#61/#62): one read pass over a shoot
+dir instead of the ls/cat/grep sequence an operator ran by hand (measured:
+2,638 such calls, 13.4h across 114 sessions — #61).
+
+Deliberately thin: the per-stage "is this done" logic already has one
+definition, in lib/single_pass.py's STAGE_CHECK, and these tests don't
+re-litigate it — they lock down status.py's own job (frame count, sku/ledger
+lookup, and assembling the one-line next_action).
+"""
+import csv
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "lib"))
+
+import status as st  # noqa: E402
+
+
+def _clean_prep_manifest(names=("a.jpg",)) -> dict:
+    photos = {n: {"orientation": {"applied": 0, "needs_ask": False, "guessed": False,
+                                   "subject_angle": 0, "osd_proposal": 0},
+                  "crop": {"applied": True, "box": [0, 0, 10, 10]}}
+              for n in names}
+    return {"version": 1, "photos": photos, "approved": True, "auto": {"guessed": []}}
+
+
+def _clean_shoot(tmp_path: Path, sku: str = "") -> Path:
+    shoot = tmp_path / "item"
+    shoot.mkdir()
+    (shoot / "identify.txt").write_text("SHOOT SUMMARY\n", encoding="utf-8")
+    prep_dir = shoot / ".prep"
+    prep_dir.mkdir()
+    (prep_dir / "prep.json").write_text(json.dumps(_clean_prep_manifest()), encoding="utf-8")
+    (shoot / "price.txt").write_text("Max supported price: $40\n", encoding="utf-8")
+    (shoot / "investigate.txt").write_text("fine.\n", encoding="utf-8")
+    sku_line = f'  ebay_inventory_sku: "{sku}"\n' if sku else ""
+    (shoot / "draft.md").write_text(
+        f'---\ntitle: "x"\nmeta:\n{sku_line}---\nbody\n', encoding="utf-8")
+    (shoot / "a.jpg").write_bytes(b"\xff\xd8")
+    (shoot / "b.JPG").write_bytes(b"\xff\xd8")
+    (shoot / "notes.txt").write_text("not a frame\n", encoding="utf-8")
+    return shoot
+
+
+# --------------------------------------------------------------------------
+# frame count — images only, case-insensitive extension
+# --------------------------------------------------------------------------
+def test_frame_count_ignores_non_image_files(tmp_path):
+    shoot = _clean_shoot(tmp_path)
+    assert st._frame_count(shoot) == 2, "a.jpg + b.JPG, not notes.txt or the .prep/ dir"
+
+
+# --------------------------------------------------------------------------
+# next_action — the first stage with something pending, in STAGE_ORDER
+# --------------------------------------------------------------------------
+def test_empty_shoot_names_identify_as_next_action(tmp_path):
+    shoot = tmp_path / "empty"
+    shoot.mkdir()
+    state = st.gather(shoot)
+    assert state["next_action"].startswith("identify:")
+    assert state["stages"]["identify"]["pending"]
+    assert state["stages"]["identify"]["file"] is None
+
+
+def test_clean_shoot_reports_ready_for_review(tmp_path):
+    shoot = _clean_shoot(tmp_path)
+    state = st.gather(shoot)
+    assert state["next_action"] == "all stages clear — ready for REVIEW"
+    for stage in ("identify", "prep", "price", "investigate", "draft"):
+        assert state["stages"][stage]["pending"] == [], stage
+        assert state["stages"][stage]["file"] is not None, stage
+
+
+def test_next_action_stops_at_the_first_unresolved_stage(tmp_path):
+    # identify + a NOT-approved prep manifest: prep should be the blocker,
+    # not price/investigate/draft even though those files don't exist either.
+    shoot = tmp_path / "item"
+    shoot.mkdir()
+    (shoot / "identify.txt").write_text("x\n", encoding="utf-8")
+    prep_dir = shoot / ".prep"
+    prep_dir.mkdir()
+    manifest = _clean_prep_manifest()
+    manifest["approved"] = False
+    (prep_dir / "prep.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    state = st.gather(shoot)
+    assert state["next_action"].startswith("prep:")
+    assert state["stages"]["price"]["pending"], "price hasn't run either, but isn't the blocker reported"
+
+
+# --------------------------------------------------------------------------
+# sku / ledger lookup
+# --------------------------------------------------------------------------
+def test_sku_and_ledger_row_are_read_when_present(tmp_path, monkeypatch):
+    ledger = tmp_path / "listings_ledger.csv"
+    with ledger.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["sku", "status", "listing_id"])
+        w.writerow(["SKU-999", "SYNCED", "L12345"])
+    monkeypatch.setattr(st, "LEDGER", ledger)
+
+    shoot = _clean_shoot(tmp_path, sku="SKU-999")
+    state = st.gather(shoot)
+    assert state["sku"] == "SKU-999"
+    assert state["ledger_status"] == "SYNCED"
+    assert state["listing_id"] == "L12345"
+
+
+def test_no_sku_means_no_ledger_lookup(tmp_path, monkeypatch):
+    monkeypatch.setattr(st, "LEDGER", tmp_path / "listings_ledger.csv")
+    shoot = _clean_shoot(tmp_path)  # no sku in draft.md
+    state = st.gather(shoot)
+    assert state["sku"] is None
+    assert state["ledger_status"] is None
+
+
+# --------------------------------------------------------------------------
+# summary() — human-readable text mirrors gather()'s state
+# --------------------------------------------------------------------------
+def test_summary_marks_done_pending_and_not_started():
+    state = {
+        "shoot": "inventory/x", "frames": 3,
+        "stages": {
+            "identify": {"file": "identify.txt", "pending": []},
+            "prep": {"file": ".prep/prep.json", "pending": ["not approved"]},
+            "price": {"file": None, "pending": ["price.txt not written yet"]},
+            "investigate": {"file": None, "pending": ["investigate.txt not written yet"]},
+            "draft": {"file": None, "pending": ["draft.md not written yet"]},
+        },
+        "sku": None, "ledger_status": None, "listing_id": None,
+        "next_action": "prep: not approved",
+    }
+    out = st.summary(state)
+    assert "✓ identify" in out
+    assert "⚠ prep" in out
+    assert "· price" in out
+    assert out.endswith("→ prep: not approved")

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -387,6 +387,160 @@ def report(sessions: list[dict], top: int = 8) -> str:
     return "\n".join(out)
 
 
+IMAGE_EXT = (".jpg", ".jpeg", ".png", ".heic", ".webp", ".tiff", ".gif")
+
+
+def _turn_context(usage: dict) -> int:
+    """The full payload one assistant API call re-sent — the number the bill
+    actually scales with (#61: "bill ~= turns x context per turn")."""
+    return ((usage.get("input_tokens") or 0)
+            + (usage.get("cache_creation_input_tokens") or 0)
+            + (usage.get("cache_read_input_tokens") or 0))
+
+
+def parse_economics(path: Path) -> dict:
+    """One session's #61-style run economics: context/turn, tool-call
+    batching, Read payload by extension, backgrounding, and gate wall-clock
+    by header. A separate pass from parse_session's friction walk on
+    purpose — it answers "what did this session cost", not "what went
+    wrong", and bolting a second question onto the six-signal walk risks
+    the signals that walk already locks down."""
+    context_per_turn: list[int] = []
+    tools_per_turn: list[int] = []
+    same_tool_adjacent = 0
+    last_tool = None
+    read_bytes: Counter = Counter()
+    read_calls: Counter = Counter()
+    bash_total = bg_bash = bash_over30 = 0
+    bash_over30_secs = 0.0
+    ask_count: Counter = Counter()
+    ask_wait: Counter = Counter()
+    pending: dict = {}   # tool_use_id -> (ts, name, input)
+
+    with path.open(encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            if len(line) > MAX_LINE:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if rec.get("isSidechain"):
+                continue
+            kind = rec.get("type")
+            when = _ts(rec)
+
+            if kind == "assistant":
+                msg = rec.get("message") or {}
+                blocks = [b for b in (msg.get("content") or [])
+                          if isinstance(b, dict) and b.get("type") == "tool_use"]
+                if blocks:
+                    context_per_turn.append(_turn_context(msg.get("usage") or {}))
+                    tools_per_turn.append(len(blocks))
+                for b in blocks:
+                    name = b.get("name") or "?"
+                    inp = b.get("input") or {}
+                    pending[b.get("id")] = (when, name, inp)
+                    if last_tool == name:
+                        same_tool_adjacent += 1
+                    last_tool = name
+                    if name == "Read":
+                        ext = Path(str(inp.get("file_path") or "")).suffix.lower() or "(none)"
+                        read_calls[ext] += 1
+                    elif name in ("Bash", "PowerShell"):
+                        bash_total += 1
+                        if inp.get("run_in_background"):
+                            bg_bash += 1
+                    elif name == "AskUserQuestion":
+                        for q in (inp.get("questions") or []):
+                            ask_count[(q.get("header") or "?")[:24]] += 1
+
+            elif kind == "user":
+                content = (rec.get("message") or {}).get("content")
+                if not isinstance(content, list):
+                    continue
+                for b in content:
+                    if not isinstance(b, dict) or b.get("type") != "tool_result":
+                        continue
+                    st, name, inp = pending.pop(b.get("tool_use_id"), (None, None, {}))
+                    if not (st and when and name):
+                        continue
+                    if name == "Read":
+                        body = b.get("content")
+                        sz = len(json.dumps(body)) if body is not None else 0
+                        ext = Path(str(inp.get("file_path") or "")).suffix.lower() or "(none)"
+                        read_bytes[ext] += sz
+                        continue
+                    secs = (when - st).total_seconds()
+                    if name in ("Bash", "PowerShell") and secs > 30:
+                        bash_over30 += 1
+                        bash_over30_secs += secs
+                    elif name == "AskUserQuestion":
+                        for q in (inp.get("questions") or []):
+                            ask_wait[(q.get("header") or "?")[:24]] += secs
+                            break
+
+    return {
+        "context_per_turn": context_per_turn, "tools_per_turn": tools_per_turn,
+        "same_tool_adjacent": same_tool_adjacent,
+        "read_calls": dict(read_calls), "read_bytes": dict(read_bytes),
+        "bash_total": bash_total, "bg_bash": bg_bash,
+        "bash_over30": bash_over30, "bash_over30_secs": bash_over30_secs,
+        "ask_count": dict(ask_count), "ask_wait_secs": dict(ask_wait),
+    }
+
+
+def economics_report(paths: list[Path]) -> str:
+    """Aggregate `parse_economics` across sessions into the #61 headline
+    table — the standing version of `.scratch/analyze{,2,3,4}.py`."""
+    all_ctx: list[int] = []
+    all_tools: list[int] = []
+    same_tool_adjacent = total_turns = 0
+    read_bytes: Counter = Counter()
+    bash_total = bg_bash = bash_over30 = 0
+    bash_over30_secs = 0.0
+    ask_count: Counter = Counter()
+    ask_wait: Counter = Counter()
+
+    for p in paths:
+        e = parse_economics(p)
+        all_ctx.extend(e["context_per_turn"])
+        all_tools.extend(e["tools_per_turn"])
+        same_tool_adjacent += e["same_tool_adjacent"]
+        total_turns += len(e["tools_per_turn"])
+        read_bytes.update(e["read_bytes"])
+        bash_total += e["bash_total"]
+        bg_bash += e["bg_bash"]
+        bash_over30 += e["bash_over30"]
+        bash_over30_secs += e["bash_over30_secs"]
+        ask_count.update(e["ask_count"])
+        ask_wait.update(e["ask_wait_secs"])
+
+    out = [f"=== ECONOMICS — {len(paths)} session(s), {total_turns} tool-calling turn(s)"]
+    if all_ctx:
+        s = sorted(all_ctx)
+        out.append(f"  context/turn: mean {_k(int(sum(s) / len(s)))}  "
+                   f"median {_k(s[len(s) // 2])}  p90 {_k(s[int(len(s) * .9)])}  "
+                   f"max {_k(s[-1])}")
+    if all_tools:
+        out.append(f"  tool calls/turn: mean {sum(all_tools) / len(all_tools):.2f}  "
+                   f"same-tool-adjacent {same_tool_adjacent / max(total_turns, 1) * 100:.0f}% of turns")
+    img_bytes = sum(v for k, v in read_bytes.items() if k in IMAGE_EXT)
+    tot_bytes = sum(read_bytes.values())
+    if tot_bytes:
+        out.append(f"  Read payload: {img_bytes / 1e6:.1f} MB images of "
+                   f"{tot_bytes / 1e6:.1f} MB total ({img_bytes / tot_bytes * 100:.0f}%)")
+    if bash_total:
+        out.append(f"  Bash/PowerShell: {bash_total} calls, "
+                   f"{bg_bash / bash_total * 100:.1f}% backgrounded, "
+                   f"{bash_over30} over 30s totalling {bash_over30_secs / 3600:.1f}h")
+    if ask_wait:
+        out.append("  AskUserQuestion wait by gate:")
+        for h, secs in sorted(ask_wait.items(), key=lambda kv: -kv[1])[:8]:
+            out.append(f"    {ask_count.get(h, 0):>3}  {secs / 3600:>6.1f}h  {h}")
+    return "\n".join(out)
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(
         description="Parse Claude Code session transcripts into a friction report.")
@@ -395,6 +549,10 @@ def main(argv=None) -> int:
     ap.add_argument("--limit", type=int, default=20, help="most recent N sessions (default 20)")
     ap.add_argument("--all", action="store_true", help="every session, no window")
     ap.add_argument("--report", action="store_true", help="print the full report to stdout")
+    ap.add_argument("--economics", action="store_true",
+                    help="print the #61 run-economics table (context/turn, tool-call "
+                         "batching, image Read payload, gate wait) instead of the "
+                         "friction report")
     ap.add_argument("--json", dest="json_path", default="session_friction.json",
                     help="detail file (default session_friction.json)")
     args = ap.parse_args(argv)
@@ -411,6 +569,10 @@ def main(argv=None) -> int:
         files = files[:args.limit]
     if not files:
         print(f"no sessions in the last {args.days}d under {root}")
+        return 0
+
+    if args.economics:
+        print(economics_report(files))
         return 0
 
     sessions = [parse_session(f) for f in files]


### PR DESCRIPTION
## What
Companion issues #61 (measures the problem) and #62 (proposes the fix shape) — this lands the parts of both that are actually completable as repo changes.

**#62** — its own 3-day-later comment (in #71) says the four proposals "need to land in `prompts/_shared.md` and `RUN.md`, not stay in the tracker." Landed:
- **`RUN.md`**, new "Concurrency and delegation" section: multi-item batches fan out one `Agent` worker per item (IDENTIFY→PRICE→INVESTIGATE→DRAFT), capped at 4 concurrent; the conductor (main thread) holds only the manifest, the gates, and ledger writes (`listings_ledger.csv` is a single unlocked CSV — the one hard serialization constraint); gates become a queue, not a barrier — REVIEW still requires one explicit per-item approval, it just stops blocking every other item; anything over ~30s (`prep --auto` foremost) gets backgrounded.
- **`prompts/_shared.md`**, three standing execution-discipline rules every phase now carries: never `Read` a raw photo frame into the main thread (read the contact sheet or delegate to a worker), batch independent tool calls into one turn, write a scratch `.py` over an inline heredoc.
- **`lib/status.py`** (`ebz status <shoot>`): the one concrete tool #62 asked for — a single read pass replacing the `ls`/`cat`/`grep` sequence for "where is this item" (measured: 2,638 such calls, 13.4h across 114 sessions). Reuses `single_pass.py`'s own `STAGE_CHECK` so "is this stage done" has exactly one definition in the codebase.

**#61** — asked for its `.scratch/analyze{,2,3,4}.py` audit scripts to fold into a standing report "so this becomes a standing metric rather than a one-off audit." That's `ebz observe --economics`: context/turn (mean/median/p90/max — the number the bill actually scales with), tool-calls-per-turn and same-tool-adjacency (batching), Read payload by extension (image share of total), Bash backgrounding %  and >30s wall-clock, and `AskUserQuestion` wait by gate header. Same transcript parser #36's observer already owns; ran against the real transcript dir and the numbers land in the same range as #61's own audit (mean context/turn ~268k, tool-calls/turn 1.00, 57% same-tool-adjacent).

## Not in scope
The actual conductor+worker *runtime* — dispatching `Agent` workers, running a gate queue — isn't code to write in this repo; it's how a Claude Code session run against `RUN.md` behaves. The new section is the instruction; re-measuring adoption is `ebz observe --economics` on a later window, the same way #71 re-measured the first pass.

## Test plan
- [x] `pytest tests/test_status.py tests/test_session_observer.py` — all pass
- [x] `python -m tools.session_observer --economics --days 3` run against the real transcript dir — output shape matches #61
- [x] Full suite green

🤖 Generated with [Claude Code](https://claude.ai/code)