### PR TITLE
feat(shipping): quote and buy labels via EasyPost, confirm-gated (#80)

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -325,6 +325,58 @@ Uses only Python stdlib (`urllib.request`, `urllib.parse`, `base64`,
 
 ---
 
+## easypost_client.py — buy shipping labels via EasyPost (GH #80)
+
+eBay's own Logistics API is a confirmed dead end for a small seller
+(Limited Release, invitation-only, USPS-only — #32). This client quotes
+and buys postage from EasyPost instead: pay-as-you-go, free up to 3,000
+labels/month, no contract, rates across USPS/UPS/FedEx/DHL.
+
+Get an API key at <https://www.easypost.com/account/api-keys> — EasyPost
+issues separate **test** and **production** keys from the same dashboard;
+a test key's "purchases" never charge a real carrier or ship anything,
+which is the safe way to exercise the CLI below before trusting it with
+real postage money. Provisioning the account + funding its balance is a
+one-time human step, same spirit as the eBay OAuth setup above — nothing
+here does it for you.
+
+Set the key the same way as every other credential in this repo:
+
+```yaml
+# ~/.ebaybiz/config.yaml
+easypost:
+  api_key: "EZAK..."
+```
+
+or `EASYPOST_API_KEY` (env var wins if both are set).
+
+### CLI usage
+
+```bash
+# Quote — spends nothing, no --confirm needed
+python -m lib.cli ship-quote \
+    --to-name "Jane Buyer" --to-street1 "1 Main St" --to-city Springfield \
+    --to-state IL --to-zip 62704 \
+    --from-name "My Store" --from-street1 "9 Ship St" --from-city Elgin \
+    --from-state IL --from-zip 60120 \
+    --weight-oz 24 --length-in 10 --width-in 8 --height-in 4
+
+# Buy — DRY RUN by default; add --confirm to actually spend money
+python -m lib.cli ship-buy --shipment-id shp_... --rate-id rate_...
+python -m lib.cli ship-buy --shipment-id shp_... --rate-id rate_... --confirm
+```
+
+`ship-buy`'s confirm gate mirrors `list_edit.py --publish/--end` exactly:
+without `--confirm` it makes no call to EasyPost's purchase endpoint and
+only reports what would be bought and its cost. On a confirmed purchase,
+the printed carrier + tracking number are handed off as the exact
+`tools/pick_list.py --record-tracking ORDER_ID --carrier CODE
+--tracking-number NUM --confirm` invocation (#70) needed to advance the
+local ledger to SHIPPED — this module does not write the ledger itself,
+and (as of this writing) `--record-tracking` has not landed on `main` yet.
+
+---
+
 ## comps_csv.py — reviewable comps CSV (all PRICE stages)
 
 Stage B (Apify) saves JSON; stages A (WebSearch) and C (Chrome) are

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -54,6 +54,10 @@ COMMANDS = {
                      "gate-check IDENTIFY->PREP->PRICE->INVESTIGATE->DRAFT; one card when clean"),
     "status":       ("lib.status",
                      "one-shot shoot state: phase files, PREP gate, frames, ledger, next action (#61)"),
+    "ship-quote":   ("tools.ship_quote",
+                     "EasyPost shipping-rate quotes (#80) — free, no confirm needed"),
+    "ship-buy":     ("tools.ship_buy",
+                     "buy a label via EasyPost (#80) — DRY RUN unless --confirm"),
 }
 
 

--- a/lib/config.example.yaml
+++ b/lib/config.example.yaml
@@ -136,6 +136,25 @@ ebay:
                                          # See docs/top-rated-plus.md.
 
 # ---------------------------------------------------------------------------
+# EasyPost — self-serve carrier-rate API for buying shipping labels (GH #80)
+# ---------------------------------------------------------------------------
+# Bypasses eBay's own Logistics API (confirmed a dead end for a small
+# seller — Limited Release, invitation-only, USPS-only; see #32/#80).
+# Rate quoting (lib/easypost_client.get_rates) runs freely and costs
+# nothing. Buying a label (lib/easypost_client.buy_label /
+# `ebz ship-buy`) spends real money and is DRY RUN unless --confirm is
+# passed explicitly — same gate as `list_edit.py --publish/--end`.
+#
+# Setup is a human, one-time step, not something to provision unattended:
+#   1. Create an account at https://www.easypost.com and fund its balance.
+#   2. Get a key (test or production) at
+#      https://www.easypost.com/account/api-keys — a test key never
+#      charges a real carrier, useful for exercising ship-quote/ship-buy
+#      before trusting it with real postage money.
+easypost:
+  api_key: "EZAK_REPLACE_ME"
+
+# ---------------------------------------------------------------------------
 # CURATE strategy profiles
 # ---------------------------------------------------------------------------
 # Profiles encode the Buy Point math used by CURATE. The active profile

--- a/lib/config.py
+++ b/lib/config.py
@@ -285,6 +285,39 @@ def get_anthropic_key() -> str:
     )
 
 
+def get_easypost_key() -> str:
+    """EasyPost API key. Precedence: env var > config file > error.
+
+    Same precedence contract as get_apify_token() / get_anthropic_key().
+    EasyPost issues test and production keys from the same dashboard; which
+    one is configured decides whether a confirmed buy_label() call hits real
+    carriers or EasyPost's no-charge test mode — that is an account-setup
+    choice made by a human, not something this loader infers (GH #80).
+
+    Raises:
+        ConfigError if no key is available anywhere.
+    """
+    env = os.environ.get("EASYPOST_API_KEY")
+    if env:
+        return env
+
+    config = load_config()
+    key = _nested(config, "easypost", "api_key")
+    if key:
+        return str(key)
+
+    raise ConfigError(
+        f"EasyPost API key not found.\n"
+        f"  Set the EASYPOST_API_KEY environment variable, OR\n"
+        f"  add this to {config_path()}:\n"
+        f"      easypost:\n"
+        f"        api_key: \"<your-key>\"\n"
+        f"  Get a key (test or production) at https://www.easypost.com/account/api-keys\n"
+        f"  A human still has to create the account and fund its balance before\n"
+        f"  any real purchase can succeed — that step is deliberately not automated."
+    )
+
+
 def get_ebay_credentials() -> dict:
     """Return the raw eBay credentials section from config.
 
@@ -421,6 +454,12 @@ def _cli() -> None:
             print(f"anthropic.api_key: {_redact(anth_key)}")
         except ConfigError:
             print("anthropic.api_key: (not set)")
+
+        try:
+            ep_key = get_easypost_key()
+            print(f"easypost.api_key: {_redact(ep_key)}")
+        except ConfigError:
+            print("easypost.api_key: (not set)")
 
         ebay_creds = get_ebay_credentials()
         print()

--- a/lib/easypost_client.py
+++ b/lib/easypost_client.py
@@ -292,6 +292,15 @@ def buy_label(shipment_id: str, rate: Rate, confirm: bool = False,
     exact shape `tools/pick_list.py --record-tracking` (#70) expects — feed
     them straight through; this function does not touch the local ledger.
     """
+    if rate.shipment_id != shipment_id:
+        # A rate carries the shipment it was quoted against; if a caller
+        # passes a shipment_id that doesn't match, buying it would purchase
+        # postage for the wrong shipment — fail before either a dry-run
+        # summary or the purchase call, not after.
+        raise ValueError(
+            f"shipment_id mismatch: buy_label() called with {shipment_id!r} but "
+            f"rate {rate.id!r} was quoted for shipment {rate.shipment_id!r}")
+
     if not confirm:
         return BuyResult(dry_run=True, shipment_id=shipment_id, rate_id=rate.id,
                          carrier=rate.carrier, service=rate.service,

--- a/lib/easypost_client.py
+++ b/lib/easypost_client.py
@@ -45,7 +45,6 @@ See tools/ship_quote.py (`ebz ship-quote` — free) and tools/ship_buy.py
 from __future__ import annotations
 
 import json
-import os
 import time
 import urllib.error
 import urllib.request
@@ -53,7 +52,7 @@ from base64 import b64encode
 from dataclasses import dataclass
 from typing import Optional
 
-from config import ConfigError, config_path, load_config
+from config import get_easypost_key
 
 API_BASE = "https://api.easypost.com/v2"
 
@@ -81,28 +80,11 @@ class EasyPostAPIError(RuntimeError):
 def get_api_key() -> str:
     """EasyPost API key. Precedence: env var > config file > error.
 
-    Mirrors config.get_apify_token() / config.get_anthropic_key() exactly:
-    EASYPOST_API_KEY env var first, then config.yaml `easypost.api_key`.
+    Thin wrapper around config.get_easypost_key() — the precedence
+    contract lives in exactly one place; this name is kept so callers in
+    this module read naturally alongside get_rates()/buy_label().
     """
-    env = os.environ.get("EASYPOST_API_KEY")
-    if env:
-        return env
-
-    config = load_config()
-    key = (config.get("easypost") or {}).get("api_key")
-    if key:
-        return str(key)
-
-    raise ConfigError(
-        f"EasyPost API key not found.\n"
-        f"  Set the EASYPOST_API_KEY environment variable, OR\n"
-        f"  add this to {config_path()}:\n"
-        f"      easypost:\n"
-        f"        api_key: \"<your-key>\"\n"
-        f"  Get a key (test or production) at https://www.easypost.com/account/api-keys\n"
-        f"  A human still has to create the account and fund its balance before\n"
-        f"  any real purchase can succeed — that step is deliberately not automated."
-    )
+    return get_easypost_key()
 
 
 # ---------------------------------------------------------------------------
@@ -152,12 +134,14 @@ def api_send(method: str, path: str, body: Optional[dict] = None,
                 ) from e
             err = EasyPostAPIError(e.code, f"{m} {path} -> HTTP {e.code}", body_text)
             if e.code >= 500 and idempotent and attempt < 2:
-                time.sleep(0.8 * (attempt + 1)); continue
+                time.sleep(0.8 * (attempt + 1))
+                continue
             raise err from e
         except urllib.error.URLError as e:
             err = EasyPostAPIError(0, f"{m} {path} -> network error: {e}", None)
             if attempt < 2:
-                time.sleep(0.8 * (attempt + 1)); continue
+                time.sleep(0.8 * (attempt + 1))
+                continue
             raise err from e
 
 

--- a/lib/easypost_client.py
+++ b/lib/easypost_client.py
@@ -188,7 +188,8 @@ class Parcel:
 
     def to_dict(self) -> dict:
         d: dict = {"weight": self.weight_oz}
-        if self.length_in and self.width_in and self.height_in:
+        if (self.length_in is not None and self.width_in is not None
+                and self.height_in is not None):
             d.update({"length": self.length_in, "width": self.width_in,
                       "height": self.height_in})
         return d

--- a/lib/easypost_client.py
+++ b/lib/easypost_client.py
@@ -62,7 +62,11 @@ API_BASE = "https://api.easypost.com/v2"
 # ---------------------------------------------------------------------------
 
 class EasyPostAuthError(RuntimeError):
-    """Raised when the EasyPost API key is missing or rejected."""
+    """Raised when EasyPost rejects the API key (HTTP 401).
+
+    A *missing* key never reaches this point — get_api_key() raises
+    ConfigError before any HTTP call is made.
+    """
 
 
 class EasyPostAPIError(RuntimeError):
@@ -95,9 +99,11 @@ def api_send(method: str, path: str, body: Optional[dict] = None,
              api_key: Optional[str] = None, retry_network_errors: bool = True) -> dict:
     """Issue a JSON request against the EasyPost REST API.
 
-    Returns the decoded JSON body (or {} for an empty 2xx). Raises
-    EasyPostAuthError on a 401 (bad/missing key) and EasyPostAPIError on any
-    other non-2xx, carrying EasyPost's error body for diagnosis.
+    Returns the decoded JSON body (or {} for an empty 2xx). A missing key
+    is caught earlier by get_api_key() (ConfigError), before any call is
+    made; this function raises EasyPostAuthError on a 401 (a rejected key)
+    and EasyPostAPIError on any other non-2xx, carrying EasyPost's error
+    body for diagnosis.
 
     Retry policy is deliberately identical to ebay_client.api_send: transient
     5xx is retried only for idempotent methods (GET/PUT/DELETE) so a POST

--- a/lib/easypost_client.py
+++ b/lib/easypost_client.py
@@ -314,8 +314,9 @@ def buy_label(shipment_id: str, rate: Rate, confirm: bool = False,
                     retry_network_errors=False)
     sel = resp.get("selected_rate") or {}
     label = resp.get("postage_label") or {}
+    sel_rate = sel.get("rate")
     try:
-        price = float(sel.get("rate") or rate.rate)
+        price = float(sel_rate if sel_rate is not None else rate.rate)
     except (TypeError, ValueError):
         price = rate.rate
     return BuyResult(dry_run=False, shipment_id=shipment_id,

--- a/lib/easypost_client.py
+++ b/lib/easypost_client.py
@@ -1,0 +1,314 @@
+"""
+EasyPost self-serve carrier-rate API client (GH #80).
+
+eBay's own Logistics API is a confirmed dead end for a small seller —
+Limited Release, invitation-only, USPS-only (see #32). This module bypasses
+it entirely and quotes/buys the label from EasyPost instead: pay-as-you-go,
+free up to 3,000 labels/month, no contract, rates across USPS/UPS/FedEx/DHL.
+
+The purchased label's tracking number comes back in a shape that feeds
+straight into `tools/pick_list.py --record-tracking ORDER_ID --carrier CODE
+--tracking-number NUM --confirm` (#70) to advance the local ledger to
+SHIPPED — that endpoint doesn't care who sold the postage, and this module
+does not duplicate the ledger write. (#70 has not landed on `main` as of
+this writing — see tools/ship_buy.py's docstring.)
+
+----- Guardrail (same shape as lib/list_edit.py --publish / --end) -----
+
+Quoting rates (get_rates) spends nothing and may run freely, no
+confirmation gate. Buying a label (buy_label) spends real money: it is a
+DRY RUN unless `confirm=True` is passed explicitly. Without it, buy_label()
+makes NO call to EasyPost's purchase endpoint — it only reports what WOULD
+be bought and its cost. Never inferred, never called from an unattended
+poll loop.
+
+----- Auth -----
+
+EasyPost uses HTTP Basic Auth: the API key as the username, empty password.
+EasyPost issues separate test and production keys from the same dashboard;
+a test key's "purchases" never charge a real carrier. Which one is
+configured is an account-setup decision a human makes — this client does
+not infer or switch it.
+
+----- Key source -----
+
+Same precedence as every other API key in this repo (see config.py):
+    1. EASYPOST_API_KEY environment variable
+    2. config.yaml `easypost.api_key`
+    3. ConfigError, with setup instructions
+
+----- CLI -----
+
+See tools/ship_quote.py (`ebz ship-quote` — free) and tools/ship_buy.py
+(`ebz ship-buy` — DRY RUN unless --confirm).
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from base64 import b64encode
+from dataclasses import dataclass
+from typing import Optional
+
+from config import ConfigError, config_path, load_config
+
+API_BASE = "https://api.easypost.com/v2"
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class EasyPostAuthError(RuntimeError):
+    """Raised when the EasyPost API key is missing or rejected."""
+
+
+class EasyPostAPIError(RuntimeError):
+    """Raised when an EasyPost API call returns a non-2xx response."""
+    def __init__(self, status: int, message: str, body: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+# ---------------------------------------------------------------------------
+# API key
+# ---------------------------------------------------------------------------
+
+def get_api_key() -> str:
+    """EasyPost API key. Precedence: env var > config file > error.
+
+    Mirrors config.get_apify_token() / config.get_anthropic_key() exactly:
+    EASYPOST_API_KEY env var first, then config.yaml `easypost.api_key`.
+    """
+    env = os.environ.get("EASYPOST_API_KEY")
+    if env:
+        return env
+
+    config = load_config()
+    key = (config.get("easypost") or {}).get("api_key")
+    if key:
+        return str(key)
+
+    raise ConfigError(
+        f"EasyPost API key not found.\n"
+        f"  Set the EASYPOST_API_KEY environment variable, OR\n"
+        f"  add this to {config_path()}:\n"
+        f"      easypost:\n"
+        f"        api_key: \"<your-key>\"\n"
+        f"  Get a key (test or production) at https://www.easypost.com/account/api-keys\n"
+        f"  A human still has to create the account and fund its balance before\n"
+        f"  any real purchase can succeed — that step is deliberately not automated."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Generic JSON request — same retry policy as ebay_client.api_send
+# ---------------------------------------------------------------------------
+
+def api_send(method: str, path: str, body: Optional[dict] = None,
+             api_key: Optional[str] = None) -> dict:
+    """Issue a JSON request against the EasyPost REST API.
+
+    Returns the decoded JSON body (or {} for an empty 2xx). Raises
+    EasyPostAuthError on a 401 (bad/missing key) and EasyPostAPIError on any
+    other non-2xx, carrying EasyPost's error body for diagnosis.
+
+    Retry policy is deliberately identical to ebay_client.api_send: transient
+    5xx is retried only for idempotent methods (GET/PUT/DELETE) so a POST
+    that creates or spends money can never double-fire from a retry; a
+    network error (the request likely never reached EasyPost) retries
+    regardless of method.
+    """
+    api_key = api_key or get_api_key()
+    if not path.startswith("/"):
+        path = "/" + path
+    url = API_BASE + path
+
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    basic = b64encode(f"{api_key}:".encode("utf-8")).decode("ascii")
+    headers = {
+        "Authorization": f"Basic {basic}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+    m = method.upper()
+    idempotent = m in ("GET", "PUT", "DELETE")
+    for attempt in range(3):
+        req = urllib.request.Request(url, data=data, method=m, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                raw = resp.read().decode("utf-8")
+                return json.loads(raw) if raw.strip() else {}
+        except urllib.error.HTTPError as e:
+            body_text = e.read().decode("utf-8", errors="replace")
+            if e.code == 401:
+                raise EasyPostAuthError(
+                    f"EasyPost rejected the API key (HTTP 401): {body_text}"
+                ) from e
+            err = EasyPostAPIError(e.code, f"{m} {path} -> HTTP {e.code}", body_text)
+            if e.code >= 500 and idempotent and attempt < 2:
+                time.sleep(0.8 * (attempt + 1)); continue
+            raise err from e
+        except urllib.error.URLError as e:
+            err = EasyPostAPIError(0, f"{m} {path} -> network error: {e}", None)
+            if attempt < 2:
+                time.sleep(0.8 * (attempt + 1)); continue
+            raise err from e
+
+
+# ---------------------------------------------------------------------------
+# Shipment inputs
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Address:
+    """A shipping address — EasyPost's `address` object (subset used here)."""
+    name: str
+    street1: str
+    city: str
+    state: str
+    zip: str
+    country: str = "US"
+    street2: Optional[str] = None
+    phone: Optional[str] = None
+    email: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        d = {"name": self.name, "street1": self.street1, "city": self.city,
+             "state": self.state, "zip": self.zip, "country": self.country}
+        if self.street2:
+            d["street2"] = self.street2
+        if self.phone:
+            d["phone"] = self.phone
+        if self.email:
+            d["email"] = self.email
+        return d
+
+
+@dataclass
+class Parcel:
+    """A parcel — EasyPost's `parcel` object. weight is OUNCES, dims INCHES
+    (EasyPost's default `imperial` unit system, which this client assumes).
+    Dimensions are optional (weight-only quoting), but most carrier
+    services need them to return a full rate table.
+    """
+    weight_oz: float
+    length_in: Optional[float] = None
+    width_in: Optional[float] = None
+    height_in: Optional[float] = None
+
+    def to_dict(self) -> dict:
+        d: dict = {"weight": self.weight_oz}
+        if self.length_in and self.width_in and self.height_in:
+            d.update({"length": self.length_in, "width": self.width_in,
+                      "height": self.height_in})
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Rate quoting — free, no confirmation gate
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Rate:
+    id: str
+    carrier: str
+    service: str
+    rate: float
+    currency: str
+    delivery_days: Optional[int]
+    shipment_id: str
+
+
+def get_rates(to_address: Address, from_address: Address, parcel: Parcel,
+              api_key: Optional[str] = None) -> tuple[str, list[Rate]]:
+    """Create a shipment with EasyPost and return (shipment_id, rates).
+
+    This is the ONLY call in this module that may run unattended / freely —
+    it creates a quote, never a purchase, and spends nothing. Rates are
+    sorted cheapest first. `shipment_id` plus a chosen `Rate.id` is exactly
+    what buy_label() needs.
+    """
+    body = {"shipment": {"to_address": to_address.to_dict(),
+                         "from_address": from_address.to_dict(),
+                         "parcel": parcel.to_dict()}}
+    resp = api_send("POST", "/shipments", body=body, api_key=api_key)
+    shipment_id = str(resp.get("id") or "")
+
+    rates: list[Rate] = []
+    for r in resp.get("rates") or []:
+        try:
+            price = float(r.get("rate"))
+        except (TypeError, ValueError):
+            continue
+        rates.append(Rate(id=str(r.get("id") or ""),
+                          carrier=str(r.get("carrier") or ""),
+                          service=str(r.get("service") or ""),
+                          rate=price,
+                          currency=str(r.get("currency") or "USD"),
+                          delivery_days=r.get("delivery_days"),
+                          shipment_id=shipment_id))
+    rates.sort(key=lambda r: r.rate)
+    return shipment_id, rates
+
+
+# ---------------------------------------------------------------------------
+# BUY — explicit, manual, confirmation-gated (the one purchase path)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BuyResult:
+    dry_run: bool
+    shipment_id: str
+    rate_id: str
+    carrier: str
+    service: str
+    price: float
+    currency: str = "USD"
+    tracking_code: Optional[str] = None    # set only on a real purchase
+    label_url: Optional[str] = None        # set only on a real purchase
+    postage_label_id: Optional[str] = None  # set only on a real purchase
+
+
+def buy_label(shipment_id: str, rate: Rate, confirm: bool = False,
+              api_key: Optional[str] = None) -> BuyResult:
+    """Buy postage for a previously-quoted rate. DRY RUN unless confirm=True.
+
+    Guarded exactly like list_edit.publish_offer(): with confirm=False this
+    makes NO call to EasyPost's purchase endpoint (POST
+    /shipments/{id}/buy) — it only reports what WOULD be bought and its
+    cost, using the rate already returned by get_rates(). This is the ONLY
+    function in this module that can spend money, and the ONLY place that
+    calls the buy endpoint.
+
+    On a real purchase, the returned `carrier` + `tracking_code` are in the
+    exact shape `tools/pick_list.py --record-tracking` (#70) expects — feed
+    them straight through; this function does not touch the local ledger.
+    """
+    if not confirm:
+        return BuyResult(dry_run=True, shipment_id=shipment_id, rate_id=rate.id,
+                         carrier=rate.carrier, service=rate.service,
+                         price=rate.rate, currency=rate.currency)
+
+    resp = api_send("POST", f"/shipments/{shipment_id}/buy",
+                    body={"rate": {"id": rate.id}}, api_key=api_key)
+    sel = resp.get("selected_rate") or {}
+    label = resp.get("postage_label") or {}
+    try:
+        price = float(sel.get("rate") or rate.rate)
+    except (TypeError, ValueError):
+        price = rate.rate
+    return BuyResult(dry_run=False, shipment_id=shipment_id,
+                     rate_id=str(sel.get("id") or rate.id),
+                     carrier=str(sel.get("carrier") or rate.carrier),
+                     service=str(sel.get("service") or rate.service),
+                     price=price,
+                     currency=str(sel.get("currency") or rate.currency),
+                     tracking_code=resp.get("tracking_code") or None,
+                     label_url=label.get("label_url") or None,
+                     postage_label_id=(str(label.get("id")) if label.get("id") else None))

--- a/lib/easypost_client.py
+++ b/lib/easypost_client.py
@@ -92,7 +92,7 @@ def get_api_key() -> str:
 # ---------------------------------------------------------------------------
 
 def api_send(method: str, path: str, body: Optional[dict] = None,
-             api_key: Optional[str] = None) -> dict:
+             api_key: Optional[str] = None, retry_network_errors: bool = True) -> dict:
     """Issue a JSON request against the EasyPost REST API.
 
     Returns the decoded JSON body (or {} for an empty 2xx). Raises
@@ -101,9 +101,14 @@ def api_send(method: str, path: str, body: Optional[dict] = None,
 
     Retry policy is deliberately identical to ebay_client.api_send: transient
     5xx is retried only for idempotent methods (GET/PUT/DELETE) so a POST
-    that creates or spends money can never double-fire from a retry; a
-    network error (the request likely never reached EasyPost) retries
-    regardless of method.
+    that creates or spends money can never double-fire from a retry. A
+    network error is ambiguous — the request may never have reached
+    EasyPost, or it may have reached it and spent money while the response
+    was lost — so by default it still retries regardless of method (the
+    common case for a free/idempotent call like creating a shipment quote).
+    Pass retry_network_errors=False for a call where that ambiguity is
+    unacceptable (the purchase endpoint): a lost response there must never
+    risk a second real charge.
     """
     api_key = api_key or get_api_key()
     if not path.startswith("/"):
@@ -139,7 +144,7 @@ def api_send(method: str, path: str, body: Optional[dict] = None,
             raise err from e
         except urllib.error.URLError as e:
             err = EasyPostAPIError(0, f"{m} {path} -> network error: {e}", None)
-            if attempt < 2:
+            if retry_network_errors and attempt < 2:
                 time.sleep(0.8 * (attempt + 1))
                 continue
             raise err from e
@@ -224,6 +229,13 @@ def get_rates(to_address: Address, from_address: Address, parcel: Parcel,
                          "parcel": parcel.to_dict()}}
     resp = api_send("POST", "/shipments", body=body, api_key=api_key)
     shipment_id = str(resp.get("id") or "")
+    if not shipment_id:
+        # No id means nothing downstream (buy_label, --record-tracking) has
+        # anything usable to act on — treat it as the API error it is,
+        # rather than handing the operator a shipment_id that can't buy.
+        raise EasyPostAPIError(
+            0, "EasyPost /shipments response is missing an id",
+            json.dumps(resp))
 
     rates: list[Rate] = []
     for r in resp.get("rates") or []:
@@ -231,9 +243,14 @@ def get_rates(to_address: Address, from_address: Address, parcel: Parcel,
             price = float(r.get("rate"))
         except (TypeError, ValueError):
             continue
-        rates.append(Rate(id=str(r.get("id") or ""),
-                          carrier=str(r.get("carrier") or ""),
-                          service=str(r.get("service") or ""),
+        rate_id = str(r.get("id") or "")
+        carrier = str(r.get("carrier") or "")
+        service = str(r.get("service") or "")
+        if not (rate_id and carrier and service):
+            # Missing the identifiers ship-buy needs to actually buy/print
+            # this rate — surfacing it would just be a dead end.
+            continue
+        rates.append(Rate(id=rate_id, carrier=carrier, service=service,
                           rate=price,
                           currency=str(r.get("currency") or "USD"),
                           delivery_days=r.get("delivery_days"),
@@ -280,8 +297,12 @@ def buy_label(shipment_id: str, rate: Rate, confirm: bool = False,
                          carrier=rate.carrier, service=rate.service,
                          price=rate.rate, currency=rate.currency)
 
+    # retry_network_errors=False: unlike a quote, a lost response here can't
+    # be safely retried — the purchase may have already gone through, and a
+    # retry risks buying (and charging for) a second label.
     resp = api_send("POST", f"/shipments/{shipment_id}/buy",
-                    body={"rate": {"id": rate.id}}, api_key=api_key)
+                    body={"rate": {"id": rate.id}}, api_key=api_key,
+                    retry_network_errors=False)
     sel = resp.get("selected_rate") or {}
     label = resp.get("postage_label") or {}
     try:

--- a/tests/test_easypost_client.py
+++ b/tests/test_easypost_client.py
@@ -501,6 +501,19 @@ def test_buy_label_with_confirm_calls_the_buy_endpoint_and_returns_tracking():
     _patched(fake, go)
 
 
+def test_buy_label_confirmed_keeps_a_legitimate_zero_price():
+    # selected_rate.rate == 0 is a real (if unusual) EasyPost value, not a
+    # missing one — `or rate.rate` would treat it as falsy and silently
+    # substitute the quoted price instead (Copilot review fix).
+    fake = _Fake(_buy_response(price=0.0))
+
+    def go():
+        result = buy_label("shp_1", CHEAP_RATE, confirm=True)
+        assert result.price == 0.0
+
+    _patched(fake, go)
+
+
 def test_buy_label_confirmed_5xx_does_not_retry_and_surfaces_error():
     # A purchase POST must never silently retry — could double-buy a label.
     fake = _Fake(_http_error(500, b'{"error":{"message":"carrier timeout"}}'))
@@ -618,6 +631,23 @@ def test_ship_quote_prints_currency_in_the_ship_buy_follow_up_command():
     assert "--currency GBP" in buf.getvalue()
 
 
+def test_ship_quote_double_quotes_a_service_name_with_spaces():
+    # Python's repr() (single quotes) isn't shell-agnostic — e.g. Windows
+    # cmd.exe treats a single quote as literal, splitting a multi-word
+    # service into separate arguments. The printed follow-up command must
+    # double-quote it instead (Copilot review fix).
+    rate = Rate(id="rate_x", carrier="UPS", service="Priority Mail Express",
+               rate=9.0, currency="USD", delivery_days=1, shipment_id="shp_1")
+    fake = lambda *a, **kw: ("shp_1", [rate])  # noqa: E731
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = _run_ship_quote_cli([], fake=fake)
+    assert rc == 0
+    out = buf.getvalue()
+    assert '--service "Priority Mail Express"' in out
+    assert "'Priority Mail Express'" not in out
+
+
 # ---------------------------------------------------------------------------
 # tools/ship_buy.py CLI — --price 0.0 must count as "provided" (Copilot review fix)
 # ---------------------------------------------------------------------------
@@ -710,6 +740,30 @@ def test_ship_buy_shipment_mismatch_reported_cleanly_not_a_traceback():
         sys.argv = real_argv
     assert rc == 1
     assert fake.requests == []
+
+
+def test_ship_buy_confirmed_prints_carrier_unquoted_in_pick_list_command():
+    # repr() (single-quoted) isn't shell-agnostic (Windows cmd.exe treats a
+    # single quote as literal) — carrier codes don't need quoting at all,
+    # so the printed follow-up command should print the raw value
+    # (Copilot review fix).
+    fake = _Fake(_buy_response(carrier="USPS"))
+    real_argv = sys.argv
+    sys.argv = ["ship_buy.py", "--shipment-id", "shp_1", "--rate-id", "rate_1", "--confirm"]
+    buf = io.StringIO()
+
+    def go():
+        with redirect_stdout(buf):
+            return ship_buy.main()
+
+    try:
+        rc = _patched(fake, go)
+    finally:
+        sys.argv = real_argv
+    out = buf.getvalue()
+    assert rc == 0
+    assert "--carrier USPS " in out
+    assert "'USPS'" not in out
 
 
 if __name__ == "__main__":

--- a/tests/test_easypost_client.py
+++ b/tests/test_easypost_client.py
@@ -281,6 +281,25 @@ def test_api_send_network_error_retries_even_for_post():
     _patched(fake, go)
 
 
+def test_api_send_network_error_not_retried_when_disabled():
+    # A lost response after the request reached the server is ambiguous —
+    # for a money-spending call (retry_network_errors=False) a single
+    # network error must surface immediately, never retry (Copilot review
+    # fix: could otherwise double-fire a purchase).
+    fake = _Fake(urllib.error.URLError("reset"), _FakeResponse({"ok": True}))
+
+    def go():
+        try:
+            api_send("POST", "/shipments/shp_1/buy", {"rate": {}},
+                     retry_network_errors=False)
+            raise AssertionError("expected EasyPostAPIError")
+        except EasyPostAPIError as e:
+            assert e.status == 0
+            assert len(fake.requests) == 1
+
+    _patched(fake, go)
+
+
 # ---------------------------------------------------------------------------
 # get_rates — the free path
 # ---------------------------------------------------------------------------
@@ -350,6 +369,39 @@ def test_get_rates_no_rates_returns_empty_list():
         shipment_id, rates = get_rates(TO_ADDR, FROM_ADDR, PARCEL)
         assert shipment_id == "shp_1"
         assert rates == []
+
+    _patched(fake, go)
+
+
+def test_get_rates_missing_shipment_id_raises_api_error():
+    # A blank shipment_id is useless to every downstream caller (buy_label,
+    # --record-tracking) — surface it as the API error it is instead of
+    # handing back an unusable id (Copilot review fix).
+    fake = _Fake(_shipment_response(shipment_id=""))
+
+    def go():
+        try:
+            get_rates(TO_ADDR, FROM_ADDR, PARCEL)
+            raise AssertionError("expected EasyPostAPIError")
+        except EasyPostAPIError as e:
+            assert "missing an id" in str(e)
+
+    _patched(fake, go)
+
+
+def test_get_rates_skips_rate_entries_missing_identifiers():
+    # A rate missing id/carrier/service parses fine as a price but can't be
+    # bought or printed — it's a dead end for ship-buy, so drop it rather
+    # than hand the operator an entry they can't act on.
+    fake = _Fake(_shipment_response(rates=[
+        {"id": "", "carrier": "UPS", "service": "Ground", "rate": "5.00"},
+        {"id": "rate_x", "carrier": "", "service": "Ground", "rate": "6.00"},
+        {"id": "rate_ok", "carrier": "USPS", "service": "Priority", "rate": "9.00"},
+    ]))
+
+    def go():
+        _, rates = get_rates(TO_ADDR, FROM_ADDR, PARCEL)
+        assert [r.id for r in rates] == ["rate_ok"]
 
     _patched(fake, go)
 
@@ -424,6 +476,25 @@ def test_buy_label_confirmed_5xx_does_not_retry_and_surfaces_error():
         except EasyPostAPIError as e:
             assert e.status == 500
             assert "carrier timeout" in e.body
+            assert len(fake.requests) == 1
+
+    _patched(fake, go)
+
+
+def test_buy_label_confirmed_network_error_does_not_retry():
+    # Same guardrail as the 5xx case, for the other failure mode: a lost
+    # response after the purchase POST may mean EasyPost already charged
+    # for and issued the label. Retrying could buy (and pay for) a second
+    # one, so a network error on the buy call must surface immediately
+    # (Copilot review fix).
+    fake = _Fake(urllib.error.URLError("reset"), _buy_response())
+
+    def go():
+        try:
+            buy_label("shp_1", CHEAP_RATE, confirm=True)
+            raise AssertionError("expected EasyPostAPIError")
+        except EasyPostAPIError as e:
+            assert e.status == 0
             assert len(fake.requests) == 1
 
     _patched(fake, go)

--- a/tests/test_easypost_client.py
+++ b/tests/test_easypost_client.py
@@ -550,7 +550,15 @@ def test_buy_label_confirmed_network_error_does_not_retry():
 
 
 def test_buy_label_missing_api_key_raises_before_any_call():
+    # api_key=None only clears EASYPOST_API_KEY; without also patching
+    # load_config, a developer's real config.yaml (if it has
+    # easypost.api_key set) would supply a key and this test would stop
+    # exercising the "missing everywhere" branch (Copilot review fix —
+    # same hermeticity pattern as test_get_api_key_missing_everywhere_
+    # raises_config_error above).
     fake = _Fake()
+    real_load = CFG.load_config
+    CFG.load_config = lambda reload=False: {}
 
     def go():
         try:
@@ -559,7 +567,10 @@ def test_buy_label_missing_api_key_raises_before_any_call():
         except ConfigError:
             assert fake.requests == []
 
-    _patched(fake, go, api_key=None)
+    try:
+        _patched(fake, go, api_key=None)
+    finally:
+        CFG.load_config = real_load
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_easypost_client.py
+++ b/tests/test_easypost_client.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""lib/easypost_client.py — quote + buy, tested offline (GH #80).
+
+Buying a label spends real money, so this module's own tests are the first
+line of defense that the confirm gate actually holds: buy_label() must
+never touch the purchase endpoint (POST /shipments/{id}/buy) unless called
+with confirm=True. Every test here asserts on the exact set of HTTP calls
+made, the same way tests/test_ebay_client.py and tests/test_list_edit.py
+verify their money-moving paths.
+
+All HTTP is faked by patching urllib.request.urlopen; no network, no real
+API key needed to run these.
+
+Run:  python tests/test_easypost_client.py
+  or: pytest tests/test_easypost_client.py
+"""
+import io
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "lib"))
+
+import easypost_client as EP                                            # noqa: E402
+from easypost_client import (                                          # noqa: E402
+    Address,
+    BuyResult,
+    EasyPostAPIError,
+    EasyPostAuthError,
+    Parcel,
+    Rate,
+    api_send,
+    buy_label,
+    get_api_key,
+    get_rates,
+)
+from config import ConfigError                                         # noqa: E402
+
+
+TO_ADDR = Address(name="Jane Buyer", street1="1 Main St", city="Springfield",
+                  state="IL", zip="62704")
+FROM_ADDR = Address(name="My Store", street1="9 Ship St", city="Elgin",
+                    state="IL", zip="60120")
+PARCEL = Parcel(weight_oz=24, length_in=10, width_in=8, height_in=4)
+
+
+# ---------------------------------------------------------------------------
+# Fakes — same shape as tests/test_ebay_client.py's _Fake/_FakeResponse
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, payload, raw=None):
+        self._raw = raw if raw is not None else json.dumps(payload).encode()
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _http_error(code, body=b'{"error":{"message":"boom"}}'):
+    return urllib.error.HTTPError("https://x", code, f"HTTP {code}", None, io.BytesIO(body))
+
+
+class _Fake:
+    """Scripted stand-in for urllib.request.urlopen. Requests beyond the
+    script repeat the last scripted entry."""
+
+    def __init__(self, *script):
+        self.script = list(script)
+        self.requests = []
+
+    def __call__(self, req, timeout=None):
+        self.requests.append(req)
+        step = self.script[min(len(self.requests), len(self.script)) - 1]
+        if isinstance(step, Exception):
+            raise step
+        return step
+
+
+def _patched(fake, fn, *, api_key="test-key-123"):
+    """Run fn with urlopen faked, retry sleeps zeroed, and the API key
+    forced via env var so no real config.yaml can leak in or out."""
+    real_open, real_sleep = urllib.request.urlopen, EP.time.sleep
+    prev_env = os.environ.get("EASYPOST_API_KEY")
+    urllib.request.urlopen = fake
+    EP.time.sleep = lambda s: None
+    if api_key is not None:
+        os.environ["EASYPOST_API_KEY"] = api_key
+    else:
+        os.environ.pop("EASYPOST_API_KEY", None)
+    try:
+        return fn()
+    finally:
+        urllib.request.urlopen, EP.time.sleep = real_open, real_sleep
+        if prev_env is None:
+            os.environ.pop("EASYPOST_API_KEY", None)
+        else:
+            os.environ["EASYPOST_API_KEY"] = prev_env
+
+
+def _shipment_response(shipment_id="shp_1", rates=None):
+    return _FakeResponse({
+        "id": shipment_id,
+        "rates": rates if rates is not None else [
+            {"id": "rate_usps", "carrier": "USPS", "service": "Priority",
+             "rate": "8.45", "currency": "USD", "delivery_days": 2},
+            {"id": "rate_ups", "carrier": "UPS", "service": "Ground",
+             "rate": "11.20", "currency": "USD", "delivery_days": 3},
+        ],
+    })
+
+
+def _buy_response(tracking="TRK123456789", carrier="USPS", service="Priority",
+                  rate_id="rate_usps", price="8.45"):
+    return _FakeResponse({
+        "id": "shp_1",
+        "tracking_code": tracking,
+        "selected_rate": {"id": rate_id, "carrier": carrier, "service": service,
+                          "rate": price, "currency": "USD"},
+        "postage_label": {"id": "pl_1",
+                          "label_url": "https://easypost-labels.example/pl_1.png"},
+    })
+
+
+# ---------------------------------------------------------------------------
+# API key resolution
+# ---------------------------------------------------------------------------
+
+def test_get_api_key_missing_everywhere_raises_config_error():
+    # Patch the name as bound inside easypost_client's own namespace (it did
+    # `from config import load_config`), not the config module's attribute —
+    # rebinding the latter would not affect the former.
+    prev_env = os.environ.pop("EASYPOST_API_KEY", None)
+    real_load = EP.load_config
+    EP.load_config = lambda reload=False: {}
+    try:
+        try:
+            get_api_key()
+            raise AssertionError("expected ConfigError")
+        except ConfigError as e:
+            assert "EASYPOST_API_KEY" in str(e)
+            assert "easypost" in str(e)
+    finally:
+        EP.load_config = real_load
+        if prev_env is not None:
+            os.environ["EASYPOST_API_KEY"] = prev_env
+
+
+def test_get_api_key_prefers_env_var_over_config_file():
+    prev_env = os.environ.get("EASYPOST_API_KEY")
+    os.environ["EASYPOST_API_KEY"] = "from-env"
+    real_load = EP.load_config
+    EP.load_config = lambda reload=False: {"easypost": {"api_key": "from-config"}}
+    try:
+        assert get_api_key() == "from-env"
+    finally:
+        EP.load_config = real_load
+        if prev_env is None:
+            os.environ.pop("EASYPOST_API_KEY", None)
+        else:
+            os.environ["EASYPOST_API_KEY"] = prev_env
+
+
+def test_get_api_key_falls_back_to_config_file():
+    prev_env = os.environ.pop("EASYPOST_API_KEY", None)
+    real_load = EP.load_config
+    EP.load_config = lambda reload=False: {"easypost": {"api_key": "from-config"}}
+    try:
+        assert get_api_key() == "from-config"
+    finally:
+        EP.load_config = real_load
+        if prev_env is not None:
+            os.environ["EASYPOST_API_KEY"] = prev_env
+
+
+# ---------------------------------------------------------------------------
+# api_send — auth header + retry policy (mirrors ebay_client's contract)
+# ---------------------------------------------------------------------------
+
+def test_api_send_sends_basic_auth_with_key_as_username():
+    fake = _Fake(_FakeResponse({"ok": True}))
+
+    def go():
+        out = api_send("GET", "/shipments/shp_1")
+        assert out == {"ok": True}
+        auth = fake.requests[0].get_header("Authorization")
+        import base64
+        assert auth.startswith("Basic ")
+        decoded = base64.b64decode(auth.split(" ", 1)[1]).decode()
+        assert decoded == "test-key-123:"
+
+    _patched(fake, go)
+
+
+def test_api_send_401_raises_easypost_auth_error():
+    fake = _Fake(_http_error(401, b'{"error":{"message":"invalid API key"}}'))
+
+    def go():
+        try:
+            api_send("GET", "/shipments/shp_1")
+            raise AssertionError("expected EasyPostAuthError")
+        except EasyPostAuthError as e:
+            assert "invalid API key" in str(e)
+
+    _patched(fake, go)
+
+
+def test_api_send_400_preserves_status_and_body():
+    fake = _Fake(_http_error(422, b'{"error":{"message":"bad zip"}}'))
+
+    def go():
+        try:
+            api_send("POST", "/shipments", {"shipment": {}})
+            raise AssertionError("expected EasyPostAPIError")
+        except EasyPostAPIError as e:
+            assert e.status == 422
+            assert "bad zip" in e.body
+            assert len(fake.requests) == 1  # no retry on 4xx
+
+    _patched(fake, go)
+
+
+def test_api_send_5xx_on_post_does_not_retry():
+    fake = _Fake(_http_error(500))
+
+    def go():
+        try:
+            api_send("POST", "/shipments/shp_1/buy", {"rate": {"id": "r"}})
+            raise AssertionError("expected EasyPostAPIError")
+        except EasyPostAPIError as e:
+            assert e.status == 500
+            assert len(fake.requests) == 1  # a purchase call must never double-fire
+
+    _patched(fake, go)
+
+
+def test_api_send_5xx_on_get_retries_then_succeeds():
+    fake = _Fake(_http_error(503), _http_error(503), _FakeResponse({"ok": True}))
+
+    def go():
+        out = api_send("GET", "/shipments/shp_1")
+        assert out == {"ok": True}
+        assert len(fake.requests) == 3
+
+    _patched(fake, go)
+
+
+def test_api_send_network_error_retries_even_for_post():
+    fake = _Fake(urllib.error.URLError("reset"), _FakeResponse({"ok": True}))
+
+    def go():
+        out = api_send("POST", "/shipments", {"shipment": {}})
+        assert out == {"ok": True}
+        assert len(fake.requests) == 2
+
+    _patched(fake, go)
+
+
+# ---------------------------------------------------------------------------
+# get_rates — the free path
+# ---------------------------------------------------------------------------
+
+def test_get_rates_parses_and_sorts_cheapest_first():
+    fake = _Fake(_shipment_response())
+
+    def go():
+        shipment_id, rates = get_rates(TO_ADDR, FROM_ADDR, PARCEL)
+        assert shipment_id == "shp_1"
+        assert [r.carrier for r in rates] == ["USPS", "UPS"]  # 8.45 < 11.20
+        assert rates[0].rate == 8.45
+        assert rates[0].id == "rate_usps"
+        # exactly one call — quoting never calls the purchase endpoint
+        assert len(fake.requests) == 1
+        assert fake.requests[0].full_url.endswith("/shipments")
+        assert fake.requests[0].get_method() == "POST"
+
+    _patched(fake, go)
+
+
+def test_get_rates_sends_addresses_and_parcel_in_body():
+    fake = _Fake(_shipment_response())
+
+    def go():
+        get_rates(TO_ADDR, FROM_ADDR, PARCEL)
+        body = json.loads(fake.requests[0].data.decode())
+        shipment = body["shipment"]
+        assert shipment["to_address"]["zip"] == "62704"
+        assert shipment["from_address"]["city"] == "Elgin"
+        assert shipment["parcel"]["weight"] == 24
+
+    _patched(fake, go)
+
+
+def test_get_rates_skips_malformed_rate_entries():
+    fake = _Fake(_shipment_response(rates=[
+        {"id": "rate_bad", "carrier": "UPS", "service": "Ground", "rate": "not-a-number"},
+        {"id": "rate_ok", "carrier": "USPS", "service": "Priority", "rate": "9.00"},
+    ]))
+
+    def go():
+        _, rates = get_rates(TO_ADDR, FROM_ADDR, PARCEL)
+        assert [r.id for r in rates] == ["rate_ok"]
+
+    _patched(fake, go)
+
+
+def test_get_rates_no_rates_returns_empty_list():
+    fake = _Fake(_shipment_response(rates=[]))
+
+    def go():
+        shipment_id, rates = get_rates(TO_ADDR, FROM_ADDR, PARCEL)
+        assert shipment_id == "shp_1"
+        assert rates == []
+
+    _patched(fake, go)
+
+
+# ---------------------------------------------------------------------------
+# buy_label — the ONE money-spending path; the confirm gate is load-bearing
+# ---------------------------------------------------------------------------
+
+CHEAP_RATE = Rate(id="rate_usps", carrier="USPS", service="Priority", rate=8.45,
+                  currency="USD", delivery_days=2, shipment_id="shp_1")
+
+
+def test_buy_label_without_confirm_is_a_pure_dry_run_no_http_call():
+    fake = _Fake()  # scripted with NOTHING — any HTTP call fails the test
+
+    def go():
+        result = buy_label("shp_1", CHEAP_RATE, confirm=False)
+        assert isinstance(result, BuyResult)
+        assert result.dry_run is True
+        assert result.shipment_id == "shp_1"
+        assert result.rate_id == "rate_usps"
+        assert result.carrier == "USPS"
+        assert result.price == 8.45
+        assert result.tracking_code is None
+        assert result.label_url is None
+        assert fake.requests == []  # the load-bearing assertion: no call made
+
+    _patched(fake, go)
+
+
+def test_buy_label_default_confirm_is_false():
+    # Calling positionally/without the kwarg must default to the safe path.
+    fake = _Fake()
+
+    def go():
+        result = buy_label("shp_1", CHEAP_RATE)
+        assert result.dry_run is True
+        assert fake.requests == []
+
+    _patched(fake, go)
+
+
+def test_buy_label_with_confirm_calls_the_buy_endpoint_and_returns_tracking():
+    fake = _Fake(_buy_response())
+
+    def go():
+        result = buy_label("shp_1", CHEAP_RATE, confirm=True)
+        assert result.dry_run is False
+        assert result.tracking_code == "TRK123456789"
+        assert result.carrier == "USPS"
+        assert result.service == "Priority"
+        assert result.label_url == "https://easypost-labels.example/pl_1.png"
+        assert result.price == 8.45
+        assert len(fake.requests) == 1
+        req = fake.requests[0]
+        assert req.full_url.endswith("/shipments/shp_1/buy")
+        assert req.get_method() == "POST"
+        body = json.loads(req.data.decode())
+        assert body == {"rate": {"id": "rate_usps"}}
+
+    _patched(fake, go)
+
+
+def test_buy_label_confirmed_5xx_does_not_retry_and_surfaces_error():
+    # A purchase POST must never silently retry — could double-buy a label.
+    fake = _Fake(_http_error(500, b'{"error":{"message":"carrier timeout"}}'))
+
+    def go():
+        try:
+            buy_label("shp_1", CHEAP_RATE, confirm=True)
+            raise AssertionError("expected EasyPostAPIError")
+        except EasyPostAPIError as e:
+            assert e.status == 500
+            assert "carrier timeout" in e.body
+            assert len(fake.requests) == 1
+
+    _patched(fake, go)
+
+
+def test_buy_label_missing_api_key_raises_before_any_call():
+    fake = _Fake()
+
+    def go():
+        try:
+            buy_label("shp_1", CHEAP_RATE, confirm=True)
+            raise AssertionError("expected ConfigError")
+        except ConfigError:
+            assert fake.requests == []
+
+    _patched(fake, go, api_key=None)
+
+
+if __name__ == "__main__":
+    fails = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except Exception as e:  # noqa: BLE001
+                fails += 1
+                print(f"FAIL {name}: {e}")
+    sys.exit(1 if fails else 0)

--- a/tests/test_easypost_client.py
+++ b/tests/test_easypost_client.py
@@ -414,6 +414,42 @@ CHEAP_RATE = Rate(id="rate_usps", carrier="USPS", service="Priority", rate=8.45,
                   currency="USD", delivery_days=2, shipment_id="shp_1")
 
 
+def test_buy_label_shipment_mismatch_raises_before_any_call_dry_run():
+    # rate was quoted against a *different* shipment than the one passed in
+    # — buying it would purchase postage for the wrong shipment. Must fail
+    # before even the DRY RUN summary (Copilot review fix).
+    fake = _Fake()
+    mismatched_rate = Rate(id="rate_usps", carrier="USPS", service="Priority",
+                           rate=8.45, currency="USD", delivery_days=2,
+                           shipment_id="shp_OTHER")
+
+    def go():
+        try:
+            buy_label("shp_1", mismatched_rate, confirm=False)
+            raise AssertionError("expected ValueError")
+        except ValueError as e:
+            assert "shp_1" in str(e) and "shp_OTHER" in str(e)
+            assert fake.requests == []
+
+    _patched(fake, go)
+
+
+def test_buy_label_shipment_mismatch_raises_before_any_call_confirmed():
+    fake = _Fake()
+    mismatched_rate = Rate(id="rate_usps", carrier="USPS", service="Priority",
+                           rate=8.45, currency="USD", delivery_days=2,
+                           shipment_id="shp_OTHER")
+
+    def go():
+        try:
+            buy_label("shp_1", mismatched_rate, confirm=True)
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            assert fake.requests == []
+
+    _patched(fake, go)
+
+
 def test_buy_label_without_confirm_is_a_pure_dry_run_no_http_call():
     fake = _Fake()  # scripted with NOTHING — any HTTP call fails the test
 
@@ -568,6 +604,20 @@ def test_ship_quote_accepts_no_dimensions():
     assert len(calls) == 1
 
 
+def test_ship_quote_prints_currency_in_the_ship_buy_follow_up_command():
+    # The printed copy/paste ship-buy command must carry the real quoted
+    # currency so ship-buy's DRY RUN preview doesn't misreport a non-USD
+    # rate as USD (Copilot review fix).
+    gbp_rate = Rate(id="rate_gb", carrier="RoyalMail", service="Tracked48",
+                    rate=6.5, currency="GBP", delivery_days=3, shipment_id="shp_1")
+    fake = lambda *a, **kw: ("shp_1", [gbp_rate])  # noqa: E731
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = _run_ship_quote_cli([], fake=fake)
+    assert rc == 0
+    assert "--currency GBP" in buf.getvalue()
+
+
 # ---------------------------------------------------------------------------
 # tools/ship_buy.py CLI — --price 0.0 must count as "provided" (Copilot review fix)
 # ---------------------------------------------------------------------------
@@ -610,6 +660,56 @@ def test_ship_buy_dry_run_without_price_shows_the_missing_hint():
     rc, out = _run_ship_buy_cli([])
     assert rc == 0
     assert "pass --price" in out
+
+
+def test_ship_buy_dry_run_currency_defaults_to_usd():
+    rc, out = _run_ship_buy_cli(["--price", "12.34"])
+    assert rc == 0
+    assert "$12.34 USD" in out
+
+
+def test_ship_buy_dry_run_honours_a_non_usd_currency():
+    # ship-quote's printed follow-up command now passes --currency along
+    # with --price; ship-buy must show it, not hardcode USD (Copilot
+    # review fix).
+    rc, out = _run_ship_buy_cli(["--price", "6.50", "--currency", "GBP"])
+    assert rc == 0
+    assert "$6.50 GBP" in out
+
+
+def test_ship_buy_shipment_mismatch_reported_cleanly_not_a_traceback():
+    fake = _Fake()
+    real_argv = sys.argv
+    sys.argv = ["ship_buy.py", "--shipment-id", "shp_1",
+               "--rate-id", "rate_1"]  # matches base argv's shipment id
+    buf = io.StringIO()
+
+    def go():
+        # ship_buy.py always builds its Rate with shipment_id=args.shipment_id,
+        # so the CLI can't itself trigger a mismatch — this exercises the
+        # ValueError -> clean [X] message path directly via a monkeypatched
+        # buy_label, the same way a future caller passing a stale rate would
+        # surface it.
+        real_buy_label = ship_buy.buy_label
+
+        def mismatched(*a, **kw):
+            raise ValueError("shipment_id mismatch: buy_label() called with "
+                             "'shp_1' but rate 'rate_1' was quoted for "
+                             "shipment 'shp_OTHER'")
+
+        ship_buy.buy_label = mismatched
+        try:
+            with redirect_stdout(buf):
+                return ship_buy.main()
+        finally:
+            ship_buy.buy_label = real_buy_label
+
+    try:
+        rc = _patched(fake, go)
+    finally:
+        sys.argv = real_argv
+    assert rc == 1
+    assert fake.requests == []
 
 
 if __name__ == "__main__":

--- a/tests/test_easypost_client.py
+++ b/tests/test_easypost_client.py
@@ -20,6 +20,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
+from contextlib import redirect_stdout
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -315,6 +316,20 @@ def test_get_rates_sends_addresses_and_parcel_in_body():
     _patched(fake, go)
 
 
+def test_parcel_to_dict_keeps_a_zero_value_dimension():
+    # A 0.0 dimension is a *provided* value (flat/thin item), not "missing" —
+    # to_dict() must not silently drop it via truthiness (Copilot review fix).
+    d = Parcel(weight_oz=8, length_in=0.0, width_in=6, height_in=1).to_dict()
+    assert d["length"] == 0.0
+    assert d["width"] == 6
+    assert d["height"] == 1
+
+
+def test_parcel_to_dict_omits_dims_when_truly_absent():
+    d = Parcel(weight_oz=8).to_dict()
+    assert "length" not in d and "width" not in d and "height" not in d
+
+
 def test_get_rates_skips_malformed_rate_entries():
     fake = _Fake(_shipment_response(rates=[
         {"id": "rate_bad", "carrier": "UPS", "service": "Ground", "rate": "not-a-number"},
@@ -480,6 +495,50 @@ def test_ship_quote_accepts_no_dimensions():
     rc = _run_ship_quote_cli([], fake=fake)
     assert rc == 0
     assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# tools/ship_buy.py CLI — --price 0.0 must count as "provided" (Copilot review fix)
+# ---------------------------------------------------------------------------
+
+import ship_buy                                                        # noqa: E402
+
+_SHIP_BUY_BASE_ARGV = [
+    "ship_buy.py", "--shipment-id", "shp_1", "--rate-id", "rate_1",
+]
+
+
+def _run_ship_buy_cli(extra_argv):
+    # DRY RUN only (no --confirm passed): buy_label() never calls the fake
+    # urlopen, but _patched() still supplies the env var buy_label() needs
+    # to resolve an API key before it can decide that.
+    real_argv = sys.argv
+    sys.argv = _SHIP_BUY_BASE_ARGV + extra_argv
+    fake = _Fake(_shipment_response())
+    buf = io.StringIO()
+
+    def go():
+        with redirect_stdout(buf):
+            return ship_buy.main()
+
+    try:
+        rc = _patched(fake, go)
+        return rc, buf.getvalue()
+    finally:
+        sys.argv = real_argv
+
+
+def test_ship_buy_dry_run_price_zero_shows_a_real_cost_not_the_missing_hint():
+    rc, out = _run_ship_buy_cli(["--price", "0.0"])
+    assert rc == 0
+    assert "$0.00 USD" in out
+    assert "pass --price" not in out
+
+
+def test_ship_buy_dry_run_without_price_shows_the_missing_hint():
+    rc, out = _run_ship_buy_cli([])
+    assert rc == 0
+    assert "pass --price" in out
 
 
 if __name__ == "__main__":

--- a/tests/test_easypost_client.py
+++ b/tests/test_easypost_client.py
@@ -39,6 +39,7 @@ from easypost_client import (                                          # noqa: E
     get_api_key,
     get_rates,
 )
+import config as CFG                                                   # noqa: E402
 from config import ConfigError                                         # noqa: E402
 
 
@@ -137,12 +138,12 @@ def _buy_response(tracking="TRK123456789", carrier="USPS", service="Priority",
 # ---------------------------------------------------------------------------
 
 def test_get_api_key_missing_everywhere_raises_config_error():
-    # Patch the name as bound inside easypost_client's own namespace (it did
-    # `from config import load_config`), not the config module's attribute —
-    # rebinding the latter would not affect the former.
+    # easypost_client.get_api_key() delegates to config.get_easypost_key();
+    # patch the name as bound inside config's own namespace, not
+    # easypost_client's, so the delegation is actually exercised.
     prev_env = os.environ.pop("EASYPOST_API_KEY", None)
-    real_load = EP.load_config
-    EP.load_config = lambda reload=False: {}
+    real_load = CFG.load_config
+    CFG.load_config = lambda reload=False: {}
     try:
         try:
             get_api_key()
@@ -151,7 +152,7 @@ def test_get_api_key_missing_everywhere_raises_config_error():
             assert "EASYPOST_API_KEY" in str(e)
             assert "easypost" in str(e)
     finally:
-        EP.load_config = real_load
+        CFG.load_config = real_load
         if prev_env is not None:
             os.environ["EASYPOST_API_KEY"] = prev_env
 
@@ -159,12 +160,12 @@ def test_get_api_key_missing_everywhere_raises_config_error():
 def test_get_api_key_prefers_env_var_over_config_file():
     prev_env = os.environ.get("EASYPOST_API_KEY")
     os.environ["EASYPOST_API_KEY"] = "from-env"
-    real_load = EP.load_config
-    EP.load_config = lambda reload=False: {"easypost": {"api_key": "from-config"}}
+    real_load = CFG.load_config
+    CFG.load_config = lambda reload=False: {"easypost": {"api_key": "from-config"}}
     try:
         assert get_api_key() == "from-env"
     finally:
-        EP.load_config = real_load
+        CFG.load_config = real_load
         if prev_env is None:
             os.environ.pop("EASYPOST_API_KEY", None)
         else:
@@ -173,14 +174,27 @@ def test_get_api_key_prefers_env_var_over_config_file():
 
 def test_get_api_key_falls_back_to_config_file():
     prev_env = os.environ.pop("EASYPOST_API_KEY", None)
-    real_load = EP.load_config
-    EP.load_config = lambda reload=False: {"easypost": {"api_key": "from-config"}}
+    real_load = CFG.load_config
+    CFG.load_config = lambda reload=False: {"easypost": {"api_key": "from-config"}}
     try:
         assert get_api_key() == "from-config"
     finally:
-        EP.load_config = real_load
+        CFG.load_config = real_load
         if prev_env is not None:
             os.environ["EASYPOST_API_KEY"] = prev_env
+
+
+def test_get_api_key_delegates_to_config_get_easypost_key():
+    """The Copilot-review fix: easypost_client no longer has its own copy
+    of the precedence/error-message logic — it must call straight through
+    to config.get_easypost_key() (bound in easypost_client's own namespace
+    via `from config import get_easypost_key`)."""
+    real = EP.get_easypost_key
+    EP.get_easypost_key = lambda: "delegated-value"
+    try:
+        assert get_api_key() == "delegated-value"
+    finally:
+        EP.get_easypost_key = real
 
 
 # ---------------------------------------------------------------------------
@@ -411,6 +425,61 @@ def test_buy_label_missing_api_key_raises_before_any_call():
             assert fake.requests == []
 
     _patched(fake, go, api_key=None)
+
+
+# ---------------------------------------------------------------------------
+# tools/ship_quote.py CLI — partial-dimension validation (Copilot review fix)
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, str(ROOT / "tools"))
+import ship_quote                                                     # noqa: E402
+
+_BASE_ARGV = [
+    "ship_quote.py",
+    "--to-name", "Jane Buyer", "--to-street1", "1 Main St",
+    "--to-city", "Springfield", "--to-state", "IL", "--to-zip", "62704",
+    "--from-name", "My Store", "--from-street1", "9 Ship St",
+    "--from-city", "Elgin", "--from-state", "IL", "--from-zip", "60120",
+    "--weight-oz", "24",
+]
+
+
+def _run_ship_quote_cli(extra_argv, fake=None):
+    real_argv = sys.argv
+    real_get_rates = ship_quote.get_rates
+    sys.argv = _BASE_ARGV + extra_argv
+    if fake is not None:
+        ship_quote.get_rates = fake
+    try:
+        return ship_quote.main()
+    finally:
+        sys.argv = real_argv
+        ship_quote.get_rates = real_get_rates
+
+
+def test_ship_quote_rejects_a_partial_dimension_set():
+    calls = []
+    fake = lambda *a, **kw: calls.append((a, kw)) or ("shp_1", [])  # noqa: E731
+    rc = _run_ship_quote_cli(["--length-in", "10"], fake=fake)
+    assert rc == 1
+    assert calls == [], "get_rates must not be called — dims would be silently dropped"
+
+
+def test_ship_quote_accepts_all_three_dimensions():
+    calls = []
+    fake = lambda *a, **kw: calls.append((a, kw)) or ("shp_1", [])  # noqa: E731
+    rc = _run_ship_quote_cli(
+        ["--length-in", "10", "--width-in", "8", "--height-in", "4"], fake=fake)
+    assert rc == 0
+    assert len(calls) == 1
+
+
+def test_ship_quote_accepts_no_dimensions():
+    calls = []
+    fake = lambda *a, **kw: calls.append((a, kw)) or ("shp_1", [])  # noqa: E731
+    rc = _run_ship_quote_cli([], fake=fake)
+    assert rc == 0
+    assert len(calls) == 1
 
 
 if __name__ == "__main__":

--- a/tools/ship_buy.py
+++ b/tools/ship_buy.py
@@ -90,7 +90,7 @@ def main() -> int:
     print()
     print("  Feed this into the local ledger's SHIPPED transition once #70 lands:")
     print(f"    python -m lib.cli pick-list --record-tracking {order_id} "
-         f"--carrier {result.carrier!r} --tracking-number {result.tracking_code} --confirm")
+         f"--carrier {result.carrier} --tracking-number {result.tracking_code} --confirm")
     return 0
 
 

--- a/tools/ship_buy.py
+++ b/tools/ship_buy.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Buy a shipping label via EasyPost (GH #80).
+
+DRY RUN BY DEFAULT. Buying postage spends real money — this makes NO call
+to EasyPost's purchase endpoint unless --confirm is given explicitly. Same
+gate, same style, as `lib/list_edit.py --publish/--end` (never inferred,
+never something to run from an unattended poll loop). Get shipment_id +
+rate_id from `ship-quote` first.
+
+    python -m lib.cli ship-buy --shipment-id shp_... --rate-id rate_...           # DRY RUN
+    python -m lib.cli ship-buy --shipment-id shp_... --rate-id rate_... --confirm  # buys it
+
+On a real (confirmed) purchase this prints the carrier, tracking number,
+and label URL, plus the exact `pick_list.py --record-tracking` call to
+feed the tracking number into the local ledger's SHIPPED transition (#70)
+— that ledger write is NOT done here; #70 owns it, and has not landed on
+`main` as of this writing. Composing with it once it lands needs nothing
+more than running the printed command.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "lib"))
+
+from config import ConfigError                                        # noqa: E402
+from easypost_client import EasyPostAPIError, EasyPostAuthError, Rate, buy_label  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--shipment-id", required=True, help="from `ship-quote`'s output")
+    ap.add_argument("--rate-id", required=True, help="from `ship-quote`'s output")
+    ap.add_argument("--carrier", default="", help="carrier, for the printed summary (cosmetic)")
+    ap.add_argument("--service", default="", help="service, for the printed summary (cosmetic)")
+    ap.add_argument("--price", type=float, default=0.0,
+                    help="expected price from `ship-quote`, for the DRY RUN summary (cosmetic — "
+                         "a confirmed purchase always charges EasyPost's live price for --rate-id, "
+                         "not this value)")
+    ap.add_argument("--order-id", default=None,
+                    help="eBay order ID this label is for — used only in the printed "
+                         "--record-tracking follow-up command, never sent to EasyPost")
+    ap.add_argument("--confirm", action="store_true",
+                    help="required to actually buy the label. Without it: DRY RUN — no money "
+                         "spent, no call made to EasyPost's purchase endpoint.")
+    args = ap.parse_args()
+
+    # The rate object buy_label() needs for a DRY RUN print is exactly what
+    # ship-quote already showed the operator; a confirmed purchase re-quotes
+    # nothing and just tells EasyPost which shipment_id/rate_id to buy.
+    rate = Rate(id=args.rate_id, carrier=args.carrier, service=args.service,
+               rate=args.price, currency="USD", delivery_days=None,
+               shipment_id=args.shipment_id)
+
+    try:
+        result = buy_label(args.shipment_id, rate, confirm=args.confirm)
+    except ConfigError as e:
+        print(f"[X] {e}", file=sys.stderr)
+        return 1
+    except (EasyPostAuthError, EasyPostAPIError) as e:
+        print(f"[X] {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+
+    if result.dry_run:
+        print("[DRY RUN] Nothing bought. This WOULD purchase:")
+        print(f"  shipment       {result.shipment_id}")
+        label = f"{result.carrier} {result.service}".strip() or "(pass --carrier/--service to show)"
+        print(f"  rate           {result.rate_id}  ({label})")
+        cost = f"${result.price:.2f} {result.currency}" if args.price else \
+              "(pass --price from `ship-quote` to preview the cost here)"
+        print(f"  cost           {cost}")
+        print()
+        print("  To actually buy this label: re-run with --confirm")
+        return 0
+
+    print("[OK] Label purchased — money was spent:")
+    print(f"  carrier        {result.carrier} {result.service}")
+    print(f"  cost           ${result.price:.2f} {result.currency}")
+    print(f"  tracking code  {result.tracking_code}")
+    print(f"  label url      {result.label_url}")
+    order_id = args.order_id or "ORDER_ID"
+    print()
+    print("  Feed this into the local ledger's SHIPPED transition once #70 lands:")
+    print(f"    python -m lib.cli pick-list --record-tracking {order_id} "
+         f"--carrier {result.carrier!r} --tracking-number {result.tracking_code} --confirm")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ship_buy.py
+++ b/tools/ship_buy.py
@@ -37,7 +37,7 @@ def main() -> int:
     ap.add_argument("--rate-id", required=True, help="from `ship-quote`'s output")
     ap.add_argument("--carrier", default="", help="carrier, for the printed summary (cosmetic)")
     ap.add_argument("--service", default="", help="service, for the printed summary (cosmetic)")
-    ap.add_argument("--price", type=float, default=0.0,
+    ap.add_argument("--price", type=float, default=None,
                     help="expected price from `ship-quote`, for the DRY RUN summary (cosmetic — "
                          "a confirmed purchase always charges EasyPost's live price for --rate-id, "
                          "not this value)")
@@ -53,8 +53,8 @@ def main() -> int:
     # ship-quote already showed the operator; a confirmed purchase re-quotes
     # nothing and just tells EasyPost which shipment_id/rate_id to buy.
     rate = Rate(id=args.rate_id, carrier=args.carrier, service=args.service,
-               rate=args.price, currency="USD", delivery_days=None,
-               shipment_id=args.shipment_id)
+               rate=args.price if args.price is not None else 0.0, currency="USD",
+               delivery_days=None, shipment_id=args.shipment_id)
 
     try:
         result = buy_label(args.shipment_id, rate, confirm=args.confirm)
@@ -70,7 +70,7 @@ def main() -> int:
         print(f"  shipment       {result.shipment_id}")
         label = f"{result.carrier} {result.service}".strip() or "(pass --carrier/--service to show)"
         print(f"  rate           {result.rate_id}  ({label})")
-        cost = f"${result.price:.2f} {result.currency}" if args.price else \
+        cost = f"${result.price:.2f} {result.currency}" if args.price is not None else \
               "(pass --price from `ship-quote` to preview the cost here)"
         print(f"  cost           {cost}")
         print()

--- a/tools/ship_buy.py
+++ b/tools/ship_buy.py
@@ -41,6 +41,10 @@ def main() -> int:
                     help="expected price from `ship-quote`, for the DRY RUN summary (cosmetic — "
                          "a confirmed purchase always charges EasyPost's live price for --rate-id, "
                          "not this value)")
+    ap.add_argument("--currency", default="USD",
+                    help="currency of --price, from `ship-quote`'s output, for the DRY RUN "
+                         "summary (cosmetic — default USD; pass the real currency for a "
+                         "non-US shipment so the preview doesn't misreport it)")
     ap.add_argument("--order-id", default=None,
                     help="eBay order ID this label is for — used only in the printed "
                          "--record-tracking follow-up command, never sent to EasyPost")
@@ -53,7 +57,7 @@ def main() -> int:
     # ship-quote already showed the operator; a confirmed purchase re-quotes
     # nothing and just tells EasyPost which shipment_id/rate_id to buy.
     rate = Rate(id=args.rate_id, carrier=args.carrier, service=args.service,
-               rate=args.price if args.price is not None else 0.0, currency="USD",
+               rate=args.price if args.price is not None else 0.0, currency=args.currency,
                delivery_days=None, shipment_id=args.shipment_id)
 
     try:
@@ -61,7 +65,7 @@ def main() -> int:
     except ConfigError as e:
         print(f"[X] {e}", file=sys.stderr)
         return 1
-    except (EasyPostAuthError, EasyPostAPIError) as e:
+    except (ValueError, EasyPostAuthError, EasyPostAPIError) as e:
         print(f"[X] {type(e).__name__}: {e}", file=sys.stderr)
         return 1
 

--- a/tools/ship_quote.py
+++ b/tools/ship_quote.py
@@ -71,6 +71,14 @@ def main() -> int:
     ap.add_argument("--json", action="store_true", help="print raw rates as JSON")
     args = ap.parse_args()
 
+    dims = (args.length_in, args.width_in, args.height_in)
+    if any(d is not None for d in dims) and not all(d is not None for d in dims):
+        print("[X] --length-in, --width-in, and --height-in must all be given "
+             "together, or all omitted — a partial set is silently dropped by "
+             "the carrier API and would misrepresent what was quoted.",
+             file=sys.stderr)
+        return 1
+
     to_addr = _address_from_args(args, "to")
     from_addr = _address_from_args(args, "from")
     parcel = Parcel(weight_oz=args.weight_oz, length_in=args.length_in,

--- a/tools/ship_quote.py
+++ b/tools/ship_quote.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Quote shipping rates via EasyPost (GH #80).
+
+Bypasses eBay's own Logistics API (confirmed a dead end for a small
+seller — Limited Release, invitation-only, USPS-only; see #32) and asks
+EasyPost for a live rate table across USPS/UPS/FedEx/DHL instead.
+
+Spends nothing. Quoting is never gated — no --confirm exists here because
+none is needed; buying (`ship-buy`) is the gated step.
+
+    python -m lib.cli ship-quote \\
+        --to-name "Jane Buyer" --to-street1 "1 Main St" --to-city Springfield \\
+        --to-state IL --to-zip 62704 \\
+        --from-name "My Store" --from-street1 "9 Ship St" --from-city Elgin \\
+        --from-state IL --from-zip 60120 \\
+        --weight-oz 24 --length-in 10 --width-in 8 --height-in 4
+
+Prints every rate, cheapest first, plus the exact `ship-buy` invocation
+(as a DRY RUN) to buy the cheapest one.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "lib"))
+
+from config import ConfigError                                       # noqa: E402
+from easypost_client import (                                        # noqa: E402
+    Address, EasyPostAPIError, EasyPostAuthError, Parcel, get_rates,
+)
+
+
+def _add_address_args(ap: argparse.ArgumentParser, prefix: str, label: str) -> None:
+    ap.add_argument(f"--{prefix}-name", required=True, help=f"{label} recipient name")
+    ap.add_argument(f"--{prefix}-street1", required=True, help=f"{label} street address")
+    ap.add_argument(f"--{prefix}-street2", default=None, help=f"{label} street address line 2")
+    ap.add_argument(f"--{prefix}-city", required=True, help=f"{label} city")
+    ap.add_argument(f"--{prefix}-state", required=True, help=f"{label} state/province code")
+    ap.add_argument(f"--{prefix}-zip", required=True, help=f"{label} postal code")
+    ap.add_argument(f"--{prefix}-country", default="US", help=f"{label} country code (default US)")
+    ap.add_argument(f"--{prefix}-phone", default=None,
+                    help=f"{label} phone (some carrier services require one)")
+
+
+def _address_from_args(args: argparse.Namespace, prefix: str) -> Address:
+    return Address(
+        name=getattr(args, f"{prefix}_name"),
+        street1=getattr(args, f"{prefix}_street1"),
+        street2=getattr(args, f"{prefix}_street2"),
+        city=getattr(args, f"{prefix}_city"),
+        state=getattr(args, f"{prefix}_state"),
+        zip=getattr(args, f"{prefix}_zip"),
+        country=getattr(args, f"{prefix}_country"),
+        phone=getattr(args, f"{prefix}_phone"),
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    _add_address_args(ap, "to", "ship-to")
+    _add_address_args(ap, "from", "ship-from")
+    ap.add_argument("--weight-oz", type=float, required=True, help="parcel weight, ounces")
+    ap.add_argument("--length-in", type=float, default=None, help="parcel length, inches")
+    ap.add_argument("--width-in", type=float, default=None, help="parcel width, inches")
+    ap.add_argument("--height-in", type=float, default=None, help="parcel height, inches")
+    ap.add_argument("--json", action="store_true", help="print raw rates as JSON")
+    args = ap.parse_args()
+
+    to_addr = _address_from_args(args, "to")
+    from_addr = _address_from_args(args, "from")
+    parcel = Parcel(weight_oz=args.weight_oz, length_in=args.length_in,
+                    width_in=args.width_in, height_in=args.height_in)
+
+    try:
+        shipment_id, rates = get_rates(to_addr, from_addr, parcel)
+    except ConfigError as e:
+        print(f"[X] {e}", file=sys.stderr)
+        return 1
+    except (EasyPostAuthError, EasyPostAPIError) as e:
+        print(f"[X] {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps({"shipment_id": shipment_id,
+                          "rates": [r.__dict__ for r in rates]}, indent=2))
+        return 0
+
+    if not rates:
+        print(f"shipment {shipment_id}: no rates returned")
+        return 0
+
+    print(f"shipment {shipment_id} — {len(rates)} rate(s), cheapest first:")
+    for r in rates:
+        days = f"~{r.delivery_days}d" if r.delivery_days is not None else "? d"
+        print(f"  [{r.id}]  {r.carrier:<8} {r.service:<24} ${r.rate:>8.2f} {r.currency}  {days}")
+
+    cheapest = rates[0]
+    print()
+    print("  Nothing has been bought — quoting spends nothing. To buy the cheapest")
+    print("  one (still a DRY RUN — add --confirm yourself to actually spend money):")
+    print(f"    python -m lib.cli ship-buy --shipment-id {shipment_id} "
+         f"--rate-id {cheapest.id} --carrier {cheapest.carrier} "
+         f"--service {cheapest.service!r} --price {cheapest.rate:.2f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ship_quote.py
+++ b/tools/ship_quote.py
@@ -46,6 +46,17 @@ def _add_address_args(ap: argparse.ArgumentParser, prefix: str, label: str) -> N
                     help=f"{label} phone (some carrier services require one)")
 
 
+def _dquote(s: str) -> str:
+    """Double-quoted, backslash-escaped form for a printed CLI argument.
+
+    Python's repr() (single-quoted) isn't shell-agnostic — Windows cmd.exe
+    treats a single quote as a literal character, not quoting, so a repr'd
+    value with spaces (a carrier service name) would be split into several
+    arguments. Double quotes are the more portable common denominator.
+    """
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
 def _address_from_args(args: argparse.Namespace, prefix: str) -> Address:
     return Address(
         name=getattr(args, f"{prefix}_name"),
@@ -113,7 +124,7 @@ def main() -> int:
     print("  one (still a DRY RUN — add --confirm yourself to actually spend money):")
     print(f"    python -m lib.cli ship-buy --shipment-id {shipment_id} "
          f"--rate-id {cheapest.id} --carrier {cheapest.carrier} "
-         f"--service {cheapest.service!r} --price {cheapest.rate:.2f} "
+         f"--service {_dquote(cheapest.service)} --price {cheapest.rate:.2f} "
          f"--currency {cheapest.currency}")
     return 0
 

--- a/tools/ship_quote.py
+++ b/tools/ship_quote.py
@@ -113,7 +113,8 @@ def main() -> int:
     print("  one (still a DRY RUN — add --confirm yourself to actually spend money):")
     print(f"    python -m lib.cli ship-buy --shipment-id {shipment_id} "
          f"--rate-id {cheapest.id} --carrier {cheapest.carrier} "
-         f"--service {cheapest.service!r} --price {cheapest.rate:.2f}")
+         f"--service {cheapest.service!r} --price {cheapest.rate:.2f} "
+         f"--currency {cheapest.currency}")
     return 0
 
 


### PR DESCRIPTION
## Summary

Addresses #80: eBay's own Logistics API is a confirmed dead end for a small seller (Limited Release, invitation-only, USPS-only — #32). This bypasses it entirely and quotes/buys postage from EasyPost instead — pay-as-you-go, free up to 3,000 labels/month, no contract, rates across USPS/UPS/FedEx/DHL.

- **`lib/easypost_client.py`** — thin REST client for `api.easypost.com`, reusing `ebay_client.api_send`'s HTTP/retry conventions (5xx retried only for idempotent methods so a purchase POST can never double-fire on retry; network errors retried for any method).
  - `get_rates(to_address, from_address, parcel)` — creates a shipment, returns parsed `Rate`s sorted cheapest-first. **Runs freely, no confirmation gate** (quoting spends nothing).
  - `buy_label(shipment_id, rate, confirm=False)` — **DRY RUN by default**. Without `confirm=True` it makes **zero HTTP calls** to EasyPost's purchase endpoint and only reports what would be bought and its cost. Only with `confirm=True` does it call `POST /shipments/{id}/buy`.
- **`lib/config.py`** — `get_easypost_key()`: `EASYPOST_API_KEY` env var → `config.yaml` `easypost.api_key` → `ConfigError`, exactly mirroring `get_apify_token()` / `get_anthropic_key()`'s precedence. Documented in `lib/config.example.yaml` and `lib/README.md`.
- **`tools/ship_quote.py`** / **`tools/ship_buy.py`** — CLIs wired into `lib/cli.py`'s flat verb table as `python -m lib.cli ship-quote` and `python -m lib.cli ship-buy [--confirm]`.

## Guardrail (same shape as #32's `--record-tracking`)

Buying postage spends real money. `buy_label()` / `ship-buy` follow the exact same gate style as `lib/list_edit.py`'s `--publish`/`--end`: **dry run unless `--confirm` is passed explicitly, never inferred, never something to run from an unattended poll loop.** The tests assert this directly — `buy_label(..., confirm=False)` makes `fake.requests == []` (no HTTP call at all), and only `confirm=True` reaches the buy endpoint, exactly once.

## Composing with #70 / #32

I checked `tools/pick_list.py` on `main` (`git log origin/main`) — **`--record-tracking` has not landed on `main` yet** (only referenced in an unrelated doc match); PR #70 that adds it is still open. So this PR does not import from or depend on #70's branch. Instead, `ship-buy`'s output is shaped to compose with it once it lands: on a confirmed purchase it prints the carrier + tracking number and the exact follow-up command,

```
python -m lib.cli pick-list --record-tracking ORDER_ID --carrier 'USPS' --tracking-number TRK123... --confirm
```

This module never writes the local ledger itself — that stays #70's responsibility, unduplicated.

## What's left / not built

- **No real-account testing.** Per the issue's own "Status: forward-looking idea" framing, a human still has to create an EasyPost account, fund its balance, and provision `EASYPOST_API_KEY` before any of this is usable end-to-end — that step is deliberately not automated here, and I never called the real purchase endpoint during development (everything below is mocked).
- Not marked "Closes #80" for that reason — this builds the full proposed alternative (quote + confirm-gated buy + composition with `--record-tracking`) but the issue's own precondition (a funded EasyPost account) can't be exercised by me.
- `--record-tracking` itself is #70's scope, not duplicated here.

## Test plan

- `tests/test_easypost_client.py` — all HTTP faked via `urllib.request.urlopen` patching, no network, no real API key. Covers: key-resolution precedence (env > config > error), the retry policy (5xx not retried on POST/buy, retried on GET; network errors retried for any method), 401 → `EasyPostAuthError`, rate parsing + cheapest-first sort, malformed-rate skipping, and — the load-bearing assertions — `buy_label(confirm=False)` makes no HTTP call at all, `buy_label(confirm=True)` calls the buy endpoint exactly once and returns a tracking number, and a confirmed 5xx does not retry.
- `python -m pytest tests/ -q` → **479 passed, 1 skipped** (pre-existing skip, unrelated) — no regressions.
- `python -m py_compile` clean on all touched files.
- Manual smoke test of the CLI: `ship-buy` without `--confirm` prints a DRY RUN summary and exits 0 with **no** `EASYPOST_API_KEY` needed; `ship-buy --confirm` without a key fails cleanly with the setup message and makes no call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnrWxtKQStiTx1qFkqc5sm


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnrWxtKQStiTx1qFkqc5sm)_