### PR TITLE
fix(tests): list_edit sync-path mock missing strict= kwarg

### DIFF
--- a/tests/test_list_edit.py
+++ b/tests/test_list_edit.py
@@ -588,7 +588,7 @@ def _patch_sync_collaborators():
         L,
         _resolve_policies_and_location=lambda creds: (dict(_POLICIES), "LOC-1"),
         get_allowed_condition_ids=lambda *a, **kw: (set(), False),
-        _resolve_shipping_policy=lambda draft, policies, creds: (policies["fulfillment"], []),
+        _resolve_shipping_policy=lambda draft, policies, creds, strict=False: (policies["fulfillment"], []),
         _assert_photos_cleared=lambda paths: None,
         upload_site_hosted_picture=lambda data, picture_name=None, creds=None: f"https://eps/{picture_name}.jpg",
     )


### PR DESCRIPTION
## What
\`main\`'s CI has been red since PR #68 merged (\`_resolve_shipping_policy\` gained a \`strict\` kwarg at two call sites in \`lib/list_edit.py\` — 1460, 1767 — but \`tests/test_list_edit.py\`'s \`_patch_sync_collaborators()\` mock lambda only accepted \`(draft, policies, creds)\`). One-line fix: give the mock the same default the real function has.

Found while landing #78 (#61/#62) — its own CI run failed on this, unrelated to that PR's content, and confirmed failing on \`main\` directly too.

## Test plan
- [x] \`pytest tests/test_list_edit.py\` — 19 passed (was 1 failed/18 passed)