### PR TITLE
feat(price): learn charm-pricing convention from competing stores (#82)

### DIFF
--- a/lib/ebay_browse.py
+++ b/lib/ebay_browse.py
@@ -143,8 +143,10 @@ def top_sellers_active(q: str | None = None, *, category_ids: str | None = None,
                        marketplace: str = "EBAY_US", creds=None) -> list[dict]:
     """Active listings from the top `top_n` sellers in a category/query sample.
 
-    One `search()` pull (up to `sample` active listings) stands in for "the
-    competing stores in this niche" — Browse has no seller-ranking endpoint,
+    One `search()` call (paging internally, PAGE_LIMIT=200 items per Browse
+    API request, when `sample` exceeds that) pulls up to `sample` active
+    listings to stand in for "the competing stores in this niche" — Browse
+    has no seller-ranking endpoint,
     so listing count within the sample is the proxy for who's moving volume
     here. Returns the normalised listings (each carries `seller` +
     `askingPrice`) belonging to just those top sellers — feed this straight

--- a/lib/ebay_browse.py
+++ b/lib/ebay_browse.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections import Counter
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -137,6 +138,27 @@ def seller_active(seller: str, *, q: str | None = None,
     return total, recs
 
 
+def top_sellers_active(q: str | None = None, *, category_ids: str | None = None,
+                       sample: int = 200, top_n: int = 5,
+                       marketplace: str = "EBAY_US", creds=None) -> list[dict]:
+    """Active listings from the top `top_n` sellers in a category/query sample.
+
+    One `search()` pull (up to `sample` active listings) stands in for "the
+    competing stores in this niche" — Browse has no seller-ranking endpoint,
+    so listing count within the sample is the proxy for who's moving volume
+    here. Returns the normalised listings (each carries `seller` +
+    `askingPrice`) belonging to just those top sellers — feed this straight
+    into `price_stats.competitor_charm_pattern` (GH #82) to learn the
+    charm-pricing convention the sellers actually winning this niche use,
+    rather than defaulting to a generic charm price.
+    """
+    listings = search(q=q, category_ids=category_ids, max_items=sample,
+                      marketplace=marketplace, creds=creds)
+    counts = Counter(r["seller"] for r in listings if r.get("seller"))
+    top = {name for name, _ in counts.most_common(top_n)}
+    return [r for r in listings if r.get("seller") in top]
+
+
 def _print(records: list[dict], header: str) -> None:
     try:
         sys.stdout.reconfigure(encoding="utf-8")
@@ -169,11 +191,23 @@ def main() -> None:
     p.add_argument("--max", type=int, default=100)
     p.add_argument("--json", default=None)
 
+    p = sub.add_parser("top-sellers", help="active listings from the top N sellers in a "
+                                           "category/query sample (GH #82 — competitor charm pricing)")
+    p.add_argument("query", nargs="?", default=None, help="optional keyword filter")
+    p.add_argument("--category", default=None, help="category_ids (required if no query)")
+    p.add_argument("--sample", type=int, default=200, help="active listings to sample")
+    p.add_argument("--top", type=int, default=5, help="how many top sellers to keep")
+    p.add_argument("--json", default=None)
+
     args = ap.parse_args()
     try:
         if args.cmd == "seller":
             recs = seller_items(args.username, q=args.q, category_ids=args.category, max_items=args.max)
             _print(recs, f"Seller {args.username} (active)")
+        elif args.cmd == "top-sellers":
+            recs = top_sellers_active(q=args.query, category_ids=args.category,
+                                      sample=args.sample, top_n=args.top)
+            _print(recs, f"Top {args.top} sellers")
         else:
             recs = search(q=args.query, seller=args.seller, category_ids=args.category, max_items=args.max)
             _print(recs, f"Search {args.query!r}")

--- a/lib/price_stats.py
+++ b/lib/price_stats.py
@@ -726,6 +726,11 @@ def price_from_runs(
     if not best_match_json and not price_high_json:
         raise ValueError("provide at least one of best_match_json / price_high_json")
 
+    # "Requested" means a caller supplied a source at all — an explicit
+    # competitor_listings=[] or a --competitor-active file with zero usable
+    # listings still counts, so render() shows why the signal came up empty
+    # instead of looking identical to never having asked (Copilot review).
+    competitor_requested = competitor_listings is not None or bool(competitor_active_json)
     competitor_recs: list[dict] = list(competitor_listings or [])
     if competitor_active_json:
         competitor_recs += _load_competitor_listings(competitor_active_json)
@@ -789,7 +794,7 @@ def price_from_runs(
         "distribution": dist,
         "confidence": conf,
         "competitor_charm_pattern": competitor_charm,
-        "competitor_active_requested": bool(competitor_recs),
+        "competitor_active_requested": competitor_requested,
         "kept_comps": [
             {"title": c.title, "price": c.price, "url": c.url,
              "condition": c.condition, "sold_date": c.sold_date,

--- a/lib/price_stats.py
+++ b/lib/price_stats.py
@@ -527,6 +527,12 @@ def competitor_charm_pattern(
     prices: list[float] = []
     for rec in listings:
         seller = rec.get("seller") or rec.get("sellerName") or rec.get("seller_username")
+        if not seller:
+            # No seller id means this listing can't be attributed to a
+            # "top competing seller" — counting it would skew both the
+            # bucket shares and the min-sellers/min-listings gate away
+            # from what this signal is actually measuring.
+            continue
         price = rec.get("askingPrice")
         if price is None:
             price = rec.get("price")
@@ -538,8 +544,7 @@ def competitor_charm_pattern(
             continue
         if price <= 0:
             continue
-        if seller:
-            sellers.add(seller)
+        sellers.add(seller)
         prices.append(price)
 
     n = len(prices)
@@ -563,6 +568,18 @@ def competitor_charm_pattern(
             "n_listings": n, "buckets": bucket_share,
             "reason": (f"no majority ending — top bucket '{top_pattern}' at "
                        f"{top_share:.0%} < {majority_pct:.0%} threshold"),
+        }
+    if top_pattern == "other":
+        # A majority landing on a non-charm cents value isn't actionable —
+        # apply_charm_ending() no-ops on "other", so surfacing it as a
+        # decisive pattern would make price_from_runs() claim a "nudged to
+        # competitor-dominant ending" that never actually moved the price.
+        return {
+            "pattern": None, "share": top_share, "n_competitors": n_sellers,
+            "n_listings": n, "buckets": bucket_share,
+            "reason": (f"top ending is 'other' ({top_share:.0%}) — a majority "
+                       f"of competitors don't use a charm price at all, "
+                       f"nothing to nudge toward"),
         }
     return {
         "pattern": top_pattern, "share": top_share, "n_competitors": n_sellers,
@@ -764,6 +781,7 @@ def price_from_runs(
         "distribution": dist,
         "confidence": conf,
         "competitor_charm_pattern": competitor_charm,
+        "competitor_active_requested": bool(competitor_recs),
         "kept_comps": [
             {"title": c.title, "price": c.price, "url": c.url,
              "condition": c.condition, "sold_date": c.sold_date,
@@ -877,7 +895,11 @@ def render(report: dict) -> str:
         out.append(f"  Competitor charm pattern: {cc['pattern']} "
                    f"({cc['share']:.0%} of {cc['n_competitors']} competing sellers, "
                    f"n={cc['n_listings']} listings) — preferred over generic charm default")
-    elif cc.get("n_listings"):
+    elif report.get("competitor_active_requested"):
+        # Competitor data WAS supplied — show why it produced no signal
+        # (e.g. every record was unparseable or missing a seller id) rather
+        # than rendering nothing, which would be indistinguishable from
+        # never having asked for a competitor signal at all.
         out.append(f"  Competitor charm pattern: no clear signal — {cc.get('reason')}")
 
     if report["confidence"] == "thin":

--- a/lib/price_stats.py
+++ b/lib/price_stats.py
@@ -485,12 +485,20 @@ def apply_charm_ending(price: float, pattern: str) -> float:
     34.0
     >>> apply_charm_ending(19.60, ".99")
     19.99
+    >>> apply_charm_ending(0.10, ".95")
+    0.95
     """
     cents = {".00": 0, ".99": 99, ".97": 97, ".95": 95}.get(pattern)
     if cents is None:
         return round(price, 2)
     base = int(price)
     candidates = [base + cents / 100, base - 1 + cents / 100, base + 1 + cents / 100]
+    # The "prior whole dollar" candidate can go negative for a low-dollar
+    # price (e.g. price=0.10 -> base-1+cents/100 = -0.05) and would then win
+    # on raw distance — a charm-price nudge must never produce a negative
+    # tier price. Excluding it still leaves the "current"/"next" candidates,
+    # so there's always a non-negative choice.
+    candidates = [c for c in candidates if c >= 0]
     return round(min(candidates, key=lambda c: abs(c - price)), 2)
 
 

--- a/lib/price_stats.py
+++ b/lib/price_stats.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 import json
 import re
 import statistics
+from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -78,6 +79,22 @@ TIGHT_DISPERSION = 0.50     # IQR/median at/below this is "tight"
 OUTLIER_MULT = 2.5
 
 MIN_SELLER_FEEDBACK = 50    # below this feedback count → Tier-C exclusion
+
+# competitor_charm_pattern (GH #82) — the top-competing-sellers' charm-price
+# convention, as distinct from charm_price_share (our own sold comps, used
+# only as a currency-leak guard — see comps_core.charm_share). A majority
+# ending among ENOUGH competitors is preferred over the generic charm default
+# when proposing the recommended/working price; too thin a sample falls back
+# to today's unadjusted behavior unchanged.
+COMPETITOR_CHARM_MAJORITY = 0.60     # issue's own threshold: ≥60% ⇒ decisive
+# The issue frames this as "top 3-5 sellers" — 2 sellers agreeing is
+# coincidence, not a convention, so 3 is the floor.
+COMPETITOR_MIN_SELLERS = 3
+# A majority off a handful of listings (even from enough sellers) is noise;
+# require a real sample before trusting the winning bucket.
+COMPETITOR_MIN_LISTINGS = 5
+
+_CHARM_ENDING_CENTS = {0: ".00", 99: ".99", 97: ".97", 95: ".95"}
 
 # Tokens that mark a listing as multi-item (a "lot"), used by the unit filter.
 _MULTI_ITEM_WORDS = {
@@ -427,6 +444,133 @@ def filter_exclusions(comps: list["Comp"]) -> FilterLog:
 
 
 # ---------------------------------------------------------------------------
+# Competitor charm-price convention (GH #82)
+# ---------------------------------------------------------------------------
+
+def _load_competitor_listings(json_path: Union[str, Path]) -> list[dict]:
+    """Read a saved competing-active-listings JSON — a bare list, or a dict
+    carrying it under `listings` (lib/ebay_browse.py's shape) / `comps` (this
+    module's own dual-run shape) / `items`."""
+    data = json.loads(Path(json_path).read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return data
+    return data.get("listings") or data.get("comps") or data.get("items") or []
+
+
+def charm_ending(price: float) -> str:
+    """.00 / .99 / .97 / .95 / other, off a single price's cent value.
+
+    >>> charm_ending(34.99)
+    '.99'
+    >>> charm_ending(20.00)
+    '.00'
+    >>> charm_ending(18.50)
+    'other'
+    """
+    cents = int(round((price - int(price)) * 100)) % 100
+    return _CHARM_ENDING_CENTS.get(cents, "other")
+
+
+def apply_charm_ending(price: float, pattern: str) -> float:
+    """Nudge `price` to the nearest price ending in `pattern`'s cents.
+
+    Tries the ending at the current, prior, and next whole dollar and keeps
+    whichever lands closest to `price` — so the nudge is at most ~$1, never a
+    jump to an unrelated price point. Unknown pattern (e.g. "other"/None) is
+    a no-op.
+
+    >>> apply_charm_ending(34.50, ".99")
+    34.99
+    >>> apply_charm_ending(34.50, ".00")
+    34.0
+    >>> apply_charm_ending(19.60, ".99")
+    19.99
+    """
+    cents = {".00": 0, ".99": 99, ".97": 97, ".95": 95}.get(pattern)
+    if cents is None:
+        return round(price, 2)
+    base = int(price)
+    candidates = [base + cents / 100, base - 1 + cents / 100, base + 1 + cents / 100]
+    return round(min(candidates, key=lambda c: abs(c - price)), 2)
+
+
+def competitor_charm_pattern(
+    listings: list[dict],
+    *,
+    min_sellers: int = COMPETITOR_MIN_SELLERS,
+    min_listings: int = COMPETITOR_MIN_LISTINGS,
+    majority_pct: float = COMPETITOR_CHARM_MAJORITY,
+) -> dict:
+    """Bucket competing ACTIVE listings' price endings; surface the dominant
+    convention among the top competing sellers in the matched category.
+
+    `listings` — active listings from the top sellers in the category (e.g.
+    `lib/ebay_browse.top_sellers_active`, or a saved dump of the same shape).
+    Each record needs a seller id (`seller` / `sellerName` /
+    `seller_username`) and an asking price (`askingPrice` / `price`) — this
+    accepts ebay_browse's normalised records directly, or any dict carrying
+    those keys, so it composes without a hard dependency on ebay_browse (this
+    module stays stdlib-only; see the module docstring).
+
+    Always returns a dict (never None) so callers don't need a null-check
+    before reading `n_competitors`/`buckets`:
+        {"pattern": ".99", "share": 0.71, "n_competitors": 7,
+         "n_listings": 12, "buckets": {".99": 0.71, ".00": 0.17, ...},
+         "reason": None}
+    `pattern` is None — with `reason` explaining why — when the signal isn't
+    trustworthy: too few distinct sellers (< min_sellers), too few priced
+    listings (< min_listings), or no ending clears `majority_pct` (the
+    issue's own ≥60% bar). That is the fall-back-to-current-behavior case;
+    the caller applies no charm-ending nudge in it.
+    """
+    sellers: set = set()
+    prices: list[float] = []
+    for rec in listings:
+        seller = rec.get("seller") or rec.get("sellerName") or rec.get("seller_username")
+        price = rec.get("askingPrice")
+        if price is None:
+            price = rec.get("price")
+        if price is None:
+            continue
+        try:
+            price = float(price)
+        except (TypeError, ValueError):
+            continue
+        if price <= 0:
+            continue
+        if seller:
+            sellers.add(seller)
+        prices.append(price)
+
+    n = len(prices)
+    n_sellers = len(sellers)
+    buckets = Counter(charm_ending(p) for p in prices)
+    bucket_share = {k: round(v / n, 3) for k, v in buckets.items()} if n else {}
+    top_pattern, top_count = buckets.most_common(1)[0] if buckets else (None, 0)
+    top_share = round(top_count / n, 3) if n else 0.0
+
+    if n < min_listings or n_sellers < min_sellers:
+        return {
+            "pattern": None, "share": top_share, "n_competitors": n_sellers,
+            "n_listings": n, "buckets": bucket_share,
+            "reason": (f"too few competitors for a trustworthy signal "
+                       f"(n_sellers={n_sellers}/{min_sellers} min, "
+                       f"n_listings={n}/{min_listings} min)"),
+        }
+    if top_share < majority_pct:
+        return {
+            "pattern": None, "share": top_share, "n_competitors": n_sellers,
+            "n_listings": n, "buckets": bucket_share,
+            "reason": (f"no majority ending — top bucket '{top_pattern}' at "
+                       f"{top_share:.0%} < {majority_pct:.0%} threshold"),
+        }
+    return {
+        "pattern": top_pattern, "share": top_share, "n_competitors": n_sellers,
+        "n_listings": n, "buckets": bucket_share, "reason": None,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Statistics
 # ---------------------------------------------------------------------------
 
@@ -525,6 +669,11 @@ def price_from_runs(
     condition: Optional[str] = None,
     price_field: str = "sold",
     pool_used_when_thin: bool = True,
+    competitor_active_json: Optional[Union[str, Path]] = None,
+    competitor_listings: Optional[list[dict]] = None,
+    competitor_min_sellers: int = COMPETITOR_MIN_SELLERS,
+    competitor_min_listings: int = COMPETITOR_MIN_LISTINGS,
+    competitor_majority_pct: float = COMPETITOR_CHARM_MAJORITY,
 ) -> dict:
     """Run the full distribution-based pricing pipeline. Returns a report dict.
 
@@ -534,9 +683,34 @@ def price_from_runs(
     cleaned representative set is thin (n < THIN_N) the report sets
     tiers=None and confidence='thin' — the caller falls back to the
     closest-comp method rather than trust percentiles off too few points.
+
+    `competitor_active_json` (a saved dump, see `_load_competitor_listings`)
+    and/or `competitor_listings` (already-loaded records — the two compose;
+    both are pooled when both are given) feed GH #82's competitor-charm
+    signal: active listings from the top sellers in the matched category
+    (`lib/ebay_browse.top_sellers_active`). The report always carries
+    `competitor_charm_pattern` (see `competitor_charm_pattern()` — never
+    None). When it finds a clear majority ending (>= `competitor_majority_pct`
+    among >= `competitor_min_sellers` sellers / `competitor_min_listings`
+    listings), the `recommended` tier's price is nudged to that ending
+    (`apply_charm_ending`) instead of the generic charm default; the
+    unadjusted median survives alongside it as `pre_charm_price`. With no
+    competitor data, or too thin/no-majority a signal, `recommended` is
+    exactly today's median — unchanged.
     """
     if not best_match_json and not price_high_json:
         raise ValueError("provide at least one of best_match_json / price_high_json")
+
+    competitor_recs: list[dict] = list(competitor_listings or [])
+    if competitor_active_json:
+        competitor_recs += _load_competitor_listings(competitor_active_json)
+    competitor_charm = competitor_charm_pattern(
+        competitor_recs, min_sellers=competitor_min_sellers,
+        min_listings=competitor_min_listings, majority_pct=competitor_majority_pct,
+    ) if competitor_recs else {
+        "pattern": None, "share": None, "n_competitors": 0, "n_listings": 0,
+        "buckets": {}, "reason": "no competitor active-listing data supplied",
+    }
 
     runs: list[dict] = []
     bm: list[Comp] = []
@@ -589,6 +763,7 @@ def price_from_runs(
         "row0_flags": row0_flags,
         "distribution": dist,
         "confidence": conf,
+        "competitor_charm_pattern": competitor_charm,
         "kept_comps": [
             {"title": c.title, "price": c.price, "url": c.url,
              "condition": c.condition, "sold_date": c.sold_date,
@@ -629,14 +804,35 @@ def price_from_runs(
         ceiling_basis = f"vetted ceiling comp from price_high: \"{ceiling.title[:55]}\" ({ceiling.url})"
     else:
         ceiling_basis = f"no price_high comp survived filters → {PUSH_HIGH_FALLBACK_PCT}th percentile fallback"
+
+    conservative_price = round(percentile(sorted_kept, CONSERVATIVE_PCT), 2)
+    recommended_median = round(percentile(sorted_kept, RECOMMENDED_PCT), 2)
+    recommended_price = recommended_median
+    recommended_basis = "median of like-condition comparable sold (working price)"
+    # GH #82: a clear competitor-charm majority beats the generic charm
+    # default — nudge the working price to that ending. Never below the
+    # conservative floor, and never more than ~$1 from the median (see
+    # apply_charm_ending) — this composes with the distribution, it doesn't
+    # override it.
+    if competitor_charm.get("pattern"):
+        nudged = apply_charm_ending(recommended_median, competitor_charm["pattern"])
+        recommended_price = max(nudged, conservative_price)
+        recommended_basis = (
+            f"median of like-condition comparable sold (${recommended_median}), "
+            f"nudged to competitor-dominant ending {competitor_charm['pattern']} "
+            f"({competitor_charm['share']:.0%} of {competitor_charm['n_competitors']} "
+            f"competing sellers — >= {competitor_majority_pct:.0%} majority threshold)"
+        )
+
     report["tiers"] = {
         "conservative": {
-            "price": round(percentile(sorted_kept, CONSERVATIVE_PCT), 2),
+            "price": conservative_price,
             "basis": f"{CONSERVATIVE_PCT}th percentile of like-condition sold (no-objection floor)",
         },
         "recommended": {
-            "price": round(percentile(sorted_kept, RECOMMENDED_PCT), 2),
-            "basis": "median of like-condition comparable sold (working price)",
+            "price": recommended_price,
+            "basis": recommended_basis,
+            **({"pre_charm_price": recommended_median} if recommended_price != recommended_median else {}),
         },
         "push_high": {
             "price": round(push_high, 2),
@@ -675,6 +871,14 @@ def render(report: dict) -> str:
     out.append(f"  raw={report['n_raw']} → kept={report['n_kept']}  "
                f"runs: {runs}")
     out.append(f"  Confidence: {report['confidence']}")
+
+    cc = report.get("competitor_charm_pattern") or {}
+    if cc.get("pattern"):
+        out.append(f"  Competitor charm pattern: {cc['pattern']} "
+                   f"({cc['share']:.0%} of {cc['n_competitors']} competing sellers, "
+                   f"n={cc['n_listings']} listings) — preferred over generic charm default")
+    elif cc.get("n_listings"):
+        out.append(f"  Competitor charm pattern: no clear signal — {cc.get('reason')}")
 
     if report["confidence"] == "thin":
         out.append("")
@@ -735,6 +939,10 @@ def _cli() -> None:
                     help="Price the stats run on: item sold price (default) or sold+shipping")
     ap.add_argument("--no-pool-used", action="store_true",
                     help="Do NOT pool Used grades when the strict cohort is thin")
+    ap.add_argument("--competitor-active",
+                    help="Saved active-listings JSON from the top competing sellers in the "
+                         "matched category (lib/ebay_browse.py top-sellers) — GH #82: learn "
+                         "their charm-price convention instead of the generic default")
     ap.add_argument("--json", action="store_true", help="Emit the full report as JSON")
     args = ap.parse_args()
 
@@ -745,6 +953,7 @@ def _cli() -> None:
         report = price_from_runs(
             best_match_json=args.best_match,
             price_high_json=args.price_high,
+            competitor_active_json=args.competitor_active,
             unit_type=args.unit,
             require_tokens=args.require_tokens,
             condition=args.condition,

--- a/prompts/price.md
+++ b/prompts/price.md
@@ -181,10 +181,17 @@ hard you looked. An exact match beats any era-peer; commit to it (per _shared).
   top-level `charm_price_share` / `currency_leak_suspected`.
 
 `python lib/price_stats.py`:
-- `--best-match <bm.json> [--price-high <ph.json>] --unit <single|pair|set|lot|duplicate> --condition <new|used> [--require-tokens <tok>...] [--price-field <sold|total>]`
+- `--best-match <bm.json> [--price-high <ph.json>] --unit <single|pair|set|lot|duplicate> --condition <new|used> [--require-tokens <tok>...] [--price-field <sold|total>] [--competitor-active <competitors.json>]`
 - Prints the Distribution line (n/median/IQR/dispersion), vetted ceiling, three
-  tiers, confidence, per-filter drop log. `--price-field total` for free-ship.
-  Fold the block into `price.txt`; n<3 ⇒ `thin` ⇒ era-peer fallback.
+  tiers, confidence, per-filter drop log, and (when `--competitor-active` is
+  given or data supplied) the Competitor charm pattern line. `--price-field
+  total` for free-ship. Fold the block into `price.txt`; n<3 ⇒ `thin` ⇒
+  era-peer fallback (the competitor-charm line still prints even when thin).
+
+`python lib/ebay_browse.py top-sellers [<query>] [--category <id>] [--sample N] [--top N]`:
+- One Browse pull, bucketed to the `--top` sellers (default 5) by listing
+  count in the sample — feeds `--competitor-active` above. `--json <file>`
+  saves the listings.
 
 ## Saved comp artifacts (every stage leaves a reviewable record)
 
@@ -293,8 +300,10 @@ From `price_stats.py` on the cleaned set — adopt its numbers, don't re-derive.
 Free-shipping ⇒ these are delivered prices; always pair with net-to-us.
 
 - **Conservative** — 25th percentile of the like-condition cleaned set.
-- **Recommended (max supported)** — median. In headless flow this is the
-  provisional working price (SOFT gate — logged to NEEDS_REVIEW, not a stop).
+- **Recommended (max supported)** — median, nudged to the competitor charm
+  ending when one is decisive (below); otherwise the plain median. In
+  headless flow this is the provisional working price (SOFT gate — logged to
+  NEEDS_REVIEW, not a stop).
 - **Push-high** — the vetted `price_high` ceiling. If flagged `needs_vetting`
   (>2.5× median) and it doesn't vet as comparable, drop to the
   90th-percentile fallback it prints. State which you used.
@@ -302,6 +311,24 @@ Free-shipping ⇒ these are delivered prices; always pair with net-to-us.
 **Exact-match short-circuit:** ≥1 true exact comp (same item + condition) ⇒
 anchor Recommended on the exact-match median instead; say so; keep the
 distribution as context.
+
+**Competitor charm-price convention (GH #82).** `charm_price_share` (above,
+from our own sold comps) is a currency-leak guard, not a pricing signal — it
+says charm pricing is common in general, not what THIS niche's winning
+sellers actually do. When useful (a category with an obvious cluster of
+competing stores), pull `lib/ebay_browse.py top-sellers "<query>" --category
+<id> --json competitors.json` and pass it to `price_stats.py
+--competitor-active competitors.json`. The report's
+`competitor_charm_pattern` buckets `.00`/`.99`/`.97`/`.95`/`other` across
+those sellers' active listings:
+- **Clear majority** (≥60% of ≥3 competing sellers / ≥5 listings — the
+  `pattern`/`share`/`n_competitors` fields) ⇒ Recommended is nudged to that
+  ending (`tiers.recommended.pre_charm_price` keeps the un-nudged median for
+  the record). State the pattern + share in the Distribution line.
+- **No majority, or too few competitors** (`pattern: null`, see `reason`) ⇒
+  unchanged — Recommended stays the plain median, same as when this step is
+  skipped entirely. This is optional per item; skip it outright on a thin or
+  single-competitor niche rather than force a signal that isn't there.
 
 **Thin market (conf=thin, n<3):** no percentiles — closest-comp/era-peer
 method, widen the bracket, flag rarity. The three tiers still apply, anchored

--- a/tests/test_competitor_charm_pricing.py
+++ b/tests/test_competitor_charm_pricing.py
@@ -212,6 +212,65 @@ def test_competitor_charm_pattern_surfaced_even_when_thin():
     assert r["competitor_charm_pattern"]["pattern"] == ".00"
 
 
+def test_records_without_a_seller_id_are_not_counted():
+    # Copilot review on #93: an unattributed listing (no seller/sellerName/
+    # seller_username) can't be credited to "a top competing seller" — it
+    # must not count toward n_listings, the bucket shares, or the
+    # min-sellers/min-listings gate.
+    listings = _listings([("alice", 9.99), ("bob", 8.99), ("carol", 7.99)])
+    listings.append({"askingPrice": 0.50})     # no seller key at all
+    listings.append({"seller": "", "askingPrice": 6.99})   # falsy seller
+    r = price_stats.competitor_charm_pattern(listings, min_listings=3, min_sellers=3)
+    assert r["n_listings"] == 3
+    assert r["n_competitors"] == 3
+    assert r["pattern"] == ".99"
+
+
+def test_majority_other_ending_is_not_actionable():
+    # A decisive majority that lands on a non-charm cents value (e.g. most
+    # competitors price at .50) has nothing for apply_charm_ending() to do —
+    # it must fall back like "no majority" rather than surface a "pattern"
+    # that produces a silent no-op nudge downstream.
+    listings = _listings([
+        ("alice", 12.50), ("bob", 22.50), ("carol", 8.50),
+        ("dave", 15.99), ("erin", 30.00),
+    ])
+    r = price_stats.competitor_charm_pattern(listings)
+    assert r["pattern"] is None
+    assert "other" in r["reason"]
+    assert r["n_competitors"] == 5
+
+
+def test_recommended_unchanged_when_majority_is_other():
+    listings = _listings([
+        ("alice", 12.50), ("bob", 22.50), ("carol", 8.50),
+        ("dave", 15.99), ("erin", 30.00),
+    ])
+    r = _report(competitor_listings=listings)
+    assert r["competitor_charm_pattern"]["pattern"] is None
+    assert r["tiers"]["recommended"]["price"] == 35.95
+    assert "pre_charm_price" not in r["tiers"]["recommended"]
+
+
+def test_render_shows_the_no_signal_reason_when_competitor_data_was_requested():
+    # Copilot review on #93: gating the fallback line on n_listings alone
+    # made `--competitor-active <file>` with all-unusable input print
+    # nothing — indistinguishable from never having asked at all.
+    listings = [{"askingPrice": 9.99}, {"askingPrice": 8.99}]   # no seller ids
+    r = _report(competitor_listings=listings)
+    assert r["competitor_charm_pattern"]["n_listings"] == 0
+    assert r["competitor_active_requested"] is True
+    out = price_stats.render(r)
+    assert "Competitor charm pattern: no clear signal" in out
+
+
+def test_render_is_silent_when_no_competitor_data_was_requested_at_all():
+    r = _report()
+    assert r["competitor_active_requested"] is False
+    out = price_stats.render(r)
+    assert "Competitor charm pattern" not in out
+
+
 def test_competitor_active_json_loader():
     import json
     import tempfile

--- a/tests/test_competitor_charm_pricing.py
+++ b/tests/test_competitor_charm_pricing.py
@@ -67,6 +67,15 @@ def test_apply_charm_ending_stays_within_a_dollar():
     assert price_stats.apply_charm_ending(34.503, "other") == 34.5
 
 
+def test_apply_charm_ending_never_returns_a_negative_price():
+    # Copilot review on #93: the "prior whole dollar" candidate
+    # (base - 1 + cents/100) goes negative for a low-dollar price and used
+    # to win on raw distance — e.g. price=0.10, pattern='.95' picked -0.05.
+    assert price_stats.apply_charm_ending(0.10, ".95") == 0.95
+    assert price_stats.apply_charm_ending(0.02, ".99") == 0.99
+    assert price_stats.apply_charm_ending(0.50, ".00") >= 0
+
+
 def test_majority_pattern_found_and_returned():
     listings = _listings([
         ("alice", 12.99), ("bob", 22.99), ("carol", 8.99),

--- a/tests/test_competitor_charm_pricing.py
+++ b/tests/test_competitor_charm_pricing.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Competitor charm-price convention (GH #82).
+
+`charm_price_share` (lib/comps_core.py, folded into price_stats' run meta) is
+a currency-leak guard over OUR OWN sold comps — it says charm pricing is
+common in general, nothing about what a specific niche's competing stores are
+doing right now. `competitor_charm_pattern` (lib/price_stats.py) buckets
+ending-price patterns across the top competing sellers' ACTIVE listings (from
+lib/ebay_browse.py) and, when there's a clear majority, prefers that ending
+for the `recommended` tier instead of the generic charm default.
+
+Two things have to hold:
+  1. A real majority (>=60%, >=3 sellers, >=5 listings — the issue's own bar)
+     is preferred over the generic default, and the nudge is traceable
+     (`pre_charm_price` survives alongside the adjusted price).
+  2. Anything short of that — too few competitors, or no majority ending —
+     changes NOTHING: `recommended` is exactly today's median, and
+     `charm_price_share`-only behavior (no competitor data at all) is
+     unaffected.
+
+Run:  python tests/test_competitor_charm_pricing.py
+  or: pytest tests/test_competitor_charm_pricing.py
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "lib"))
+
+import price_stats  # noqa: E402
+
+FIX = Path(__file__).resolve().parent / "fixtures" / "price_stats_pair"
+BM = FIX / "best_match.json"
+PH = FIX / "price_high.json"
+
+
+def _report(**kw):
+    return price_stats.price_from_runs(
+        best_match_json=BM, price_high_json=PH,
+        unit_type="pair", condition="used", price_field="total", **kw,
+    )
+
+
+def _listings(pairs):
+    """[(seller, price), ...] -> the ebay_browse.search() normalised shape."""
+    return [{"seller": s, "askingPrice": p} for s, p in pairs]
+
+
+# ---------------------------------------------------------------------------
+# competitor_charm_pattern() — pure bucketing logic
+# ---------------------------------------------------------------------------
+
+def test_charm_ending_buckets():
+    assert price_stats.charm_ending(34.99) == ".99"
+    assert price_stats.charm_ending(20.00) == ".00"
+    assert price_stats.charm_ending(18.97) == ".97"
+    assert price_stats.charm_ending(9.95) == ".95"
+    assert price_stats.charm_ending(18.50) == "other"
+
+
+def test_apply_charm_ending_stays_within_a_dollar():
+    assert price_stats.apply_charm_ending(34.50, ".99") == 34.99
+    assert price_stats.apply_charm_ending(34.50, ".00") == 34.0
+    assert price_stats.apply_charm_ending(19.60, ".99") == 19.99
+    # unknown pattern is a no-op (just rounds)
+    assert price_stats.apply_charm_ending(34.503, "other") == 34.5
+
+
+def test_majority_pattern_found_and_returned():
+    listings = _listings([
+        ("alice", 12.99), ("bob", 22.99), ("carol", 8.99),
+        ("dave", 15.99), ("erin", 30.00), ("frank", 40.99),
+        ("gail", 5.99),
+    ])
+    r = price_stats.competitor_charm_pattern(listings)
+    assert r["pattern"] == ".99"
+    assert r["n_competitors"] == 7
+    assert r["n_listings"] == 7
+    assert r["share"] == round(6 / 7, 3)
+    assert r["reason"] is None
+
+
+def test_no_majority_falls_back():
+    # Enough sellers/listings, but no single ending clears 60%.
+    listings = _listings([
+        ("alice", 12.99), ("bob", 22.00), ("carol", 8.97),
+        ("dave", 15.95), ("erin", 30.99), ("frank", 40.00),
+    ])
+    r = price_stats.competitor_charm_pattern(listings)
+    assert r["pattern"] is None
+    assert r["n_competitors"] == 6
+    assert "no majority" in r["reason"]
+
+
+def test_too_few_sellers_falls_back_even_with_unanimous_price():
+    # 2 sellers unanimously at .99 is NOT a decisive competitor signal —
+    # the issue explicitly calls out guarding against exactly this.
+    listings = _listings([("alice", 12.99), ("alice", 13.99), ("bob", 9.99)])
+    r = price_stats.competitor_charm_pattern(listings)
+    assert r["pattern"] is None
+    assert r["n_competitors"] == 2
+    assert "too few competitors" in r["reason"]
+
+
+def test_too_few_listings_falls_back_even_with_enough_sellers():
+    listings = _listings([("a", 9.99), ("b", 8.99), ("c", 7.99)])
+    r = price_stats.competitor_charm_pattern(listings, min_listings=5)
+    assert r["pattern"] is None
+    assert "too few competitors" in r["reason"]
+
+
+def test_accepts_sellerName_and_price_keys_too():
+    # ebay_browse's shape uses seller/askingPrice; other saved shapes may use
+    # sellerName/price (e.g. Apify-style comps) — both must compose.
+    listings = [
+        {"sellerName": "alice", "price": 12.99},
+        {"sellerName": "bob", "price": 8.99},
+        {"sellerName": "carol", "price": 22.99},
+        {"sellerName": "dave", "price": 5.99},
+        {"sellerName": "erin", "price": 30.99},
+    ]
+    r = price_stats.competitor_charm_pattern(listings)
+    assert r["pattern"] == ".99"
+    assert r["n_competitors"] == 5
+
+
+def test_junk_prices_are_skipped_not_fatal():
+    listings = _listings([("a", 9.99), ("b", 8.99), ("c", 7.99),
+                          ("d", 6.99), ("e", None)])
+    listings.append({"seller": "f", "askingPrice": "not-a-price"})
+    r = price_stats.competitor_charm_pattern(listings, min_listings=4, min_sellers=4)
+    assert r["n_listings"] == 4
+    assert r["pattern"] == ".99"
+
+
+# ---------------------------------------------------------------------------
+# price_from_runs() — wired into the price-proposal logic
+# ---------------------------------------------------------------------------
+
+def test_recommended_is_nudged_when_a_majority_is_found():
+    baseline = _report()["tiers"]["recommended"]["price"]  # 35.95 (whole-ish)
+    listings = _listings([
+        ("alice", 30.00), ("bob", 40.00), ("carol", 50.00),
+        ("dave", 20.00), ("erin", 60.00), ("frank", 12.99),
+    ])
+    r = _report(competitor_listings=listings)
+    cc = r["competitor_charm_pattern"]
+    assert cc["pattern"] == ".00"
+    rec = r["tiers"]["recommended"]
+    assert price_stats.charm_ending(rec["price"]) == ".00"
+    assert rec["price"] != baseline
+    assert rec["pre_charm_price"] == baseline
+    assert ".00" in rec["basis"]
+    # the nudge never crosses the conservative floor
+    assert rec["price"] >= r["tiers"]["conservative"]["price"]
+    # other tiers are untouched by the nudge
+    assert "pre_charm_price" not in r["tiers"]["conservative"]
+    assert "pre_charm_price" not in r["tiers"]["push_high"]
+
+
+def test_recommended_unchanged_when_no_majority():
+    baseline = _report()
+    listings = _listings([
+        ("alice", 12.99), ("bob", 22.00), ("carol", 8.97),
+        ("dave", 15.95), ("erin", 30.99), ("frank", 40.00),
+    ])
+    r = _report(competitor_listings=listings)
+    assert r["competitor_charm_pattern"]["pattern"] is None
+    assert r["tiers"]["recommended"] == baseline["tiers"]["recommended"]
+    assert "pre_charm_price" not in r["tiers"]["recommended"]
+
+
+def test_recommended_unchanged_when_too_few_competitors():
+    baseline = _report()
+    listings = _listings([("alice", 12.99), ("bob", 13.99)])
+    r = _report(competitor_listings=listings)
+    assert r["competitor_charm_pattern"]["pattern"] is None
+    assert "too few competitors" in r["competitor_charm_pattern"]["reason"]
+    assert r["tiers"]["recommended"] == baseline["tiers"]["recommended"]
+
+
+def test_charm_price_share_only_behavior_is_unchanged_with_no_competitor_data():
+    """The regression the issue calls out explicitly: our OWN charm_price_share
+    (surfaced via run meta) keeps working exactly as before when this feature
+    finds no competitor data at all — nothing here should touch it."""
+    r = _report()
+    assert r["runs"][0]["charm_price_share"] == 0.8
+    cc = r["competitor_charm_pattern"]
+    assert cc["pattern"] is None
+    assert cc["n_competitors"] == 0
+    assert cc["reason"] == "no competitor active-listing data supplied"
+    assert r["tiers"]["recommended"]["price"] == 35.95
+    assert "pre_charm_price" not in r["tiers"]["recommended"]
+
+
+def test_competitor_charm_pattern_surfaced_even_when_thin():
+    # Thin (n < THIN_N) sold-comp distribution still short-circuits to
+    # tiers=None, but the competitor signal is independent of sold comps and
+    # should still be computed and surfaced.
+    listings = _listings([
+        ("alice", 30.00), ("bob", 40.00), ("carol", 50.00), ("dave", 20.00),
+        ("erin", 60.00),
+    ])
+    r = price_stats.price_from_runs(
+        best_match_json=BM, unit_type="pair", condition="used",
+        price_field="total", require_tokens=["nonexistent-token-xyz"],
+        competitor_listings=listings,
+    )
+    assert r["confidence"] == "thin"
+    assert r["tiers"] is None
+    assert r["competitor_charm_pattern"]["pattern"] == ".00"
+
+
+def test_competitor_active_json_loader():
+    import json
+    import tempfile
+    listings = _listings([
+        ("alice", 30.00), ("bob", 40.00), ("carol", 50.00),
+        ("dave", 20.00), ("erin", 60.00),
+    ])
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "competitors.json"
+        p.write_text(json.dumps({"listings": listings}), encoding="utf-8")
+        r = _report(competitor_active_json=p)
+    assert r["competitor_charm_pattern"]["pattern"] == ".00"
+
+
+if __name__ == "__main__":
+    fails = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except Exception as e:  # noqa: BLE001
+                fails += 1
+                print(f"FAIL {name}: {e}")
+    sys.exit(1 if fails else 0)

--- a/tests/test_competitor_charm_pricing.py
+++ b/tests/test_competitor_charm_pricing.py
@@ -280,6 +280,18 @@ def test_render_is_silent_when_no_competitor_data_was_requested_at_all():
     assert "Competitor charm pattern" not in out
 
 
+def test_an_explicit_empty_competitor_listings_still_counts_as_requested():
+    # Second Copilot review pass on #93: "requested" has to be about
+    # whether a source was supplied, not whether it produced any usable
+    # records — competitor_listings=[] (or a --competitor-active file with
+    # nothing parseable in it) is still an explicit ask.
+    r = _report(competitor_listings=[])
+    assert r["competitor_active_requested"] is True
+    assert r["competitor_charm_pattern"]["n_listings"] == 0
+    out = price_stats.render(r)
+    assert "Competitor charm pattern: no clear signal" in out
+
+
 def test_competitor_active_json_loader():
     import json
     import tempfile

--- a/tests/test_ebay_browse.py
+++ b/tests/test_ebay_browse.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""lib/ebay_browse.py — the Browse API reader, tested offline (GH #82).
+
+All HTTP is faked by patching `ebay_browse.ec.api_get` (this repo's
+convention — see tests/test_ebay_client.py for the lower-level urlopen fake
+that `ec.api_get` itself sits on); no network, no creds.
+
+Run:  python tests/test_ebay_browse.py
+  or: pytest tests/test_ebay_browse.py
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "lib"))
+
+import ebay_browse  # noqa: E402
+
+# A fabricated active-listings sample: 12 items across 4 sellers, uneven
+# counts so "top N by listing count" has an unambiguous answer.
+#   alice: 5 listings   bob: 4 listings   carol: 2 listings   dave: 1 listing
+
+def _item(i, seller, price):
+    return {
+        "itemId": f"v1|{seller}-{i}|0",
+        "title": f"{seller} item {i}",
+        "price": {"value": str(price), "currency": "USD"},
+        "condition": "Used",
+        "seller": {"username": seller, "feedbackPercentage": "99.1", "feedbackScore": 500},
+        "itemWebUrl": f"https://www.ebay.com/itm/{seller}-{i}?hash=x",
+    }
+
+
+SAMPLE_ITEMS = (
+    [_item(i, "alice", 9.99) for i in range(5)]
+    + [_item(i, "bob", 20.00) for i in range(4)]
+    + [_item(i, "carol", 15.99) for i in range(2)]
+    + [_item(0, "dave", 30.00)]
+)
+
+
+class _FakeApiGet:
+    """Stand-in for ec.api_get: pages SAMPLE_ITEMS honoring limit/offset."""
+
+    def __init__(self, items):
+        self.items = items
+        self.calls = []
+
+    def __call__(self, path, query=None, marketplace=None, creds=None):
+        self.calls.append({"path": path, "query": dict(query or {})})
+        q = query or {}
+        limit = q.get("limit", 200)
+        offset = q.get("offset", 0)
+        batch = self.items[offset: offset + limit]
+        return {"itemSummaries": batch, "total": len(self.items)}
+
+
+def _patched(fake, fn):
+    real = ebay_browse.ec.api_get
+    ebay_browse.ec.api_get = fake
+    try:
+        return fn()
+    finally:
+        ebay_browse.ec.api_get = real
+
+
+# ---------------------------------------------------------------------------
+# search() — normalisation + paging
+# ---------------------------------------------------------------------------
+
+def test_search_normalizes_seller_and_price():
+    fake = _FakeApiGet(SAMPLE_ITEMS)
+
+    def go():
+        recs = ebay_browse.search(q="widget", max_items=200)
+        assert len(recs) == len(SAMPLE_ITEMS)
+        assert recs[0]["seller"] == "alice"
+        assert recs[0]["askingPrice"] == 9.99
+        assert recs[0]["url"] == "https://www.ebay.com/itm/alice-0"
+        assert recs[0]["listingStatus"] == "active"
+
+    _patched(fake, go)
+
+
+def test_search_requires_q_or_category():
+    try:
+        ebay_browse.search()
+        raise AssertionError("expected ValueError")
+    except ValueError:
+        pass
+
+
+def test_search_pages_across_multiple_calls():
+    fake = _FakeApiGet(SAMPLE_ITEMS)
+
+    def go():
+        recs = ebay_browse.search(q="widget", max_items=200)
+        assert len(recs) == 12
+        # PAGE_LIMIT-sized pages would be one call here (12 < 200), but the
+        # loop must still terminate correctly at total.
+        assert len(fake.calls) == 1
+
+    _patched(fake, go)
+
+
+def test_search_respects_max_items_cap():
+    fake = _FakeApiGet(SAMPLE_ITEMS)
+
+    def go():
+        recs = ebay_browse.search(q="widget", max_items=3)
+        assert len(recs) == 3
+
+    _patched(fake, go)
+
+
+# ---------------------------------------------------------------------------
+# top_sellers_active() — GH #82: the competing-store lookup PRICE feeds into
+# price_stats.competitor_charm_pattern
+# ---------------------------------------------------------------------------
+
+def test_top_sellers_active_keeps_only_the_top_n_by_listing_count():
+    fake = _FakeApiGet(SAMPLE_ITEMS)
+
+    def go():
+        recs = ebay_browse.top_sellers_active(q="widget", sample=200, top_n=2)
+        sellers = {r["seller"] for r in recs}
+        # alice (5) and bob (4) are the top 2 by count; carol/dave dropped.
+        assert sellers == {"alice", "bob"}
+        assert len(recs) == 9  # 5 + 4
+        assert all(r.get("askingPrice") is not None for r in recs)
+
+    _patched(fake, go)
+
+
+def test_top_sellers_active_top_n_larger_than_seller_count_keeps_everyone():
+    fake = _FakeApiGet(SAMPLE_ITEMS)
+
+    def go():
+        recs = ebay_browse.top_sellers_active(q="widget", sample=200, top_n=10)
+        assert len(recs) == len(SAMPLE_ITEMS)
+
+    _patched(fake, go)
+
+
+def test_top_sellers_active_feeds_price_stats_competitor_charm_pattern():
+    """The intended pipeline, end to end offline: Browse listings ->
+    top_sellers_active -> price_stats.competitor_charm_pattern."""
+    sys.path.insert(0, str(ROOT / "lib"))
+    import price_stats  # noqa: PLC0415
+
+    items = (
+        [_item(i, "alice", 9.99) for i in range(3)]
+        + [_item(i, "bob", 19.99) for i in range(3)]
+        + [_item(i, "carol", 29.99) for i in range(2)]
+        + [_item(0, "dave", 40.00)]
+    )
+    fake = _FakeApiGet(items)
+
+    def go():
+        recs = ebay_browse.top_sellers_active(q="widget", sample=200, top_n=5)
+        return price_stats.competitor_charm_pattern(recs)
+
+    result = _patched(fake, go)
+    assert result["pattern"] == ".99"
+    assert result["n_competitors"] == 4
+
+
+if __name__ == "__main__":
+    fails = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except Exception as e:  # noqa: BLE001
+                fails += 1
+                print(f"FAIL {name}: {e}")
+    sys.exit(1 if fails else 0)


### PR DESCRIPTION
## Summary

`charm_price_share` (`lib/comps_core.py`, surfaced via `price_stats.py`'s run meta) is a currency-leak guard over *our own* sold comps — it tells us charm pricing is common in general, not what the specific sellers competing in this niche actually do. This adds a second, independent signal: `competitor_charm_pattern`, learned from the top competing sellers' *active* listings, and wires a majority-preference rule into the price-proposal logic.

## How the proposed scope is satisfied

1. **Bucket ending-price patterns across top sellers in the category** — `lib/ebay_browse.top_sellers_active()` (new) does one `search()` pull over a category/query, ranks sellers by listing count in that sample (Browse has no seller-ranking endpoint, so this is the practical proxy), and returns just the top-N sellers' listings (already carrying `seller` + `askingPrice` — no extension to `_normalize()` needed). New `top-sellers` CLI subcommand.

   `lib/price_stats.competitor_charm_pattern()` (new, stdlib-only — keeps the module's "runs in minimal/sandboxed envs" contract) buckets `.00`/`.99`/`.97`/`.95`/`other` across any list of `{seller, askingPrice}`-shaped records.

2. **Surface `competitor_charm_pattern` alongside `charm_price_share`** — `price_from_runs()` always includes `report["competitor_charm_pattern"]` (never `None` — a dict with `pattern: None` + `reason` when the signal isn't trustworthy, so callers never need a null-check), shape per the issue: `{"pattern": ".99", "share": 0.71, "n_competitors": 7, "n_listings": 12, "buckets": {...}, "reason": None}`. It's computed independently of the sold-comp distribution, so it's still surfaced even when the distribution is `thin`.

3. **Prefer the competitor-dominant ending on a clear majority** — when `share >= 60%` (the issue's own bar) among `>= 3` sellers and `>= 5` listings, the `recommended` tier's price is nudged to that ending via `apply_charm_ending()` (moves at most ~$1, clamped to never drop below the `conservative` tier). The un-nudged median survives alongside it as `tiers.recommended.pre_charm_price`, and `basis` states the nudge + the competitor evidence.
   - Sample-size floors (documented in `lib/price_stats.py` next to the constants): **3 sellers min** — the issue itself frames this as "top 3-5 sellers"; 2 agreeing is coincidence, not a convention. **5 listings min** — guards against a majority read off a handful of listings even when the seller count is technically enough.

4. **Fall back to unchanged behavior otherwise** — too few competitors, or no majority ending ⇒ `pattern: None` (with `reason`), and `recommended` is *exactly* today's plain median — verified by a regression test (`test_charm_price_share_only_behavior_is_unchanged_with_no_competitor_data`) and by the full existing suite staying green.

5. **`prompts/price.md`** documents the new field, the CLI flags (`price_stats.py --competitor-active`, `ebay_browse.py top-sellers`), and the preference rule, in the doc's existing terse style — including that this step is optional per item and should be skipped outright on a thin/single-competitor niche rather than forcing a signal.

## Descoped / left for follow-up

- No automatic "is this niche worth checking" heuristic — PRICE decides per-item whether to pull competitor data (documented as optional/judgment-call, consistent with the doc's existing style for similar optional steps).
- `top_sellers_active`'s "top sellers" proxy is listing-count-in-sample, not sales volume (Browse has no ranking endpoint for that) — same honesty caveat the rest of `ebay_browse.py` already carries (asking price, not realized).
- No UI/report-rendering changes beyond `price_stats.render()`'s existing text-block style (a new "Competitor charm pattern" line).

## Test plan

- `python -m pytest tests/ -q` → 482 passed, 1 skipped (no regressions).
- New `tests/test_competitor_charm_pricing.py` (14 tests): pure bucketing (`charm_ending`, `apply_charm_ending`, `competitor_charm_pattern` — majority found, no majority, too-few-sellers, too-few-listings, alternate key shapes, junk-price tolerance) + `price_from_runs()` integration (majority nudges `recommended` and clamps to conservative; no-majority/too-few-competitors leave `recommended` byte-identical to the no-competitor-data baseline; signal still surfaces when the sold-comp distribution is `thin`; JSON-file loader).
- New `tests/test_ebay_browse.py` (7 tests): `search()` normalization/paging, `top_sellers_active()` top-N selection, and an offline end-to-end `top_sellers_active → competitor_charm_pattern` pipeline test — all HTTP faked by patching `ebay_browse.ec.api_get` (this repo's mocking convention, mirroring `tests/test_ebay_client.py`).
- `python -m py_compile` on all touched files — clean.
- `ruff check` on all touched files — clean (`All checks passed!`).
- Manual CLI smoke test: `price_stats.py --competitor-active <file>` against the existing `tests/fixtures/price_stats_pair` fixtures produces the documented output (Distribution line's new "Competitor charm pattern" row, `recommended` nudged from $35.95 → $36.00 with `pre_charm_price` retained).

Closes #82


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnrWxtKQStiTx1qFkqc5sm)_