### PR TITLE
docs: require worktree isolation for git state changes in this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# Repo-wide instructions
+
+## Shared working directory — use a worktree for git state changes
+
+This directory is opened by many concurrent Claude Code sessions at once
+(interactive terminals, Remote Control, scheduled tasks). They all share one
+git working tree. A `git checkout`/`switch`/`stash` in one session changes
+the files every other session sees, mid-task, with no warning to them.
+
+**Any session about to run `git checkout <branch>`, `git switch`, `git
+stash` (push or pop), or `git checkout -b <new-branch>` must call
+`EnterWorktree` first**, unless it is only reading git state (`status`,
+`log`, `diff`, `show`) — reads are safe and don't need a worktree.
+
+`EnterWorktree` creates an isolated checkout under `.claude/worktrees/` and
+moves *this session's* working directory there; it does not disturb any
+other session. Use `ExitWorktree` with `action: "keep"` when handing the
+branch off for review, or `action: "remove"` once its PR has merged and
+there's nothing left to keep.
+
+This rule exists because a session once ran `git checkout main` →
+`git checkout -b <feature>` directly in the shared directory, silently
+switching the working tree under every other concurrent session.


### PR DESCRIPTION
## Summary
- Adds a repo-root `CLAUDE.md`, read automatically by every session opened here, requiring `EnterWorktree` before any git checkout/switch/stash in this directory.
- Closes #87 — the incident that prompted it: this working directory is shared by ~25 concurrent Claude Code sessions (confirmed via `ListAgents`), and a checkout+branch sequence run directly in the shared tree by one session very likely caused another session's in-progress edit to appear as an unexplained working-tree change.

## Test plan
- [x] N/A — documentation-only change, no code paths affected.
- [ ] Confirm a future session opened in this directory picks up CLAUDE.md and follows the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)