### PR TITLE
docs: retire v2/v3 framing, README describes v4 standalone (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ manages any offer/SKU on the account: `--offers` (query all, read-only),
 <id>` and `--delete-item <sku>` (permanent removal). Mutations are dry-run
 unless `--confirm` and are user-initiated — never part of the pipeline.
 
-Python infrastructure (`config`, `ebay_client`, `apify_ebay`,
+Python infrastructure (`config`, `ebay_client`, `ebay_sold_browse`,
 `list_edit`, `draft_io`, `photo_prep`) lives in `lib/`.
 
 ## Core invariants
@@ -103,11 +103,12 @@ listing template + its `_field_constraints`, the unit_type vocabulary, and
 the deterministic output-file-per-phase convention all hold. The REVIEW
 gate is what turns "publish" from an absolute refusal into an
 approval-gated action: nothing goes LIVE without one explicit human
-approval at the decision card. eBay sold comps via the logged-in browser
-([`lib/ebay_sold_browse.py`](lib/ebay_sold_browse.py)) run as the un-gated
-default Stage B of the comp hunt (Chrome is an optional low-confidence
-cross-check); Apify was retired 2026-08-15 and must not be re-enabled —
-see [`docs/pricing-backend-issues.md`](docs/pricing-backend-issues.md).
+approval at the decision card. Stage B of the comp hunt runs, un-gated by
+default, through the logged-in browser
+([`lib/ebay_sold_browse.py`](lib/ebay_sold_browse.py)); Chrome is an
+optional low-confidence cross-check. Apify was retired 2026-08-15 and
+must not be re-enabled — see
+[`docs/pricing-backend-issues.md`](docs/pricing-backend-issues.md).
 See
 [`docs/archive/v2-to-v3-migration.md`](docs/archive/v2-to-v3-migration.md)
 if you want the history of how these settled.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
-# v3 — headless prompt suite
+# eBay listing pipeline — v4
 
-A full rewrite of the v2 prompt pipeline with three goals: run as
-headless as possible, output far fewer words with more confidence, and
-dig deeper on condition and exact-match pricing. **v2 is untouched and
-remains the working reference;** v3 is the new path.
+A prompt-driven pipeline that carries a shoot from photos to a
+review-ready (then, on approval, published) eBay listing with as little
+human babysitting as possible. It runs headless end to end, stopping only
+at hard gates (photo approval, then the pre-publish review card), digs
+deep on condition and exact-match pricing before falling back to an
+era-peer comp, and reports account-wide performance after the fact. See
+[`docs/V4_PLAN.md`](docs/V4_PLAN.md) for the current refactor plan
+(skinny prompts, one CLI, fewer round-trips, a session observer) and
+[`docs/archive/v2-to-v3-migration.md`](docs/archive/v2-to-v3-migration.md)
+for the history of how this pipeline got here — v1 and v2 are frozen for
+context only in [`deprecated/`](deprecated/README.md); no active guidance
+lives there.
 
 ## Start here
 
@@ -33,40 +41,6 @@ listings — and **proposes only**. Every eBay write stays the operator's
 keystroke, because an ad added by mistake spends before anyone notices.
 
     python tools/promote.py --budget 20    # the plan + the exact calls to enact it
-
-## What changed from v2
-
-**1 — Headless.** A single orchestrator ([`RUN.md`](RUN.md)) and an
-explicit **gate contract**: only ONE thing stops a run — the REVIEW gate
-(after DRAFT, present a decision card and publish LIVE only on explicit
-approval). Every other old "ask the user" moment is now a SOFT gate —
-proceed with a documented default, append one line to
-`<shoot-dir>/NEEDS_REVIEW.md`, keep going. The user reviews that queue
-asynchronously instead of being interrupted. Notably: PRICE no longer
-waits for query approval and no longer gates on its comp source — Stage B
-runs automatically through the user's logged-in browser
-([`lib/ebay_sold_browse.py`](lib/ebay_sold_browse.py); Apify was retired
-2026-08-15 after repeated silent blocking, see
-[`docs/pricing-backend-issues.md`](docs/pricing-backend-issues.md)) — and the
-working price is auto-adopted (Recommended tier, provisional) so the pipeline
-finishes straight through to the review card.
-
-**2 — Fewer words, more confidence.** Shared rules were extracted to
-[`prompts/_shared.md`](prompts/_shared.md) (unit_type, fresh-investigation,
-firewall, char limits, one house-style block) — the ~40% duplication
-across the five v2 prompts is gone, and the suite dropped from ~2,300 to
-~1,100 lines. Scenario brackets are capped at 3, produced only on
-material value swing, with sub-15% tails and "effectively excluded"
-padding removed. Phases commit to one call instead of laddering best→worst.
-
-**3 — Depth / independence.** New
-[`prompts/condition-rubric.md`](prompts/condition-rubric.md): a
-per-material defect taxonomy + eBay grade mapping with a conservative
-tie-break, used by IDENTIFY and INVESTIGATE. PRICE gained an autonomous
-**exact-match hunt** — Stage A WebSearch → Stage B Apify eBay-sold →
-optional Stage C Chrome (only when confidence is low) — iterating query
-formulations before ever falling back to an era-peer, and reporting how
-hard it looked.
 
 ## Layout
 
@@ -121,13 +95,16 @@ unless `--confirm` and are user-initiated — never part of the pipeline.
 Python infrastructure (`config`, `ebay_client`, `apify_ebay`,
 `list_edit`, `draft_io`, `photo_prep`) lives in `lib/`.
 
-## Unchanged from v2
+## Core invariants
 
 The no-*automatic*-publish firewall (publishing requires `--confirm` and
 is never triggered by the pipeline or `--sync`), the YAML-frontmatter
 listing template + its `_field_constraints`, the unit_type vocabulary, the
 Apify opt-in policy, and the deterministic output-file-per-phase
-convention all carry over. New in v3: the REVIEW gate turns the old
-absolute publish refusal into an approval-gated publish; and Apify moved
-from a gated, opt-in fallback to the un-gated default Stage B of the comp
-hunt (Chrome demoted to an optional low-confidence cross-check).
+convention all hold. The REVIEW gate is what turns "publish" from an
+absolute refusal into an approval-gated action: nothing goes LIVE without
+one explicit human approval at the decision card. Apify runs as the
+un-gated default Stage B of the comp hunt (Chrome is an optional
+low-confidence cross-check). See
+[`docs/archive/v2-to-v3-migration.md`](docs/archive/v2-to-v3-migration.md)
+if you want the history of how these settled.

--- a/README.md
+++ b/README.md
@@ -99,12 +99,15 @@ Python infrastructure (`config`, `ebay_client`, `apify_ebay`,
 
 The no-*automatic*-publish firewall (publishing requires `--confirm` and
 is never triggered by the pipeline or `--sync`), the YAML-frontmatter
-listing template + its `_field_constraints`, the unit_type vocabulary, the
-Apify opt-in policy, and the deterministic output-file-per-phase
-convention all hold. The REVIEW gate is what turns "publish" from an
-absolute refusal into an approval-gated action: nothing goes LIVE without
-one explicit human approval at the decision card. Apify runs as the
-un-gated default Stage B of the comp hunt (Chrome is an optional
-low-confidence cross-check). See
+listing template + its `_field_constraints`, the unit_type vocabulary, and
+the deterministic output-file-per-phase convention all hold. The REVIEW
+gate is what turns "publish" from an absolute refusal into an
+approval-gated action: nothing goes LIVE without one explicit human
+approval at the decision card. eBay sold comps via the logged-in browser
+([`lib/ebay_sold_browse.py`](lib/ebay_sold_browse.py)) run as the un-gated
+default Stage B of the comp hunt (Chrome is an optional low-confidence
+cross-check); Apify was retired 2026-08-15 and must not be re-enabled —
+see [`docs/pricing-backend-issues.md`](docs/pricing-backend-issues.md).
+See
 [`docs/archive/v2-to-v3-migration.md`](docs/archive/v2-to-v3-migration.md)
 if you want the history of how these settled.

--- a/RUN.md
+++ b/RUN.md
@@ -356,7 +356,7 @@ Shared rules (style, confidence, firewall, unit_type, char limits,
 persistence) live in [prompts/_shared.md](prompts/_shared.md).
 
 Python infrastructure (config, eBay client, Apify wrapper, photo prep)
-is unchanged and shared from `lib/` — v3 does not duplicate code.
+is shared from `lib/` — no phase duplicates it.
 
 ---
 

--- a/RUN.md
+++ b/RUN.md
@@ -80,8 +80,9 @@ state. It never holds a raw photo, a comp JSON, forum matches, or a worker's
 full reasoning — those are what make the window huge.
 
 **One worker (`Agent` tool) per item**, covering IDENTIFY→PRICE→
-INVESTIGATE→DRAFT, **capped at 4 concurrent** (PRICE hits Apify/eBay Browse;
-more trips rate limits). Each worker starts on a fresh context, reads
+INVESTIGATE→DRAFT, **capped at 4 concurrent** (PRICE hits the logged-in
+browser and eBay Browse; more trips rate limits). Each worker starts on a
+fresh context, reads
 [`prompts/_shared.md`](prompts/_shared.md) plus the phase prompt it needs —
 not optional, the honesty rules and in-hand voice live only in the prompt
 files — writes its outputs to the shoot dir exactly as a normal run would,
@@ -158,11 +159,13 @@ Reclassify every "ask the user" moment as HARD or SOFT.
 **PREP and REVIEW both stop a headless run** — PREP because photos are the first
 thing a buyer judges and the rules alone did not hold, REVIEW because it is what
 authorises publishing. The maker-mark gate above is interactive-only and
-degrades. PRICE's Apify call (Stage B) used to
-be a second HARD gate; it no longer is — Apify runs automatically as part
-of the comp hunt (`automation-lab/ebay-sold-scraper`, ~$0.10/run), no cost
-confirmation. See PRICE for the Stage-A/B/C ordering and the currency-leak
-validator on Apify.
+degrades. PRICE's Stage B comp call used to
+be a second HARD gate (when it ran through Apify, a paid per-run API); it
+no longer is — Stage B now runs automatically through the operator's own
+logged-in eBay session (`lib/ebay_sold_browse.py`; Apify was retired
+2026-08-15, see [`docs/pricing-backend-issues.md`](docs/pricing-backend-issues.md)),
+which has no per-run cost to confirm. See PRICE for the Stage-A/B/C
+ordering and the currency-leak validator.
 
 ### SOFT gates — proceed with the default, log it
 
@@ -349,8 +352,8 @@ Cross-cutting depth rules:
   by default**; a run turns one on by name. It is a stylistic overlay: house
   rules (honesty bar, wear phrasing, PII, stage contract) always win.
 - PRICE runs the autonomous exact-match hunt (Stage A WebSearch → Stage B
-  Apify eBay-sold → optional Stage C Chrome when confidence is low) before
-  any era-peer fallback; see its prompt.
+  eBay sold via the logged-in browser → optional Stage C Chrome when
+  confidence is low) before any era-peer fallback; see its prompt.
 
 Shared rules (style, confidence, firewall, unit_type, char limits,
 persistence) live in [prompts/_shared.md](prompts/_shared.md).
@@ -386,9 +389,9 @@ fetch, photo prep) is shared from `lib/` — no phase duplicates it.
    `--approve-stage color` → `--approve`. Photos land in `listing/`;
    INVESTIGATE still reads the originals.
 3. PRICE each saleable item → run the exact-match hunt (Stage A WebSearch
-   → Stage B Apify eBay-sold → Stage C Chrome only if confidence is low);
-   adopt Recommended tier as provisional working price; write `price.txt`.
-   Never stops.
+   → Stage B eBay sold via the logged-in browser → Stage C Chrome only if
+   confidence is low); adopt Recommended tier as provisional working
+   price; write `price.txt`. Never stops.
 4. CURATE (plan mode) → write `review.md`.
 5. INVESTIGATE (list mode), per item → commit to the confident
    assessment; log open questions; write `investigate.txt`.

--- a/RUN.md
+++ b/RUN.md
@@ -355,8 +355,8 @@ Cross-cutting depth rules:
 Shared rules (style, confidence, firewall, unit_type, char limits,
 persistence) live in [prompts/_shared.md](prompts/_shared.md).
 
-Python infrastructure (config, eBay client, Apify wrapper, photo prep)
-is shared from `lib/` — no phase duplicates it.
+Python infrastructure (config, eBay client, logged-in-browser comp
+fetch, photo prep) is shared from `lib/` — no phase duplicates it.
 
 ---
 

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -15,3 +15,8 @@ by the active pipeline.**
 
 The live project is at the repo root: `RUN.md`, `prompts/`, `templates/`,
 `lib/`. Start at [`../RUN.md`](../RUN.md).
+
+**Convention:** v1 and v2 are frozen for context only. No new work should
+extend anything under `deprecated/`, and no doc outside this directory
+should cite v1/v2 as current guidance — cite the live pipeline (currently
+v4, see [`../docs/V4_PLAN.md`](../docs/V4_PLAN.md)) instead.

--- a/docs/archive/v2-to-v3-migration.md
+++ b/docs/archive/v2-to-v3-migration.md
@@ -36,10 +36,11 @@ padding removed. Phases commit to one call instead of laddering best→worst.
 [`prompts/condition-rubric.md`](../../prompts/condition-rubric.md): a
 per-material defect taxonomy + eBay grade mapping with a conservative
 tie-break, used by IDENTIFY and INVESTIGATE. PRICE gained an autonomous
-**exact-match hunt** — Stage A WebSearch → Stage B Apify eBay-sold →
-optional Stage C Chrome (only when confidence is low) — iterating query
-formulations before ever falling back to an era-peer, and reporting how
-hard it looked.
+**exact-match hunt** — Stage A WebSearch → Stage B Apify eBay-sold (as it
+was at the time; see "Unchanged from v2" below for how Stage B's backend
+has since moved) → optional Stage C Chrome (only when confidence is low)
+— iterating query formulations before ever falling back to an era-peer,
+and reporting how hard it looked.
 
 ## Unchanged from v2
 

--- a/docs/archive/v2-to-v3-migration.md
+++ b/docs/archive/v2-to-v3-migration.md
@@ -1,0 +1,55 @@
+# What changed when v3 replaced v2
+
+Archival context, moved out of `README.md` (#83) so the front door describes
+the current pipeline on its own terms instead of as a diff against a
+generation that's now two versions behind. v2 lives frozen in
+[`../../deprecated/v2/`](../../deprecated/v2/); this is the record of why v3
+looked the way it did when it replaced it. v3 itself was later folded into
+v4 — see [`../V4_PLAN.md`](../V4_PLAN.md) for that step.
+
+## What changed from v2
+
+**1 — Headless.** A single orchestrator ([`RUN.md`](../../RUN.md)) and an
+explicit **gate contract**: only ONE thing stops a run — the REVIEW gate
+(after DRAFT, present a decision card and publish LIVE only on explicit
+approval). Every other old "ask the user" moment is now a SOFT gate —
+proceed with a documented default, append one line to
+`<shoot-dir>/NEEDS_REVIEW.md`, keep going. The user reviews that queue
+asynchronously instead of being interrupted. Notably: PRICE no longer
+waits for query approval and no longer gates on its comp source — Stage B
+runs automatically through the user's logged-in browser
+([`lib/ebay_sold_browse.py`](../../lib/ebay_sold_browse.py); Apify was retired
+2026-08-15 after repeated silent blocking, see
+[`../pricing-backend-issues.md`](../pricing-backend-issues.md)) — and the
+working price is auto-adopted (Recommended tier, provisional) so the pipeline
+finishes straight through to the review card.
+
+**2 — Fewer words, more confidence.** Shared rules were extracted to
+[`prompts/_shared.md`](../../prompts/_shared.md) (unit_type, fresh-investigation,
+firewall, char limits, one house-style block) — the ~40% duplication
+across the five v2 prompts is gone, and the suite dropped from ~2,300 to
+~1,100 lines. Scenario brackets are capped at 3, produced only on
+material value swing, with sub-15% tails and "effectively excluded"
+padding removed. Phases commit to one call instead of laddering best→worst.
+
+**3 — Depth / independence.** New
+[`prompts/condition-rubric.md`](../../prompts/condition-rubric.md): a
+per-material defect taxonomy + eBay grade mapping with a conservative
+tie-break, used by IDENTIFY and INVESTIGATE. PRICE gained an autonomous
+**exact-match hunt** — Stage A WebSearch → Stage B Apify eBay-sold →
+optional Stage C Chrome (only when confidence is low) — iterating query
+formulations before ever falling back to an era-peer, and reporting how
+hard it looked.
+
+## Unchanged from v2
+
+The no-*automatic*-publish firewall (publishing requires `--confirm` and
+is never triggered by the pipeline or `--sync`), the YAML-frontmatter
+listing template + its `_field_constraints`, the unit_type vocabulary, the
+Apify opt-in policy, and the deterministic output-file-per-phase
+convention all carried over. v3 turned the old absolute publish refusal
+into an approval-gated publish (the REVIEW gate); and Apify moved from a
+gated, opt-in fallback to the un-gated default Stage B of the comp
+hunt (Chrome demoted to an optional low-confidence cross-check). These
+invariants are still true in the current (v4) pipeline — see README.md's
+"Core invariants" section for the standalone statement.

--- a/docs/archive/v2-to-v3-migration.md
+++ b/docs/archive/v2-to-v3-migration.md
@@ -49,7 +49,12 @@ listing template + its `_field_constraints`, the unit_type vocabulary, the
 Apify opt-in policy, and the deterministic output-file-per-phase
 convention all carried over. v3 turned the old absolute publish refusal
 into an approval-gated publish (the REVIEW gate); and Apify moved from a
-gated, opt-in fallback to the un-gated default Stage B of the comp
-hunt (Chrome demoted to an optional low-confidence cross-check). These
-invariants are still true in the current (v4) pipeline — see README.md's
-"Core invariants" section for the standalone statement.
+gated, opt-in fallback to the un-gated default Stage B of the comp hunt
+(Chrome demoted to an optional low-confidence cross-check). The firewall,
+template, vocabulary, and file convention are still true in the current
+(v4) pipeline — see README.md's "Core invariants" section for the
+standalone statement. Stage B's *backend* has since moved again: Apify
+was retired 2026-08-15 in favor of the logged-in browser
+([`../pricing-backend-issues.md`](../pricing-backend-issues.md)); the
+"un-gated default Stage B" shape described above is what's current, the
+Apify part of it is not.

--- a/kb/README.md
+++ b/kb/README.md
@@ -9,8 +9,8 @@ conventions, reproduction/fake red flags, where to find real comps, dating
 clues, shipping/handling for fragile classes — plus the curated **resource
 registry** the modules and prompts link out to.
 
-Like the rest of v3 this is prompt-driven: an article is just a Markdown file
-the pipeline reads when it's relevant. No code, no build step.
+Like the rest of the pipeline this is prompt-driven: an article is just a
+Markdown file the pipeline reads when it's relevant. No code, no build step.
 
 - **KB article** → reusable reference knowledge (a digest of one or more
   resources), category-agnostic or spanning categories.

--- a/prompts/report.md
+++ b/prompts/report.md
@@ -1,4 +1,4 @@
-# REPORT — v3, Function 7
+# REPORT — Function 7
 
 Obeys [`_shared.md`](_shared.md) (style, confidence, honesty). Read it first.
 

--- a/specializations/README.md
+++ b/specializations/README.md
@@ -8,9 +8,10 @@ better attribution, the named high-value types flagged, the right condition
 vocabulary, the inspection shots a specialist would ask for, and a coarse
 value tier so PRICE and CURATE start from an informed anchor.
 
-This is prompt-driven, like the rest of v3 — a module is just a Markdown file
-the pipeline reads on demand. No code, no build step. Adding the next
-specialization is: drop a new file in here, add one row to the registry below.
+This is prompt-driven, like the rest of the pipeline — a module is just a
+Markdown file the pipeline reads on demand. No code, no build step. Adding the
+next specialization is: drop a new file in here, add one row to the registry
+below.
 
 ---
 


### PR DESCRIPTION
## Summary

Issue #83: README.md still titled itself "v3 — headless prompt suite" and
called v2 "the working reference," even though v3 was promoted to the repo
root long ago and v4 is now the live generation on top of it. This PR:

- **Rewrites `README.md`'s title and opening** to describe the current
  pipeline on its own terms (what it does, how to run it) instead of as a
  diff against v2. The "What changed from v2" / "Unchanged from v2"
  narrative wasn't deleted — it moved to a new
  [`docs/archive/v2-to-v3-migration.md`](docs/archive/v2-to-v3-migration.md),
  following this repo's existing `docs/archive/` convention for retired
  context (used previously for root-hygiene/session-log archiving). The
  README's "Core invariants" section restates what's still true today
  standalone, with a pointer to the archive doc for anyone who wants the
  history.
- **Sweeps the other files** that referenced v2/v3 as if describing current
  behavior: `RUN.md` ("v3 does not duplicate code" → restated plainly),
  `prompts/report.md` ("REPORT — v3, Function 7" → "REPORT — Function 7"),
  and `kb/README.md` / `specializations/README.md` ("like the rest of v3
  this is prompt-driven" → "like the rest of the pipeline").
- **Adds the frozen-for-context-only convention** to `deprecated/README.md`
  (it already existed and already said nothing there is used by the active
  pipeline, but didn't spell out that no new work should extend v1/v2 or
  cite them as current guidance — now it does, with a pointer to
  `docs/V4_PLAN.md` as the live reference).

## What I found vs. the issue's file count

The issue's grep-based list (27 files) was filed before the repo moved;
re-running `grep -rln 'v2\|v3' --include='*.md' .` (excluding `deprecated/`,
which is expected/frozen) today turns up **13 files**, not 27 — several
were already folded into `docs/archive/` or `prompts/reference/` by earlier
hygiene work before this PR.

## Not swept in this PR (with rationale)

These files matched the grep but use "v2" for something **other** than the
pipeline's own v1/v2/v3/v4 generation — the exact confusion this issue
flags doesn't apply to them, so relabeling risked more confusion, not less:

- **`docs/price-strategy-v2.md`**, **`docs/pricing-backend-issues.md`**,
  **`prompts/reference/price-notes.md`** — "v2" here is the PRICE
  algorithm's own versioning (v1 = pick-the-strongest-comp by eye, v2 =
  today's distribution-based tiering). It's still called v2 because it's
  still the current, only-ever-implemented pricing design — there's no v3
  pricing algorithm to promote it past. `price-notes.md` in fact already
  follows the exact "prompt-diet" reference-notes pattern this issue asks
  for elsewhere.
- **`specializations/jewelry.md`**, **`specializations/silverplate.md`** —
  "(v2)" marks a *future revision* of that specialization module's own
  content ("Open items to deepen in a future revision (v2)"), unrelated to
  the pipeline generation.
- **`docs/archive/inventory_cleanup_prompt.md`** — already lives in
  `docs/archive/`, already framed as historical ("the v3 prep pipeline
  itself" describes what was true when the note was written); no change
  needed, it's already correctly archived.
- **`docs/V4_PLAN.md`**'s "v3 made the pipeline headless… v4 makes it cheap
  and quiet" opening — this is the one place a v3→v4 comparison is exactly
  the right framing (it's the plan document for that transition), so it
  was left as-is.

If a maintainer disagrees on any of these being out of scope, they're a
one-line follow-up each.

## Test plan

- `python3 tests/run_all.py --fast` and `python3 -m pytest tests/ -q`
  (excluding the 4 CLIP/torch-dependent suites not installed in this
  sandbox) — **428 passed**, 0 failed. Confirmed no test asserts on
  `README.md` or any of the swept files' content
  (`grep -rn 'README\.md' tests/` → no matches).
- `grep -rln 'v2\|v3' --include='*.md' .` outside `deprecated/` re-run
  after the change — the only remaining hits are the "Not swept" files
  above (rationale given) plus the new `docs/archive/v2-to-v3-migration.md`
  and `deprecated/README.md` itself (both correctly, intentionally
  historical/frozen framing).

Closes #83


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnrWxtKQStiTx1qFkqc5sm)_