### PR TITLE
feat(observer): $/listing, foreground blocking hours, prep re-run counts — part of #71

### DIFF
--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -5,20 +5,23 @@ Builds a synthetic transcript in a temp dir — no dependency on the real
 
 No pytest fixtures — runs under tests/run_all.py too.
 """
+import csv
 import json
 import sys
 import tempfile
 from collections import Counter
+from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from tools.session_observer import (  # noqa: E402
-    _classify, _clean_prompt, _match_open_issue, _open_idea_issues, _ts,
-    _tool_signature, _turn_context, aggregate_friction, economics_aggregate,
-    economics_report, file_proposals, format_idea_issue, parse_economics,
-    parse_session, propose_fixes, report, transcripts_dir,
+    _classify, _clean_prompt, _command_bucket, _match_open_issue,
+    _model_rates, _open_idea_issues, _prep_item_dir, _ts, _tool_signature,
+    _turn_context, _turn_cost_usd, aggregate_friction, cost_per_listing,
+    economics_aggregate, economics_report, file_proposals, format_idea_issue,
+    parse_economics, parse_session, propose_fixes, report, transcripts_dir,
 )
 
 T0 = "2026-08-27T10:00:0{}.000Z"
@@ -614,3 +617,226 @@ def test_economics_aggregate_matches_report_shape():
     agg = economics_aggregate([p])
     assert agg["n_sessions"] == 1
     assert agg["bash_total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# #71 §7 — $/published listing, foreground blocking hours, prep re-runs
+# ---------------------------------------------------------------------------
+
+def test_model_rates_known_model_and_unknown_fallback():
+    assert _model_rates("claude-opus-5") == (5.00, 25.00)
+    assert _model_rates("claude-sonnet-5") == (2.00, 10.00)
+    assert _model_rates("claude-haiku-4-5") == (1.00, 5.00)
+    assert _model_rates("some-future-model") != (5.00, 25.00)   # falls back, not silently free
+    assert _model_rates(None)[0] > 0
+
+
+def test_turn_cost_usd_prices_input_output_and_cache_tiers():
+    assert _turn_cost_usd({"input_tokens": 1_000_000}, "claude-sonnet-5") == 2.0
+    assert _turn_cost_usd({"output_tokens": 1_000_000}, "claude-sonnet-5") == 10.0
+    # cache write ~1.25x input rate, cache read ~0.1x input rate
+    assert _turn_cost_usd({"cache_creation_input_tokens": 1_000_000},
+                          "claude-opus-5") == 6.25
+    assert _turn_cost_usd({"cache_read_input_tokens": 1_000_000},
+                          "claude-opus-5") == 0.5
+    assert _turn_cost_usd({}, "claude-opus-5") == 0.0
+
+
+def test_command_bucket_normalizes_common_repo_commands():
+    assert _command_bucket(
+        "python -m lib.photo_prep.prep inventory/x --approve-auto"
+    ) == "python -m lib.photo_prep.prep"
+    assert _command_bucket("pytest tests/ -q") == "pytest"
+    assert _command_bucket('cd "/some/deep/path" && git status') == "git status"
+    assert _command_bucket("gh pr create --title x") == "gh pr create"
+    assert _command_bucket("ebz prep inventory/x --auto") == "ebz prep"
+    assert _command_bucket("") == "(empty)"
+
+
+def test_prep_item_dir_extracts_across_every_invocation_form():
+    assert _prep_item_dir(
+        "python -m lib.photo_prep.prep inventory/sand-dollars --approve-auto"
+    ) == "inventory/sand-dollars"
+    assert _prep_item_dir(
+        "python -m lib.cli prep inventory/sand-dollars --auto"
+    ) == "inventory/sand-dollars"
+    assert _prep_item_dir("ebz prep inventory/sand-dollars") == "inventory/sand-dollars"
+    assert _prep_item_dir(
+        'cd "/repo" && python -m lib.photo_prep.prep inventory/x --check'
+    ) == "inventory/x"
+
+
+def test_prep_item_dir_none_for_non_prep_commands_and_no_positional_arg():
+    assert _prep_item_dir("python -m lib.cli sales-report") is None
+    assert _prep_item_dir("git status") is None
+    assert _prep_item_dir("python -m lib.photo_prep.prep --help") is None
+
+
+def test_parse_economics_tracks_cost_usd_from_model_pricing():
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z", [("t1", "Bash", {"command": "ls"})],
+                      usage={"input_tokens": 1_000_000, "output_tokens": 0,
+                             "cache_creation_input_tokens": 0,
+                             "cache_read_input_tokens": 0}),
+        _tool_result_msg("2026-08-27T10:00:01Z", "t1", "a"),
+    ])
+    e = parse_economics(p)
+    assert round(e["cost_usd"], 2) == 5.00       # claude-opus-5 (test helper's model)
+
+
+def test_parse_economics_foreground_hours_exclude_backgrounded_bash():
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z", [
+            ("t1", "Bash", {"command": "python -m lib.photo_prep.prep inventory/x --auto"}),
+            ("t2", "Bash", {"command": "long_thing", "run_in_background": True}),
+        ]),
+        _tool_result_msg("2026-08-27T10:05:00Z", "t1", "done"),
+        _tool_result_msg("2026-08-27T10:00:02Z", "t2", "started"),
+    ])
+    e = parse_economics(p)
+    assert e["fg_seconds_by_tool"]["Bash"] == 300.0
+    assert e["fg_seconds_by_command"] == {"python -m lib.photo_prep.prep": 300.0}
+
+
+def test_parse_economics_foreground_hours_covers_every_tool_not_just_bash():
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z", [("t1", "Read", {"file_path": "x.py"})]),
+        _tool_result_msg("2026-08-27T10:00:10Z", "t1", [{"type": "text", "text": "hi"}]),
+    ])
+    e = parse_economics(p)
+    assert e["fg_seconds_by_tool"]["Read"] == 10.0
+    assert e["fg_seconds_by_command"] == {}      # only Bash/PowerShell get a command bucket
+
+
+def test_parse_economics_counts_prep_reruns_per_item_dir():
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z", [
+            ("t1", "Bash", {"command": "python -m lib.photo_prep.prep inventory/sand-dollars --check"}),
+        ]),
+        _tool_result_msg("2026-08-27T10:00:01Z", "t1", "a"),
+        _tool_use_msg("2026-08-27T10:01:00Z", [
+            ("t2", "Bash", {"command": "python -m lib.photo_prep.prep inventory/sand-dollars --approve-auto"}),
+        ]),
+        _tool_result_msg("2026-08-27T10:01:01Z", "t2", "b"),
+        _tool_use_msg("2026-08-27T10:02:00Z", [
+            ("t3", "Bash", {"command": "python -m lib.photo_prep.prep inventory/other-item --auto"}),
+        ]),
+        _tool_result_msg("2026-08-27T10:02:01Z", "t3", "c"),
+    ])
+    e = parse_economics(p)
+    assert e["prep_calls"] == {"inventory/sand-dollars": 2, "inventory/other-item": 1}
+
+
+def test_economics_aggregate_sums_cost_foreground_hours_and_prep_reruns():
+    def _prep_session(dir_name):
+        return _write_economics([
+            _tool_use_msg("2026-08-27T10:00:00Z", [
+                ("t1", "Bash", {"command": f"python -m lib.photo_prep.prep {dir_name} --auto"}),
+            ], usage={"input_tokens": 1000, "output_tokens": 0,
+                     "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}),
+            _tool_result_msg("2026-08-27T10:00:05Z", "t1", "a"),
+        ])
+    agg = economics_aggregate([_prep_session("inventory/a"), _prep_session("inventory/a")])
+    assert agg["prep_calls"] == {"inventory/a": 2}
+    assert agg["fg_seconds_by_tool"]["Bash"] == 10.0
+    assert round(agg["cost_usd"], 4) == round(2 * (1000 * 5.00 / 1e6), 4)
+
+
+def test_cost_per_listing_joins_ledger_rows_within_window():
+    rows = [
+        {"price": "100.00", "published_at": "2026-08-27T10:00:00Z"},
+        {"price": "50.00", "published_at": "2026-08-27T11:00:00Z"},
+        {"price": "9999.00", "published_at": "2026-08-20T00:00:00Z"},   # before window
+        {"price": "10.00", "published_at": ""},                        # never published
+    ]
+    start = datetime(2026, 8, 27, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 8, 28, 0, 0, 0, tzinfo=timezone.utc)
+    r = cost_per_listing(300.0, rows, start, end)
+    assert r["n_published"] == 2
+    assert r["total_list_price"] == 150.0
+    assert r["cost_per_listing"] == 150.0
+    assert round(r["cost_to_list_price_ratio"], 4) == round(300.0 / 150.0, 4)
+
+
+def test_cost_per_listing_unbounded_window_counts_every_published_row():
+    rows = [{"price": "10", "published_at": "2020-01-01T00:00:00Z"}]
+    r = cost_per_listing(10.0, rows, None, None)
+    assert r["n_published"] == 1
+    assert r["cost_per_listing"] == 10.0
+
+
+def test_cost_per_listing_zero_published_returns_none_ratios_not_a_crash():
+    r = cost_per_listing(50.0, [], None, None)
+    assert r["n_published"] == 0
+    assert r["cost_per_listing"] is None
+    assert r["cost_to_list_price_ratio"] is None
+
+
+def test_cost_per_listing_zero_list_price_returns_none_ratio():
+    rows = [{"price": "0", "published_at": "2026-08-27T10:00:00Z"}]
+    r = cost_per_listing(50.0, rows, None, None)
+    assert r["n_published"] == 1
+    assert r["cost_per_listing"] == 50.0
+    assert r["cost_to_list_price_ratio"] is None
+
+
+def _write_ledger(rows) -> Path:
+    d = Path(tempfile.mkdtemp())
+    path = d / "listings_ledger.csv"
+    fields = ["sku", "status", "title", "price", "offer_id", "listing_id",
+              "url", "drafted_at", "synced_at", "published_at", "ended_at",
+              "updated_at"]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    return path
+
+
+def test_economics_report_renders_the_three_71_metrics(monkeypatch):
+    ledger = _write_ledger([
+        {"sku": "a1", "status": "PUBLISHED", "title": "Widget",
+         "price": "40.00", "published_at": "2026-08-27T10:00:00Z"},
+    ])
+    monkeypatch.setenv("EBAYBIZ_LISTINGS_LEDGER", str(ledger))
+
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T09:00:00Z", [
+            ("t1", "Bash", {"command": "python -m lib.photo_prep.prep inventory/widget --check"}),
+        ], usage={"input_tokens": 1_000_000, "output_tokens": 0,
+                 "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}),
+        _tool_result_msg("2026-08-27T09:10:00Z", "t1", "a"),
+        _tool_use_msg("2026-08-27T09:20:00Z", [
+            ("t2", "Bash", {"command": "python -m lib.photo_prep.prep inventory/widget --approve-auto"}),
+        ], usage={"input_tokens": 0, "output_tokens": 0,
+                 "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}),
+        _tool_result_msg("2026-08-27T09:21:00Z", "t2", "b"),
+    ])
+    start = datetime(2026, 8, 27, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 8, 28, 0, 0, 0, tzinfo=timezone.utc)
+    out = economics_report([p], window_start=start, window_end=end)
+
+    assert "$/published listing" in out
+    assert "$5.00" in out or "5.00" in out            # cost_per_listing == model spend / 1 listing
+    assert "Foreground blocking hours by tool" in out
+    assert "Foreground blocking hours by repo command" in out
+    assert "python -m lib.photo_prep.prep" in out
+    assert "prep re-runs" in out
+    assert "2x  inventory/widget" in out
+
+
+def test_economics_report_without_ledger_env_falls_back_to_no_row_line(monkeypatch):
+    # Point the ledger at a path that doesn't exist rather than trusting
+    # whatever real listings_ledger.csv this machine happens to have.
+    monkeypatch.setenv("EBAYBIZ_LISTINGS_LEDGER",
+                       str(Path(tempfile.mkdtemp()) / "missing.csv"))
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T10:00:00Z", [("t1", "Bash", {"command": "ls"})],
+                      usage={"input_tokens": 100, "output_tokens": 0,
+                             "cache_creation_input_tokens": 0,
+                             "cache_read_input_tokens": 0}),
+        _tool_result_msg("2026-08-27T10:00:01Z", "t1", "a"),
+    ])
+    out = economics_report([p])
+    assert "no listings_ledger.csv row published in this window" in out

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -699,6 +699,38 @@ def test_parse_economics_tracks_cost_usd_from_model_pricing():
     assert round(e["cost_usd"], 2) == 5.00       # claude-opus-5 (test helper's model)
 
 
+def test_parse_economics_windows_cost_and_foreground_hours_by_turn_timestamp():
+    # Copilot review on #94: a long-lived/resumed session (#71 §5) can have
+    # turns both inside and outside a requested --days window in the SAME
+    # file — file-level mtime selection alone can't scope that, so
+    # parse_economics must bound cost_usd/fg_seconds by each turn's own
+    # timestamp when a window is given.
+    p = _write_economics([
+        # Outside the window (too early) — must not count.
+        _tool_use_msg("2026-01-01T10:00:00Z", [("t1", "Bash", {"command": "ls"})],
+                      usage={"input_tokens": 1_000_000, "output_tokens": 0,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0}),
+        _tool_result_msg("2026-01-01T10:05:00Z", "t1", "a"),
+        # Inside the window — must count.
+        _tool_use_msg("2026-08-27T10:00:00Z", [("t2", "Bash", {"command": "pwd"})],
+                      usage={"input_tokens": 1_000_000, "output_tokens": 0,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0}),
+        _tool_result_msg("2026-08-27T10:01:00Z", "t2", "b"),
+    ])
+    start = datetime(2026, 8, 27, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 8, 28, 0, 0, 0, tzinfo=timezone.utc)
+
+    unbounded = parse_economics(p)
+    assert round(unbounded["cost_usd"], 2) == 10.00   # both turns count
+    assert unbounded["fg_seconds_by_tool"]["Bash"] == 300.0 + 60.0
+
+    windowed = parse_economics(p, window_start=start, window_end=end)
+    assert round(windowed["cost_usd"], 2) == 5.00      # only the in-window turn
+    assert windowed["fg_seconds_by_tool"]["Bash"] == 60.0
+
+
 def test_parse_economics_foreground_hours_exclude_backgrounded_bash():
     p = _write_economics([
         _tool_use_msg("2026-08-27T10:00:00Z", [

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -7,6 +7,7 @@ No pytest fixtures — runs under tests/run_all.py too.
 """
 import csv
 import json
+import os
 import sys
 import tempfile
 from collections import Counter
@@ -21,7 +22,7 @@ from tools.session_observer import (  # noqa: E402
     _model_rates, _open_idea_issues, _prep_item_dir, _ts, _tool_signature,
     _turn_context, _turn_cost_usd, aggregate_friction, cost_per_listing,
     economics_aggregate, economics_report, file_proposals, format_idea_issue,
-    parse_economics, parse_session, propose_fixes, report, transcripts_dir,
+    main, parse_economics, parse_session, propose_fixes, report, transcripts_dir,
 )
 
 T0 = "2026-08-27T10:00:0{}.000Z"
@@ -178,16 +179,6 @@ def test_ts_normalizes_a_naive_timestamp_to_utc():
     naive = _ts({"timestamp": "2026-08-27T10:00:00"})
     assert aware.tzinfo is not None and naive.tzinfo is not None
     assert (aware - naive).total_seconds() == 0.0
-
-
-def test_ts_returns_none_for_a_non_string_timestamp():
-    # Copilot review on PR #47: rec["timestamp"] isn't guaranteed to be a
-    # string in a malformed line — _ts() called .replace() on it directly
-    # and raised AttributeError on a number or null, breaking the "never
-    # raises on bad lines" guarantee.
-    assert _ts({"timestamp": None}) is None
-    assert _ts({"timestamp": 12345}) is None
-    assert _ts({"timestamp": ["2026-08-27T10:00:00Z"]}) is None
 
 
 def test_wall_time_does_not_raise_on_a_mixed_naive_and_aware_transcript():
@@ -653,6 +644,30 @@ def test_command_bucket_normalizes_common_repo_commands():
     assert _command_bucket("") == "(empty)"
 
 
+def test_command_bucket_strips_a_quoted_cd_prefix_containing_spaces():
+    # Windows-style quoted paths with embedded spaces used to defeat the
+    # `\S+`-only cd-prefix strip and leak the whole `cd "..." && ...` line
+    # into its own bucket instead of collapsing to the real command.
+    assert _command_bucket(
+        'cd "C:/Users/A Name/repo" && git status'
+    ) == "git status"
+    assert _command_bucket(
+        "cd '/Users/A Name/repo' && pytest tests/ -q"
+    ) == "pytest"
+
+
+def test_command_bucket_keeps_lib_cli_subcommands_distinct():
+    # A bare `python -m <module>` bucket would collapse every
+    # `python -m lib.cli <subcommand>` invocation together, hiding `prep`
+    # runs dispatched through the CLI rather than called directly.
+    assert _command_bucket(
+        "python -m lib.cli prep inventory/x --auto"
+    ) == "python -m lib.cli prep"
+    assert _command_bucket(
+        "python -m lib.cli sales-report --by-source"
+    ) == "python -m lib.cli sales-report"
+
+
 def test_prep_item_dir_extracts_across_every_invocation_form():
     assert _prep_item_dir(
         "python -m lib.photo_prep.prep inventory/sand-dollars --approve-auto"
@@ -840,3 +855,50 @@ def test_economics_report_without_ledger_env_falls_back_to_no_row_line(monkeypat
     ])
     out = economics_report([p])
     assert "no listings_ledger.csv row published in this window" in out
+
+
+def test_main_economics_derives_ledger_window_from_included_files_not_days(
+        monkeypatch, capsys):
+    # Copilot review on #94: --limit can truncate the --days-filtered file
+    # list to fewer/newer sessions than --days alone would suggest, so the
+    # ledger join window must come from the mtimes of the files actually
+    # included, not from `now - --days`. Two sessions eight months apart,
+    # --days 365 (wide enough both pass the date filter) but --limit 1
+    # (only the newer one is actually included) — the listing published
+    # only in the OLDER session's window must NOT be counted.
+    tmp = Path(tempfile.mkdtemp())
+    old_ts, new_ts = "2026-01-01T10:00:00Z", "2026-08-20T10:00:00Z"
+    usage = {"input_tokens": 1_000_000, "output_tokens": 0,
+            "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+
+    old_path = tmp / "old-session.jsonl"
+    old_path.write_text("\n".join(json.dumps(r) for r in [
+        _tool_use_msg(old_ts, [("t1", "Bash", {"command": "ls"})], usage=usage),
+        _tool_result_msg(old_ts, "t1", "a"),
+    ]), encoding="utf-8")
+    new_path = tmp / "new-session.jsonl"
+    new_path.write_text("\n".join(json.dumps(r) for r in [
+        _tool_use_msg(new_ts, [("t1", "Bash", {"command": "ls"})], usage=usage),
+        _tool_result_msg(new_ts, "t1", "a"),
+    ]), encoding="utf-8")
+
+    old_epoch = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+    new_epoch = datetime(2026, 8, 20, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+    os.utime(old_path, (old_epoch, old_epoch))
+    os.utime(new_path, (new_epoch, new_epoch))
+
+    ledger = _write_ledger([
+        {"sku": "old-only", "status": "PUBLISHED", "title": "Old widget",
+         "price": "10.00", "published_at": old_ts},
+        {"sku": "new-only", "status": "PUBLISHED", "title": "New widget",
+         "price": "20.00", "published_at": new_ts},
+    ])
+    monkeypatch.setenv("EBAYBIZ_LISTINGS_LEDGER", str(ledger))
+
+    rc = main(["--dir", str(tmp), "--economics", "--days", "365", "--limit", "1"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "1 published in window" in out
+    assert "2 published in window" not in out
+    assert "$20.00 their" in out or "20.00" in out
+    assert "$10.00 their" not in out

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -731,6 +731,43 @@ def test_parse_economics_windows_cost_and_foreground_hours_by_turn_timestamp():
     assert windowed["fg_seconds_by_tool"]["Bash"] == 60.0
 
 
+def test_parse_economics_excludes_cost_from_a_malformed_timestamp_turn():
+    # Second Copilot review pass on #94: _in_window(None, None, None) used
+    # to return True, so an assistant turn with an unparseable/missing
+    # timestamp still counted toward cost_usd in unbounded (--all) mode —
+    # inconsistent with the windowed case, where it was already excluded.
+    # A turn that can't be placed in time shouldn't be counted either way.
+    p = _write_economics([
+        {"type": "assistant", "timestamp": None,
+         "message": {"role": "assistant", "model": "claude-opus-5", "content": [
+             {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+         ], "usage": {"input_tokens": 1_000_000, "output_tokens": 0,
+                      "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}},
+        _tool_use_msg("2026-08-27T10:00:00Z", [("t2", "Bash", {"command": "pwd"})],
+                      usage={"input_tokens": 1_000_000, "output_tokens": 0,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0}),
+        _tool_result_msg("2026-08-27T10:00:01Z", "t2", "b"),
+    ])
+    unbounded = parse_economics(p)
+    assert round(unbounded["cost_usd"], 2) == 5.00   # only the well-formed turn
+
+
+def test_parse_economics_windows_foreground_hours_on_call_start_not_completion():
+    # Second Copilot review pass on #94: the window check used the
+    # tool_result's completion timestamp instead of the tool_use call's own
+    # start timestamp — a call starting just inside the window but
+    # finishing just after it must still count as that window's call.
+    p = _write_economics([
+        _tool_use_msg("2026-08-27T23:59:00Z", [("t1", "Bash", {"command": "pwd"})]),
+        _tool_result_msg("2026-08-28T00:05:00Z", "t1", "done"),   # completes AFTER the window
+    ])
+    start = datetime(2026, 8, 27, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 8, 28, 0, 0, 0, tzinfo=timezone.utc)
+    e = parse_economics(p, window_start=start, window_end=end)
+    assert e["fg_seconds_by_tool"]["Bash"] == 360.0   # counted: call STARTED in-window
+
+
 def test_parse_economics_foreground_hours_exclude_backgrounded_bash():
     p = _write_economics([
         _tool_use_msg("2026-08-27T10:00:00Z", [

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -593,8 +593,11 @@ def cost_per_listing(total_cost_usd: float, ledger_rows: list,
 
 
 def _in_window(ts, window_start, window_end) -> bool:
+    """A malformed/missing timestamp can't be reliably placed in any
+    window — bounded or not — so it's always excluded, never counted as
+    "in an unbounded window" by default."""
     if ts is None:
-        return window_start is None and window_end is None
+        return False
     if window_start is not None and ts < window_start:
         return False
     if window_end is not None and ts > window_end:
@@ -697,7 +700,11 @@ def parse_economics(path: Path, *, window_start=None, window_end=None) -> dict:
                     # Bash/PowerShell call that opted into run_in_background.
                     backgrounded = (name in ("Bash", "PowerShell")
                                     and bool(inp.get("run_in_background")))
-                    if not backgrounded and _in_window(when, window_start, window_end):
+                    # Windowed on the call's OWN (start) timestamp, not its
+                    # completion time — a long call starting just inside the
+                    # window but finishing just after it is still that
+                    # window's call, matching the docstring's contract.
+                    if not backgrounded and _in_window(st, window_start, window_end):
                         fg_seconds_by_tool[name] += secs
                         if name in ("Bash", "PowerShell"):
                             fg_seconds_by_command[

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -202,13 +202,15 @@ def _tool_signature(name: str, inp: dict) -> str:
     return name
 
 
-_CD_PREFIX = re.compile(r"^cd\s+\S+\s*&&\s*")
+_CD_PREFIX = re.compile(r'^cd\s+(?:"[^"]*"|\'[^\']*\'|\S+)\s*&&\s*')
 
 # A Bash command collapsed to a stable "repo command" bucket — the shape
 # #61/#71's manual command tallies used by hand. Ordered most-specific first
 # so e.g. `python -m lib.cli prep ...` doesn't fall through to a bare
 # `python -m` bucket before its own pattern gets a look.
 _CMD_BUCKETS = [
+    (re.compile(r"^python3?\s+-m\s+lib\.cli\s+(\S+)"),
+     lambda m: f"python -m lib.cli {m.group(1)}"),
     (re.compile(r"^python3?\s+-m\s+(\S+)"), lambda m: f"python -m {m.group(1)}"),
     (re.compile(r"^python3?\s+((?:tools|lib)/\S+\.py)"), lambda m: f"python {m.group(1)}"),
     (re.compile(r"^pytest\b"), lambda m: "pytest"),
@@ -1076,9 +1078,18 @@ def main(argv=None) -> int:
         return 0
 
     if args.economics:
-        now = datetime.now(timezone.utc)
-        window_start = None if args.all else now - timedelta(days=args.days)
-        print(economics_report(files, window_start=window_start, window_end=now))
+        if args.all:
+            window_start = window_end = None
+        else:
+            # Derived from the mtimes of the *actually included* session
+            # files, not from --days alone — --limit can truncate `files`
+            # to fewer/newer sessions than the --days cutoff would suggest,
+            # and the ledger join must match spend against the same window
+            # the spend was measured over.
+            mtimes = [datetime.fromtimestamp(os.path.getmtime(f), timezone.utc)
+                     for f in files]
+            window_start, window_end = min(mtimes), max(mtimes)
+        print(economics_report(files, window_start=window_start, window_end=window_end))
         return 0
 
     if args.propose:

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -42,6 +42,7 @@ looks the same as walking away.
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import os
 import re
@@ -94,6 +95,54 @@ STAGES = {
     "DEV":      ("git ", "gh ", "commit", "branch", "test", "refactor", "bug",
                  "pytest", "tests/", "lib/", "tools/"),
 }
+
+
+# $/1M tokens (input, output) — first-party API rates. Matched by longest
+# known model-id prefix so a future dated variant of a listed model still
+# resolves. Cache write/read aren't priced per model in the pricing table;
+# they scale off the input rate at the standard Anthropic multipliers
+# (~1.25x to write, ~0.1x to read) rather than a second table to keep in
+# sync. An unrecognized model (a future release, a proxied name) falls back
+# to DEFAULT_PRICING rather than costing $0 — "approximately right" beats
+# "silently free" for a report whose whole point is catching overspend.
+MODEL_PRICING = {
+    "claude-opus-5": (5.00, 25.00),
+    "claude-mythos-5": (10.00, 50.00),
+    "claude-mythos-preview": (10.00, 50.00),
+    "claude-fable-5": (10.00, 50.00),
+    "claude-opus-4-8": (5.00, 25.00),
+    "claude-opus-4-7": (5.00, 25.00),
+    "claude-opus-4-6": (5.00, 25.00),
+    "claude-sonnet-5": (2.00, 10.00),
+    "claude-sonnet-4-6": (3.00, 15.00),
+    "claude-haiku-4-5": (1.00, 5.00),
+}
+DEFAULT_PRICING = (3.00, 15.00)   # unrecognized model: mid-tier fallback rate
+CACHE_WRITE_MULT = 1.25
+CACHE_READ_MULT = 0.10
+
+
+def _model_rates(model) -> tuple:
+    if isinstance(model, str):
+        for prefix in sorted(MODEL_PRICING, key=len, reverse=True):
+            if model.startswith(prefix):
+                return MODEL_PRICING[prefix]
+    return DEFAULT_PRICING
+
+
+def _turn_cost_usd(usage: dict, model) -> float:
+    """One assistant turn's $ cost from its own usage block — #71 §7's
+    '$ per published listing' needs a dollar figure and the observer only
+    ever tracked tokens before this."""
+    in_rate, out_rate = _model_rates(model)
+    input_tok = usage.get("input_tokens") or 0
+    output_tok = usage.get("output_tokens") or 0
+    cache_w = usage.get("cache_creation_input_tokens") or 0
+    cache_r = usage.get("cache_read_input_tokens") or 0
+    return (input_tok * in_rate
+            + output_tok * out_rate
+            + cache_w * in_rate * CACHE_WRITE_MULT
+            + cache_r * in_rate * CACHE_READ_MULT) / 1_000_000
 
 
 def transcripts_dir(repo: Path) -> Path:
@@ -151,6 +200,61 @@ def _tool_signature(name: str, inp: dict) -> str:
         if isinstance(v, str) and v.strip():
             return f"{name}:{' '.join(v.split())[:160]}"
     return name
+
+
+_CD_PREFIX = re.compile(r"^cd\s+\S+\s*&&\s*")
+
+# A Bash command collapsed to a stable "repo command" bucket — the shape
+# #61/#71's manual command tallies used by hand. Ordered most-specific first
+# so e.g. `python -m lib.cli prep ...` doesn't fall through to a bare
+# `python -m` bucket before its own pattern gets a look.
+_CMD_BUCKETS = [
+    (re.compile(r"^python3?\s+-m\s+(\S+)"), lambda m: f"python -m {m.group(1)}"),
+    (re.compile(r"^python3?\s+((?:tools|lib)/\S+\.py)"), lambda m: f"python {m.group(1)}"),
+    (re.compile(r"^pytest\b"), lambda m: "pytest"),
+    (re.compile(r"^git\s+(\S+)"), lambda m: f"git {m.group(1)}"),
+    (re.compile(r"^gh\s+(\S+)(?:\s+(\S+))?"),
+     lambda m: f"gh {m.group(1)}" + (f" {m.group(2)}" if m.group(2) else "")),
+    (re.compile(r"^ebz\s+(\S+)"), lambda m: f"ebz {m.group(1)}"),
+]
+
+
+def _command_bucket(command: str) -> str:
+    """Collapse a Bash command to a repo-command bucket for the foreground
+    blocking hours breakdown: 'python -m lib.photo_prep.prep', 'pytest',
+    'git status' — a `cd ... &&` prefix or trailing flags don't change it."""
+    cmd = _CD_PREFIX.sub("", (command or "").strip()).strip()
+    if not cmd:
+        return "(empty)"
+    for pattern, fmt in _CMD_BUCKETS:
+        m = pattern.match(cmd)
+        if m:
+            return fmt(m)
+    return cmd.split()[0]
+
+
+# The three shapes a PREP run reaches lib/photo_prep/prep.py's main() by:
+# the module directly, through the `ebz`/`lib.cli` dispatcher, or the
+# tools/ path some older docs still show. All three take the shoot dir as
+# their first positional argument (lib/photo_prep/prep.py: `ap.add_argument
+# ("shoot_dir")`).
+PREP_INVOCATION = re.compile(
+    r"(?:python3?\s+-m\s+lib\.photo_prep\.prep|python3?\s+-m\s+lib\.cli\s+prep|"
+    r"python3?\s+tools/prep(?:_run)?\.py|\bebz\s+prep)\b(.*)$"
+)
+
+
+def _prep_item_dir(command: str):
+    """The shoot/item directory argument to a `prep` invocation, or None
+    when the command isn't one (#71 §7: re-runs per item for `prep`)."""
+    cmd = _CD_PREFIX.sub("", (command or "").strip())
+    m = PREP_INVOCATION.search(cmd)
+    if not m:
+        return None
+    for tok in m.group(1).split():
+        if not tok.startswith("-"):
+            return tok
+    return None
 
 
 def _classify(blob: str) -> str:
@@ -419,6 +523,73 @@ def _turn_context(usage: dict) -> int:
             + (usage.get("cache_read_input_tokens") or 0))
 
 
+def _ledger_path() -> Path:
+    """Same resolution order as lib/list_edit.py's _ledger_path(): explicit
+    env override first (also how tests point this at a synthetic ledger),
+    else <repo>/listings_ledger.csv."""
+    env = os.environ.get("EBAYBIZ_LISTINGS_LEDGER") or os.environ.get("EBAYBIZ_LISTINGS_LOG")
+    return Path(env) if env else REPO / "listings_ledger.csv"
+
+
+def _ledger_rows() -> list:
+    path = _ledger_path()
+    if not path.exists():
+        return []
+    with path.open(newline="", encoding="utf-8-sig") as fh:
+        return list(csv.DictReader(fh))
+
+
+def _money(raw) -> float:
+    try:
+        return float(str(raw).replace("$", "").replace(",", "").strip())
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _parse_ledger_ts(raw: str):
+    """Same UTC-normalization idiom as _ts() above and _date() in
+    tools/sales_report.py: a ledger timestamp with no offset means UTC."""
+    if not raw:
+        return None
+    try:
+        t = datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return t if t.tzinfo else t.replace(tzinfo=timezone.utc)
+
+
+def cost_per_listing(total_cost_usd: float, ledger_rows: list,
+                     window_start, window_end) -> dict:
+    """#71 §7: total model spend against listings actually PUBLISHED in the
+    same window, joined on `published_at` — the batch ratio the audit
+    measured (3-day window: ~$2,990 spend / 43 published listings =
+    ~$69.55/listing, spend exceeding the $1,728.84 those listings were
+    worth at ask), not a per-listing session attribution — there isn't one.
+
+    `window_start`/`window_end` are `None` for an unbounded (--all) window.
+    """
+    published = []
+    for r in ledger_rows:
+        ts = _parse_ledger_ts((r.get("published_at") or "").strip())
+        if ts is None:
+            continue
+        if window_start is not None and ts < window_start:
+            continue
+        if window_end is not None and ts > window_end:
+            continue
+        published.append(r)
+    n = len(published)
+    total_list_price = sum(_money(r.get("price")) for r in published)
+    return {
+        "total_cost_usd": total_cost_usd,
+        "n_published": n,
+        "total_list_price": total_list_price,
+        "cost_per_listing": (total_cost_usd / n) if n else None,
+        "cost_to_list_price_ratio": (total_cost_usd / total_list_price)
+                                    if total_list_price else None,
+    }
+
+
 def parse_economics(path: Path) -> dict:
     """One session's #61-style run economics: context/turn, tool-call
     batching, Read payload by extension, backgrounding, and gate wall-clock
@@ -437,6 +608,11 @@ def parse_economics(path: Path) -> dict:
     ask_count: Counter = Counter()
     ask_wait: Counter = Counter()
     pending: dict = {}   # tool_use_id -> (ts, name, input)
+    cost_usd = 0.0
+    model = None
+    fg_seconds_by_tool: Counter = Counter()
+    fg_seconds_by_command: Counter = Counter()
+    prep_calls: Counter = Counter()      # item/shoot dir -> `prep` invocations
 
     with path.open(encoding="utf-8", errors="replace") as fh:
         for line in fh:
@@ -453,6 +629,8 @@ def parse_economics(path: Path) -> dict:
 
             if kind == "assistant":
                 msg = rec.get("message") or {}
+                model = msg.get("model") or model
+                cost_usd += _turn_cost_usd(msg.get("usage") or {}, model)
                 blocks = [b for b in (msg.get("content") or [])
                           if isinstance(b, dict) and b.get("type") == "tool_use"]
                 if blocks:
@@ -472,6 +650,9 @@ def parse_economics(path: Path) -> dict:
                         bash_total += 1
                         if inp.get("run_in_background"):
                             bg_bash += 1
+                        item = _prep_item_dir(str(inp.get("command") or ""))
+                        if item:
+                            prep_calls[item] += 1
                     elif name == "AskUserQuestion":
                         for q in (inp.get("questions") or []):
                             ask_count[(q.get("header") or "?")[:24]] += 1
@@ -486,13 +667,23 @@ def parse_economics(path: Path) -> dict:
                     st, name, inp = pending.pop(b.get("tool_use_id"), (None, None, {}))
                     if not (st and when and name):
                         continue
+                    secs = (when - st).total_seconds()
+                    # Foreground blocking hours by tool + repo command (#71
+                    # §7): every tool call blocks the turn UNLESS it's a
+                    # Bash/PowerShell call that opted into run_in_background.
+                    backgrounded = (name in ("Bash", "PowerShell")
+                                    and bool(inp.get("run_in_background")))
+                    if not backgrounded:
+                        fg_seconds_by_tool[name] += secs
+                        if name in ("Bash", "PowerShell"):
+                            fg_seconds_by_command[
+                                _command_bucket(str(inp.get("command") or ""))] += secs
                     if name == "Read":
                         body = b.get("content")
                         sz = len(json.dumps(body)) if body is not None else 0
                         ext = Path(str(inp.get("file_path") or "")).suffix.lower() or "(none)"
                         read_bytes[ext] += sz
                         continue
-                    secs = (when - st).total_seconds()
                     if name in ("Bash", "PowerShell") and secs > 30:
                         bash_over30 += 1
                         bash_over30_secs += secs
@@ -508,6 +699,10 @@ def parse_economics(path: Path) -> dict:
         "bash_total": bash_total, "bg_bash": bg_bash,
         "bash_over30": bash_over30, "bash_over30_secs": bash_over30_secs,
         "ask_count": dict(ask_count), "ask_wait_secs": dict(ask_wait),
+        "cost_usd": cost_usd,
+        "fg_seconds_by_tool": dict(fg_seconds_by_tool),
+        "fg_seconds_by_command": dict(fg_seconds_by_command),
+        "prep_calls": dict(prep_calls),
     }
 
 
@@ -522,6 +717,10 @@ def economics_aggregate(paths: list[Path]) -> dict:
     bash_over30_secs = 0.0
     ask_count: Counter = Counter()
     ask_wait: Counter = Counter()
+    cost_usd = 0.0
+    fg_seconds_by_tool: Counter = Counter()
+    fg_seconds_by_command: Counter = Counter()
+    prep_calls: Counter = Counter()
 
     for p in paths:
         e = parse_economics(p)
@@ -536,6 +735,10 @@ def economics_aggregate(paths: list[Path]) -> dict:
         bash_over30_secs += e["bash_over30_secs"]
         ask_count.update(e["ask_count"])
         ask_wait.update(e["ask_wait_secs"])
+        cost_usd += e["cost_usd"]
+        fg_seconds_by_tool.update(e["fg_seconds_by_tool"])
+        fg_seconds_by_command.update(e["fg_seconds_by_command"])
+        prep_calls.update(e["prep_calls"])
 
     return {
         "n_sessions": len(paths), "total_turns": total_turns,
@@ -545,12 +748,23 @@ def economics_aggregate(paths: list[Path]) -> dict:
         "bash_total": bash_total, "bg_bash": bg_bash,
         "bash_over30": bash_over30, "bash_over30_secs": bash_over30_secs,
         "ask_count": dict(ask_count), "ask_wait_secs": dict(ask_wait),
+        "cost_usd": cost_usd,
+        "fg_seconds_by_tool": dict(fg_seconds_by_tool),
+        "fg_seconds_by_command": dict(fg_seconds_by_command),
+        "prep_calls": dict(prep_calls),
     }
 
 
-def economics_report(paths: list[Path]) -> str:
+def economics_report(paths: list[Path], *, window_start=None, window_end=None) -> str:
     """Aggregate `parse_economics` across sessions into the #61 headline
-    table — the standing version of `.scratch/analyze{,2,3,4}.py`."""
+    table — the standing version of `.scratch/analyze{,2,3,4}.py` — plus
+    the three #71 §7 cost lines: $/published listing (joined to
+    `listings_ledger.csv` on `published_at`), foreground blocking hours by
+    tool and by repo command, and `prep` re-runs per item.
+
+    `window_start`/`window_end` bound the ledger join to the same window
+    `paths` was already filtered to (None/None for an unbounded --all run —
+    every published row counts)."""
     agg = economics_aggregate(paths)
     s = agg["context_per_turn"]
     all_tools = agg["tools_per_turn"]
@@ -580,6 +794,38 @@ def economics_report(paths: list[Path]) -> str:
         out.append("  AskUserQuestion wait by gate:")
         for h, secs in sorted(ask_wait.items(), key=lambda kv: -kv[1])[:8]:
             out.append(f"    {ask_count.get(h, 0):>3}  {secs / 3600:>6.1f}h  {h}")
+
+    if agg["cost_usd"]:
+        out.append(f"  model spend (est.): ${agg['cost_usd']:,.2f}")
+        cpl = cost_per_listing(agg["cost_usd"], _ledger_rows(), window_start, window_end)
+        if cpl["n_published"]:
+            ratio = (f", {cpl['cost_to_list_price_ratio']:.2f}x their ${cpl['total_list_price']:,.2f} "
+                     f"list price" if cpl["cost_to_list_price_ratio"] else "")
+            out.append(f"  $/published listing: ${cpl['cost_per_listing']:,.2f}  "
+                       f"({cpl['n_published']} published in window{ratio})")
+        else:
+            out.append("  $/published listing: no listings_ledger.csv row published in this window")
+
+    fg_tool = agg["fg_seconds_by_tool"]
+    if fg_tool:
+        out.append("  Foreground blocking hours by tool:")
+        for name, secs in sorted(fg_tool.items(), key=lambda kv: -kv[1])[:8]:
+            out.append(f"    {secs / 3600:>6.1f}h  {name}")
+
+    fg_cmd = agg["fg_seconds_by_command"]
+    if fg_cmd:
+        out.append("  Foreground blocking hours by repo command:")
+        for cmd, secs in sorted(fg_cmd.items(), key=lambda kv: -kv[1])[:8]:
+            out.append(f"    {secs / 3600:>6.1f}h  {cmd}")
+
+    prep_calls = agg["prep_calls"]
+    if prep_calls:
+        reruns = {k: v for k, v in prep_calls.items() if v > 1}
+        out.append(f"  prep re-runs: {sum(prep_calls.values())} invocation(s) across "
+                   f"{len(prep_calls)} item dir(s), {len(reruns)} re-run 2+ times")
+        for item, n in sorted(prep_calls.items(), key=lambda kv: (-kv[1], kv[0]))[:8]:
+            if n > 1:
+                out.append(f"    {n:>3}x  {item}")
     return "\n".join(out)
 
 
@@ -830,7 +1076,9 @@ def main(argv=None) -> int:
         return 0
 
     if args.economics:
-        print(economics_report(files))
+        now = datetime.now(timezone.utc)
+        window_start = None if args.all else now - timedelta(days=args.days)
+        print(economics_report(files, window_start=window_start, window_end=now))
         return 0
 
     if args.propose:

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -592,13 +592,34 @@ def cost_per_listing(total_cost_usd: float, ledger_rows: list,
     }
 
 
-def parse_economics(path: Path) -> dict:
+def _in_window(ts, window_start, window_end) -> bool:
+    if ts is None:
+        return window_start is None and window_end is None
+    if window_start is not None and ts < window_start:
+        return False
+    if window_end is not None and ts > window_end:
+        return False
+    return True
+
+
+def parse_economics(path: Path, *, window_start=None, window_end=None) -> dict:
     """One session's #61-style run economics: context/turn, tool-call
     batching, Read payload by extension, backgrounding, and gate wall-clock
     by header. A separate pass from parse_session's friction walk on
     purpose — it answers "what did this session cost", not "what went
     wrong", and bolting a second question onto the six-signal walk risks
-    the signals that walk already locks down."""
+    the signals that walk already locks down.
+
+    `window_start`/`window_end` (both None by default = unbounded, matching
+    prior behavior) bound `cost_usd` and the `fg_seconds_by_*` dicts to
+    turns whose OWN timestamp falls in the window — file-mtime selection
+    alone isn't enough for a long-lived/resumed session (#71 §5: sessions
+    spanning hundreds of hours), which would otherwise have turns from
+    outside the requested window counted toward $/published-listing and
+    foreground-hours totals for that window. The structural counters
+    (context/turn, tool-call shape, read payload, bash/backgrounding
+    counts) stay file-level — they describe session shape, not a
+    window-scoped cost, and #71 didn't flag them as skewed."""
     context_per_turn: list[int] = []
     tools_per_turn: list[int] = []
     same_tool_adjacent = 0
@@ -632,7 +653,8 @@ def parse_economics(path: Path) -> dict:
             if kind == "assistant":
                 msg = rec.get("message") or {}
                 model = msg.get("model") or model
-                cost_usd += _turn_cost_usd(msg.get("usage") or {}, model)
+                if _in_window(when, window_start, window_end):
+                    cost_usd += _turn_cost_usd(msg.get("usage") or {}, model)
                 blocks = [b for b in (msg.get("content") or [])
                           if isinstance(b, dict) and b.get("type") == "tool_use"]
                 if blocks:
@@ -675,7 +697,7 @@ def parse_economics(path: Path) -> dict:
                     # Bash/PowerShell call that opted into run_in_background.
                     backgrounded = (name in ("Bash", "PowerShell")
                                     and bool(inp.get("run_in_background")))
-                    if not backgrounded:
+                    if not backgrounded and _in_window(when, window_start, window_end):
                         fg_seconds_by_tool[name] += secs
                         if name in ("Bash", "PowerShell"):
                             fg_seconds_by_command[
@@ -708,9 +730,14 @@ def parse_economics(path: Path) -> dict:
     }
 
 
-def economics_aggregate(paths: list[Path]) -> dict:
+def economics_aggregate(paths: list[Path], *, window_start=None, window_end=None) -> dict:
     """`parse_economics` summed across sessions — the numbers both
-    `economics_report()` and `propose_fixes()` read, computed once."""
+    `economics_report()` and `propose_fixes()` read, computed once.
+
+    `window_start`/`window_end` pass straight through to `parse_economics`
+    (see its docstring) — the cost/foreground-hour totals only reflect
+    turns whose own timestamp falls in the window, not every turn in every
+    file that happened to be selected by mtime."""
     all_ctx: list[int] = []
     all_tools: list[int] = []
     same_tool_adjacent = total_turns = 0
@@ -725,7 +752,7 @@ def economics_aggregate(paths: list[Path]) -> dict:
     prep_calls: Counter = Counter()
 
     for p in paths:
-        e = parse_economics(p)
+        e = parse_economics(p, window_start=window_start, window_end=window_end)
         all_ctx.extend(e["context_per_turn"])
         all_tools.extend(e["tools_per_turn"])
         same_tool_adjacent += e["same_tool_adjacent"]
@@ -764,10 +791,11 @@ def economics_report(paths: list[Path], *, window_start=None, window_end=None) -
     `listings_ledger.csv` on `published_at`), foreground blocking hours by
     tool and by repo command, and `prep` re-runs per item.
 
-    `window_start`/`window_end` bound the ledger join to the same window
-    `paths` was already filtered to (None/None for an unbounded --all run —
-    every published row counts)."""
-    agg = economics_aggregate(paths)
+    `window_start`/`window_end` bound both the cost/foreground-hour turn
+    accumulation (see `parse_economics`) and the ledger join to the same
+    window `paths` was already filtered to (None/None for an unbounded
+    --all run — every turn and every published row counts)."""
+    agg = economics_aggregate(paths, window_start=window_start, window_end=window_end)
     s = agg["context_per_turn"]
     all_tools = agg["tools_per_turn"]
     total_turns = agg["total_turns"]


### PR DESCRIPTION
## Context

#71 is a large "run economics" audit — 3-day window: 43 listings published, $1,728.84 total list value, ~$2,990 model spend in the same window (spend exceeding list value), PREP invoked 283 times across 47 distinct item dirs (~6 re-runs/item, 6.1h foreground blocking). Its recommendations largely restate #61/#62/#74 (prompts/_shared.md runtime-discipline rules, RUN.md's concurrency/delegation section, prep.py incremental re-render) — already tracked by open PRs #63 and #64, or covered by a sibling PR working #74's cheap fixes (permission allowlist, backgrounding rules doc, prep-resume plan doc). This PR does not touch any of that.

**Addresses part of #71** — specifically its §7 "What to actually change" ask for `tools/session_observer.py`: the three cost lines the audit needed and the observer didn't yet print. It currently reports `tool_error`, `long_loop`, `repeat`, `redo`, `interrupt` counts (the friction signals) plus a `--economics` mode (context/turn, Read payload, Bash backgrounding, gate wait). This PR adds:

1. **$ per published listing** — a new per-model $/1M-token pricing table (Opus/Sonnet/Haiku tiers, standard cache write/read multipliers) prices each assistant turn's usage, summed per session and across the observed window, then joined to `listings_ledger.csv` on `published_at` (rows inside the window only). Reports total spend / listings published, and the ratio to their total list `price` when available.
2. **Foreground blocking hours by tool and by repo command** — every tool call *not* flagged `run_in_background`, summed by tool name, and (for Bash/PowerShell) by a normalized command bucket (`python -m lib.photo_prep.prep`, `pytest`, `git status`, `gh pr create`, `ebz prep`, ...).
3. **Re-runs per item for `prep`** — counts `python -m lib.photo_prep.prep` invocations (plus its `python -m lib.cli prep` / `ebz prep` equivalents) per distinct shoot/item directory argument within the window, surfacing the worst repeat offenders.

All three print under `ebz observe --economics`, in the existing table style, alongside the current context/turn and gate-wait numbers.

## Why here, not `propose_fixes`

These are new *measurements*, not new threshold-gated proposals — `propose_fixes()` (the #36 stage-2a ranked-fix generator) is untouched, so its existing tests keep passing unmodified. A follow-up can wire prep-rerun/blocking-hour thresholds into `propose_fixes` once there's a sense of what a good threshold looks like in practice.

## Testing

- `python -m pytest tests/ -q` — 477 passed, 1 pre-existing skip, no regressions.
- 16 new tests in `tests/test_session_observer.py` cover: model pricing lookup + fallback, per-turn $ computation (input/output/cache-write/cache-read), the Bash command-bucketing helper, `prep` invocation/item-dir parsing across its three call shapes, foreground-hours accumulation (including that a backgrounded Bash call is excluded and every tool — not just Bash — counts), prep re-run counting per item dir, `cost_per_listing`'s ledger join (in-window / out-of-window / unpublished / zero-list-price edge cases), and an end-to-end `economics_report()` rendering check.
- Manually smoke-tested the CLI (`python tools/session_observer.py --dir <synthetic transcripts> --all --economics`) against a synthetic transcript with two `prep` re-runs on the same item dir — output matches the intended format (see commit for a sample).

## Out of scope (intentionally)

- prep.py incremental re-render (tracked in the sibling #74 PR's plan doc)
- prompts/_shared.md runtime discipline (PR #63)
- RUN.md concurrency/delegation section (PR #64)
- the optional "one session per batch" doc note #71 suggests — low priority, left out to keep this PR to the one concrete ask

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnrWxtKQStiTx1qFkqc5sm)_