### PR TITLE
feat(prep): atomic writes + incremental checkpointing + --resume (#74 item 3)

### DIFF
--- a/docs/prep-resume-plan.md
+++ b/docs/prep-resume-plan.md
@@ -1,10 +1,15 @@
 # PREP `--resume` / `--jobs N` — implementation plan (#74 item 3)
 
-**Status: plan only. `lib/photo_prep/prep.py` is unmodified by this doc.**
-This is deliberately scoped as design, not code — it touches the production
-photo pipeline and #74 asked for a well-scoped follow-up rather than more
-analysis bundled into a friction-fixes PR. The next PR should implement
-against this plan (or an amended version of it), not restart the analysis.
+**Status: steps 1–3 of "Suggested follow-up PR shape" (below) are implemented**
+— atomic `_save_bgr` writes, incremental per-frame checkpointing, and
+`--resume` with the settings-hash/staleness check, all in `run_apply()`.
+**Step 4 (`--jobs N` / `ProcessPoolExecutor`) is still just a plan** —
+deliberately deferred, because it wants a real peak-RSS measurement at
+`--jobs 4` on a representative shoot before a default worker count is picked
+(see that section below), which is future work, not something to guess at
+in the same PR. The rest of this document is left as originally written;
+only this status line and the follow-up section's step numbering reflect
+what has since shipped.
 
 ## The problem, precisely
 
@@ -204,14 +209,17 @@ disjoint from every other frame's.
 
 ## Suggested follow-up PR shape
 
-1. Atomic `_save_bgr` write (small, low-risk, independently useful even
+1. ✅ Atomic `_save_bgr` write (small, low-risk, independently useful even
    without the rest).
-2. Incremental checkpointing in `run_apply` (move `save_manifest` inside the
+2. ✅ Incremental checkpointing in `run_apply` (move `save_manifest` inside the
    loop) — makes a killed `--apply` at least leave a *consistent* partial
    manifest, before `--resume` exists to exploit it.
-3. `--resume` flag + the settings-hash/staleness check.
-4. `--jobs N` + `ProcessPoolExecutor`, gated behind a real memory
-   measurement for the default.
+3. ✅ `--resume` flag + the settings-hash/staleness check.
+4. ⬜ **Still pending.** `--jobs N` + `ProcessPoolExecutor`, gated behind a
+   real memory measurement for the default. Not implemented by the PR that
+   shipped 1–3 (#74 item 3 follow-up) — it explicitly stayed out of scope
+   because a memory measurement is a prerequisite this repo isn't yet in a
+   position to gather, not something to bake a guess for into a PR.
 
 Each step is independently mergeable and independently useful — 1–2 alone
 fix the "partial manifest is inconsistent with partial renders" half of the

--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -1064,6 +1064,17 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
     # goes -- six looks at ~25s a frame on 12 MP, five of which a printed
     # shoot will never open. See photo_prep.categories.
     only = tuple(only) or catmod.looks_for(category_of(m))
+    # catmod.looks_for()'s own convention: an empty tuple is a sentinel for
+    # "render every preset in colormod.PRESETS", not "render nothing" --
+    # the same sentinel the per-frame render loop below resolves via
+    # `only or colormod.PRESETS`. Resolve it to the concrete list HERE,
+    # before it feeds settings_hash / _frame_is_resumable, so a hash or a
+    # staleness check can never be computed against an empty preset set
+    # while the render loop actually produces the full one (Copilot review
+    # fix on #96 -- a category with no explicit `looks` would otherwise
+    # hash/resume against zero presets and --resume could wrongly skip a
+    # frame that only has some, or none, of the actually-required presets).
+    only = only or tuple(colormod.PRESETS)
 
     # A fingerprint of the inputs that decide what gets rendered, captured
     # against what was on disk BEFORE this call overwrites it -- so a

--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -1086,6 +1086,13 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
     m["approved"] = False
     m["approved_at"] = None
 
+    # Persist BOTH of the above before rendering a single frame. Otherwise a
+    # process killed during frame 1 (the main failure mode this whole change
+    # targets) leaves the on-disk manifest showing a stale `apply_run` from
+    # the PREVIOUS apply, and possibly `approved: true` -- exactly the state
+    # the checks above exist to rule out, just not yet written down.
+    save_manifest(shoot, m)
+
     out_dir = shoot / "listing"
     out_dir.mkdir(exist_ok=True)
     rows = []
@@ -1110,6 +1117,17 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
             variants = {pname: _load_bgr(shoot / rec["presets"][pname]["path"])
                         for pname in only}
             rows.append((name, before, variants, rec))
+            # A skipped frame's exceptions are exactly as real as a freshly
+            # rendered one's -- reuse the same flag logic below, sourced from
+            # the persisted record instead of a report just computed, so
+            # verdict_emit doesn't read a resumed run as cleaner than it is.
+            c = rec.get("color") or {}
+            if c.get("subject_newly_clipped") or c.get("subject_newly_crushed"):
+                flags.append((name, f"colour pass touched item pixels "
+                                    f"(new-clip={c.get('subject_newly_clipped')}, "
+                                    f"new-crush={c.get('subject_newly_crushed')})"))
+            if rec["orientation"]["needs_ask"]:
+                flags.append((name, "orientation still ASK"))
             continue
 
         before = _load_bgr(src)

--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -128,11 +128,31 @@ def _load_bgr(path: Path) -> np.ndarray:
 
 
 def _save_bgr(path: Path, bgr: np.ndarray, quality: int = 94) -> None:
+    """Encode and write, atomically.
+
+    Same tmp-and-rename shape `save_manifest` already uses, for the same
+    reason: a killed process must never leave a plausible-looking truncated
+    JPEG at the real path. `--resume`'s staleness check (docs/prep-resume-
+    plan.md item 2) trusts "the file exists with the recorded hash" as proof
+    a render finished; a straight write to the target path could instead
+    leave a file that exists, matches nothing, but LOOKS like a finished
+    render until something re-hashes it.
+    """
     import cv2
     ok, buf = cv2.imencode(".jpg", bgr, [cv2.IMWRITE_JPEG_QUALITY, quality])
     if not ok:
         raise RuntimeError(f"could not encode {path}")
-    buf.tofile(str(path))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        buf.tofile(str(tmp))
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
 
 
 def _subject_region(bgr: np.ndarray, bbox: tuple, pad: float = 0.04) -> np.ndarray:
@@ -163,6 +183,24 @@ def _sha256(path: Path) -> str:
         for chunk in iter(lambda: f.read(1 << 20), b""):
             h.update(chunk)
     return h.hexdigest()[:16]
+
+
+def _apply_settings_hash(aspect, pad: float, pop: str, subject: str,
+                         category: str, only) -> str:
+    """Fingerprint of the inputs that decide what `--apply` renders.
+
+    Same truncated-sha256 convention as `_sha256()`/`_manifest_fingerprint()`
+    -- 16 hex chars, not a full digest. Stored as `apply_run.settings_hash`
+    (docs/prep-resume-plan.md item 2) so a later `--resume` can tell "this is
+    an answer to the question I'm asking" from "this answered a different
+    one" -- a changed aspect, pad, pop, subject, category or preset set means
+    the old renders don't answer this invocation's question, exactly like a
+    geometry/category change already invalidates crop/colour sign-off
+    elsewhere in this file.
+    """
+    payload = json.dumps([aspect, pad, pop, subject, category,
+                          sorted(only)], sort_keys=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
 def _now() -> str:
@@ -953,7 +991,33 @@ def _already_listed(shoot: Path) -> bool:
     return False
 
 
-def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
+def _frame_is_resumable(shoot: Path, name: str, rec: dict, only: tuple) -> bool:
+    """Whether an already-rendered frame can be reused under `--resume`.
+
+    Conservative by construction (docs/prep-resume-plan.md item 2): every
+    condition below must hold, or the frame is treated as not done and
+    re-rendered. Over-rendering wastes time; a stale render shipping wastes
+    a lot more. The settings-hash check (whether THIS invocation is asking
+    the same question the cached render answered) is the caller's job — it
+    is per-run, not per-frame, so it is checked once and passed down as
+    already-satisfied rather than re-checked here.
+    """
+    src = shoot / name
+    if not src.exists() or _sha256(src) != rec.get("src_sha256"):
+        return False
+    presets = rec.get("presets") or {}
+    for pname in only:
+        entry = presets.get(pname)
+        if not entry or not entry.get("path"):
+            return False
+        p_path = shoot / entry["path"]
+        if not p_path.exists() or _sha256(p_path) != entry.get("sha256"):
+            return False
+    return True
+
+
+def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
+              resume: bool = False) -> dict:
     """Render listing/ from the manifest's decisions + the review sheet.
 
     `only` restricts which presets are rendered. The default category now
@@ -965,6 +1029,14 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
     ~64s per frame per preset, that comparison is expensive on purpose to skip
     by default — it is the difference between a 3-hour run and a 17-hour one on
     a batch that was never going to look at five of the six looks anyway.
+
+    `resume` (default off; omitting it reproduces today's behaviour exactly)
+    skips a frame's re-render only when the manifest's own record proves the
+    existing render still answers THIS invocation's question — see
+    docs/prep-resume-plan.md item 3. The manifest is also checkpointed after
+    every frame instead of once at the end (item 1), so a run killed by a
+    timeout leaves a consistent partial manifest a later `--resume` can trust,
+    instead of orphaning every already-rendered JPEG.
     """
     from .center_crop import _parse_aspect
 
@@ -993,6 +1065,27 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
     # shoot will never open. See photo_prep.categories.
     only = tuple(only) or catmod.looks_for(category_of(m))
 
+    # A fingerprint of the inputs that decide what gets rendered, captured
+    # against what was on disk BEFORE this call overwrites it -- so a
+    # resumed run's own checkpoint can never trivially match itself, only a
+    # PRIOR run's, under the same settings, can (docs/prep-resume-plan.md
+    # item 2). `resume=False` (the default) never consults it: `resumable`
+    # stays False and every frame renders exactly as it always has.
+    settings_hash = _apply_settings_hash(aspect, pad, pop, smode,
+                                         category_of(m), only)
+    prior_settings_hash = (m.get("apply_run") or {}).get("settings_hash")
+    resumable = resume and prior_settings_hash == settings_hash
+    m["apply_run"] = {"settings_hash": settings_hash, "started_at": _now()}
+
+    # An apply in flight -- or interrupted mid-flight -- is not an approved
+    # one. Set this BEFORE the loop, not after, so every checkpoint below
+    # already reflects it: a resumed frame's untouched `output`/`out_sha256`
+    # would otherwise still look complete enough to slip past
+    # `assert_approved` on a stale `approved: true` left over from the run
+    # this one is replacing.
+    m["approved"] = False
+    m["approved_at"] = None
+
     out_dir = shoot / "listing"
     out_dir.mkdir(exist_ok=True)
     rows = []
@@ -1003,6 +1096,20 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
         if not src.exists():
             rec["status"] = "MISSING"
             flags.append((name, "source file MISSING"))
+            continue
+
+        # --resume: skip the (expensive) re-render only when the manifest's
+        # own record proves the existing files still answer THIS
+        # invocation's question. Conservative by construction -- any one
+        # check failing means the frame is (re)rendered, never the reverse
+        # (docs/prep-resume-plan.md item 2). The sheet still needs pixels for
+        # this frame, so load the original and the already-rendered presets
+        # back off disk rather than re-deriving them.
+        if resumable and _frame_is_resumable(shoot, name, rec, only):
+            before = _load_bgr(src)
+            variants = {pname: _load_bgr(shoot / rec["presets"][pname]["path"])
+                        for pname in only}
+            rows.append((name, before, variants, rec))
             continue
 
         before = _load_bgr(src)
@@ -1085,9 +1192,15 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = ()) -> dict:
         if rec["orientation"]["needs_ask"]:
             flags.append((name, "orientation still ASK"))
 
-    m["approved"] = False
-    m["approved_at"] = None
-    save_manifest(shoot, m)
+        # Checkpoint after every frame, not once at the end -- a killed
+        # process must orphan at most the frame in flight, never the ones
+        # already finished (docs/prep-resume-plan.md item 1). save_manifest
+        # already does compare-and-swap and re-stamps m[READ_FINGERPRINT] on
+        # this same dict after a successful write, so the next checkpoint's
+        # CAS check is automatically against the fingerprint THIS process
+        # just wrote -- nothing extra to track here.
+        save_manifest(shoot, m)
+
     # Renders from an earlier pass that this one no longer names. Nothing can
     # read them again, so they go now rather than accruing until an audit finds
     # 3.5 GB of them. See _sweep_unreferenced_presets.
@@ -2230,6 +2343,15 @@ def main(argv=None) -> int:
                     help="render every preset in color.PRESETS for a side-by-side "
                          "comparison, instead of just `crisp` (default). Overridden "
                          "by an explicit --only.")
+    ap.add_argument("--resume", action="store_true",
+                    help="with --apply: skip a frame's re-render when the manifest "
+                         "proves the existing render still answers this run's "
+                         "settings (same aspect/pad/pop/subject/category/presets, "
+                         "source unchanged, preset files present and unmodified). "
+                         "Any one check failing re-renders the frame. Re-invoke a "
+                         "backgrounded --apply that got killed by a timeout with "
+                         "this flag rather than restarting it plain -- that is the "
+                         "whole point (default: off)")
     ap.add_argument("--set-rotate", action="append", nargs="+", metavar="NAME=DEG", dest="set_rotate", help="record the ABSOLUTE subject angle — idempotent, use this in generated commands")
     ap.add_argument("--gc", action="store_true",
                     help="list the regenerable byproducts an APPROVED shoot is still holding "
@@ -2402,7 +2524,7 @@ def main(argv=None) -> int:
         only = tuple(_pairs(getattr(args, 'only', None)))
         if not only and args.filters:
             only = tuple(colormod.PRESETS)
-        m = run_apply(shoot, quiet=args.quiet, only=only)
+        m = run_apply(shoot, quiet=args.quiet, only=only, resume=args.resume)
         _print_status(shoot, m)
     return 0
 

--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -187,16 +187,21 @@ def _sha256(path: Path) -> str:
 
 def _apply_settings_hash(aspect, pad: float, pop: str, subject: str,
                          category: str, only) -> str:
-    """Fingerprint of the inputs that decide what `--apply` renders.
+    """Fingerprint of the inputs that could decide what `--apply` renders.
 
     Same truncated-sha256 convention as `_sha256()`/`_manifest_fingerprint()`
     -- 16 hex chars, not a full digest. Stored as `apply_run.settings_hash`
     (docs/prep-resume-plan.md item 2) so a later `--resume` can tell "this is
     an answer to the question I'm asking" from "this answered a different
-    one" -- a changed aspect, pad, pop, subject, category or preset set means
-    the old renders don't answer this invocation's question, exactly like a
+    one" -- a changed aspect, pad, subject, category or preset set means the
+    old renders don't answer this invocation's question, exactly like a
     geometry/category change already invalidates crop/colour sign-off
-    elsewhere in this file.
+    elsewhere in this file. `pop` is included too even though `run_apply`'s
+    render call never forwards it to `colormod.correct` (every preset
+    already bakes in its own pop level, see the comment where `pop` is read
+    above) -- harmless to fingerprint regardless, since a changed `pop` that
+    turns out not to matter only costs an unnecessary re-render, never a
+    stale one.
     """
     payload = json.dumps([aspect, pad, pop, subject, category,
                           sorted(only)], sort_keys=True)

--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -133,7 +133,7 @@ def _save_bgr(path: Path, bgr: np.ndarray, quality: int = 94) -> None:
     Same tmp-and-rename shape `save_manifest` already uses, for the same
     reason: a killed process must never leave a plausible-looking truncated
     JPEG at the real path. `--resume`'s staleness check (docs/prep-resume-
-    plan.md item 2) trusts "the file exists with the recorded hash" as proof
+    plan.md item 3) trusts "the file exists with the recorded hash" as proof
     a render finished; a straight write to the target path could instead
     leave a file that exists, matches nothing, but LOOKS like a finished
     render until something re-hashes it.
@@ -191,7 +191,7 @@ def _apply_settings_hash(aspect, pad: float, pop: str, subject: str,
 
     Same truncated-sha256 convention as `_sha256()`/`_manifest_fingerprint()`
     -- 16 hex chars, not a full digest. Stored as `apply_run.settings_hash`
-    (docs/prep-resume-plan.md item 2) so a later `--resume` can tell "this is
+    (docs/prep-resume-plan.md item 3) so a later `--resume` can tell "this is
     an answer to the question I'm asking" from "this answered a different
     one" -- a changed aspect, pad, subject, category or preset set means the
     old renders don't answer this invocation's question, exactly like a
@@ -999,7 +999,7 @@ def _already_listed(shoot: Path) -> bool:
 def _frame_is_resumable(shoot: Path, name: str, rec: dict, only: tuple) -> bool:
     """Whether an already-rendered frame can be reused under `--resume`.
 
-    Conservative by construction (docs/prep-resume-plan.md item 2): every
+    Conservative by construction (docs/prep-resume-plan.md item 3): every
     condition below must hold, or the frame is treated as not done and
     re-rendered. Over-rendering wastes time; a stale render shipping wastes
     a lot more. The settings-hash check (whether THIS invocation is asking
@@ -1039,7 +1039,7 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
     skips a frame's re-render only when the manifest's own record proves the
     existing render still answers THIS invocation's question — see
     docs/prep-resume-plan.md item 3. The manifest is also checkpointed after
-    every frame instead of once at the end (item 1), so a run killed by a
+    every frame instead of once at the end (item 2), so a run killed by a
     timeout leaves a consistent partial manifest a later `--resume` can trust,
     instead of orphaning every already-rendered JPEG.
     """
@@ -1085,7 +1085,7 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
     # against what was on disk BEFORE this call overwrites it -- so a
     # resumed run's own checkpoint can never trivially match itself, only a
     # PRIOR run's, under the same settings, can (docs/prep-resume-plan.md
-    # item 2). `resume=False` (the default) never consults it: `resumable`
+    # item 3). `resume=False` (the default) never consults it: `resumable`
     # stays False and every frame renders exactly as it always has.
     settings_hash = _apply_settings_hash(aspect, pad, pop, smode,
                                          category_of(m), only)
@@ -1125,7 +1125,7 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
         # own record proves the existing files still answer THIS
         # invocation's question. Conservative by construction -- any one
         # check failing means the frame is (re)rendered, never the reverse
-        # (docs/prep-resume-plan.md item 2). The sheet still needs pixels for
+        # (docs/prep-resume-plan.md item 3). The sheet still needs pixels for
         # this frame, so load the original and the already-rendered presets
         # back off disk rather than re-deriving them.
         if resumable and _frame_is_resumable(shoot, name, rec, only):
@@ -1228,7 +1228,7 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
 
         # Checkpoint after every frame, not once at the end -- a killed
         # process must orphan at most the frame in flight, never the ones
-        # already finished (docs/prep-resume-plan.md item 1). save_manifest
+        # already finished (docs/prep-resume-plan.md item 2). save_manifest
         # already does compare-and-swap and re-stamps m[READ_FINGERPRINT] on
         # this same dict after a successful write, so the next checkpoint's
         # CAS check is automatically against the fingerprint THIS process

--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -1011,12 +1011,18 @@ def _frame_is_resumable(shoot: Path, name: str, rec: dict, only: tuple) -> bool:
     if not src.exists() or _sha256(src) != rec.get("src_sha256"):
         return False
     presets = rec.get("presets") or {}
+    shoot_resolved = shoot.resolve()
     for pname in only:
         entry = presets.get(pname)
         if not entry or not entry.get("path"):
             return False
         p_path = shoot / entry["path"]
-        if not p_path.exists() or _sha256(p_path) != entry.get("sha256"):
+        if not p_path.exists():
+            return False
+        p_resolved = p_path.resolve()
+        if p_resolved != shoot_resolved and shoot_resolved not in p_resolved.parents:
+            return False
+        if _sha256(p_path) != entry.get("sha256"):
             return False
     return True
 

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -2107,3 +2107,68 @@ def test_apply_always_stamps_a_fresh_apply_run_settings_hash():
         assert "apply_run" in m
         assert len(m["apply_run"]["settings_hash"]) == 16
         assert m["apply_run"]["started_at"]
+
+
+def test_apply_resolves_an_empty_only_to_the_full_preset_list_before_hashing():
+    """catmod.looks_for() documents empty tuple as "render everything", the
+    same sentinel the render loop resolves via `only or colormod.PRESETS` --
+    but settings_hash/resumability must never be computed against the bare
+    empty tuple, or they'd describe a run that renders nothing while the
+    loop actually renders every preset (Copilot review fix on #96)."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=1)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+
+        with patch.object(P.catmod, "looks_for", return_value=()):
+            P.run_apply(shoot, quiet=True)
+
+        m = P.load_manifest(shoot)
+        expected = P._apply_settings_hash(
+            P._parse_aspect(m["settings"].get("aspect", P.DEFAULT_ASPECT)),
+            float(m["settings"].get("pad", P.DEFAULT_PAD)),
+            m["settings"].get("pop", "gentle"), P.subject_mode(m),
+            P.category_of(m), tuple(C.PRESETS))
+        assert m["apply_run"]["settings_hash"] == expected, (
+            "an empty `only` sentinel must hash as the full preset list "
+            "that actually gets rendered, not as an empty one")
+        # And it must have actually rendered every preset, not zero of them.
+        assert set(m["photos"]["IMG_0.jpg"]["presets"]) == set(C.PRESETS)
+
+
+def test_resume_catches_a_changed_source_even_under_the_empty_only_sentinel():
+    """The bug this guards against directly: `_frame_is_resumable`'s
+    `for pname in only:` loop checks nothing when `only` is empty, so it
+    would trivially return True for ANY frame regardless of whether its
+    source changed -- a resume that should re-render would silently skip
+    instead. Both applies here use the empty-`only` "render everything"
+    sentinel (the render loop already resolved it correctly even before
+    this fix; only the hash/resumability path did not) -- reshooting frame
+    0 between them must still force a re-render, not a false-positive skip."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=1)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+
+        with patch.object(P.catmod, "looks_for", return_value=()):
+            P.run_apply(shoot, quiet=True)
+
+            # A reshoot / replaced source file for the only frame.
+            img, _ = _scene(seed=99)
+            cv2.imencode(".jpg", img)[1].tofile(str(shoot / "IMG_0.jpg"))
+
+            rendered = []
+            orig_save_bgr = P._save_bgr
+
+            def spy_save_bgr(path, bgr, quality=94):
+                rendered.append(Path(path).stem)
+                return orig_save_bgr(path, bgr, quality=quality)
+
+            with patch.object(P, "_save_bgr", side_effect=spy_save_bgr):
+                P.run_apply(shoot, quiet=True, resume=True)
+
+        assert "IMG_0" in rendered, (
+            "a changed source must force a re-render under --resume even "
+            "when `only` is the empty 'render everything' sentinel -- a "
+            "resumability check against the bare empty tuple would have "
+            "skipped this frame unconditionally")

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -37,6 +37,7 @@ from lib.photo_prep import categories as CAT             # noqa: E402
 from lib.photo_prep import color as C                     # noqa: E402
 from lib.photo_prep import orientation as O               # noqa: E402
 from lib.photo_prep import prep as P                      # noqa: E402
+from lib.photo_prep.center_crop import _parse_aspect       # noqa: E402
 
 W, H = 1200, 900
 NO_OSD = (None, 0.0, "no text")
@@ -2125,7 +2126,7 @@ def test_apply_resolves_an_empty_only_to_the_full_preset_list_before_hashing():
 
         m = P.load_manifest(shoot)
         expected = P._apply_settings_hash(
-            P._parse_aspect(m["settings"].get("aspect", P.DEFAULT_ASPECT)),
+            _parse_aspect(m["settings"].get("aspect", P.DEFAULT_ASPECT)),
             float(m["settings"].get("pad", P.DEFAULT_PAD)),
             m["settings"].get("pop", "gentle"), P.subject_mode(m),
             P.category_of(m), tuple(C.PRESETS))

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -20,10 +20,12 @@ Run:  python tests/test_prep.py
   or: pytest tests/test_prep.py
 """
 import contextlib
+import copy
 import json
 import sys
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
@@ -1860,3 +1862,248 @@ def test_changing_category_drops_crop_and_colour_signoff():
             assert m["stages"]["color"]["approved"] is False
             assert not m["approved"]
             assert m["settings"]["category"] == "switched"
+
+
+# ---------------------------------------------------------------------------
+# --resume / incremental checkpointing (#74 item 3, docs/prep-resume-plan.md)
+#
+# A shoot big enough to exceed the Bash tool's ~600s timeout used to get
+# killed mid-`--apply`: every already-rendered JPEG was orphaned (the
+# manifest never learned about it, since it was only written once, at the
+# very end) and a re-run started over from frame 1. These lock down the fix:
+# an atomic per-file write, a checkpoint after every frame instead of one at
+# the end, and a `--resume` that only ever skips a frame when the manifest's
+# own record proves the old render still answers the CURRENT question.
+# ---------------------------------------------------------------------------
+
+def test_save_bgr_writes_via_tmp_and_rename():
+    """The target must never exist as a partial file -- it appears once,
+    fully written, via os.replace (same shape save_manifest already uses)."""
+    with tempfile.TemporaryDirectory() as td:
+        target = Path(td) / "out.jpg"
+        img = np.full((8, 8, 3), 128, np.uint8)
+        P._save_bgr(target, img)
+        assert target.exists()
+        assert not target.with_name(target.name + ".tmp").exists(), (
+            "the tmp file must not survive a successful write")
+        assert cv2.imread(str(target)) is not None, (
+            "the file must decode as a complete, valid JPEG")
+
+
+def test_save_bgr_leaves_no_trace_when_the_rename_fails():
+    """A killed/failed write must never leave a truncated file at the real
+    path -- that is exactly what --resume's staleness check depends on."""
+    with tempfile.TemporaryDirectory() as td:
+        target = Path(td) / "out.jpg"
+        img = np.full((8, 8, 3), 128, np.uint8)
+        with patch("os.replace", side_effect=OSError("disk full")):
+            try:
+                P._save_bgr(target, img)
+                raise AssertionError("a failed rename must propagate, not be swallowed")
+            except OSError:
+                pass
+        assert not target.exists(), "no file at the real path when the rename never happened"
+        assert not target.with_name(target.name + ".tmp").exists(), (
+            "the tmp file must be cleaned up after a failed rename")
+
+
+def test_apply_settings_hash_is_deterministic_order_independent_and_sensitive():
+    """Same convention as `_sha256`/`_manifest_fingerprint`: 16 hex chars, and
+    a change to ANY of the inputs that decide what gets rendered must change
+    it -- that is the whole mechanism `--resume` trusts to tell "the same
+    question" from "a different one" apart."""
+    base = P._apply_settings_hash(1.5, 0.05, "gentle", "auto", "default", ("crisp",))
+    assert len(base) == 16
+    assert base == P._apply_settings_hash(1.5, 0.05, "gentle", "auto", "default", ("crisp",)), (
+        "must be deterministic for identical inputs")
+    # preset order must not matter -- it is `only`, not a sequence.
+    assert (P._apply_settings_hash(1.5, 0.05, "gentle", "auto", "default", ("crisp", "asshot"))
+            == P._apply_settings_hash(1.5, 0.05, "gentle", "auto", "default", ("asshot", "crisp")))
+    assert base != P._apply_settings_hash(1.33, 0.05, "gentle", "auto", "default", ("crisp",)), "aspect"
+    assert base != P._apply_settings_hash(1.5, 0.10, "gentle", "auto", "default", ("crisp",)), "pad"
+    assert base != P._apply_settings_hash(1.5, 0.05, "strong", "auto", "default", ("crisp",)), "pop"
+    assert base != P._apply_settings_hash(1.5, 0.05, "gentle", "paper", "default", ("crisp",)), "subject"
+    assert base != P._apply_settings_hash(1.5, 0.05, "gentle", "auto", "printed", ("crisp",)), "category"
+    assert base != P._apply_settings_hash(1.5, 0.05, "gentle", "auto", "default", ("crisp", "asshot")), "only"
+
+
+def _fake_rec_and_preset(shoot: Path, name: str = "IMG_0.jpg", preset: str = "crisp"):
+    """A minimal manifest frame + on-disk preset file, hashed for real.
+
+    `_frame_is_resumable` only ever hashes bytes -- it never decodes an
+    image -- so plain bytes stand in for both the source and the render.
+    """
+    src = shoot / name
+    src.write_bytes(b"source-bytes-v1")
+    p_dir = shoot / ".prep" / "presets" / preset
+    p_dir.mkdir(parents=True, exist_ok=True)
+    p_path = p_dir / name
+    p_path.write_bytes(b"preset-bytes-v1")
+    rec = {
+        "src_sha256": P._sha256(src),
+        "presets": {preset: {"path": str(p_path.relative_to(shoot)).replace("\\", "/"),
+                             "sha256": P._sha256(p_path)}},
+    }
+    return rec, src, p_path
+
+
+def test_frame_is_resumable_only_when_every_condition_holds():
+    """docs/prep-resume-plan.md item 2's four checks, minus the settings-hash
+    one (that's the caller's job, gating whether `_frame_is_resumable` is
+    even consulted -- see the run_apply-level tests below). Conservative by
+    construction: any single failure re-renders, never the reverse."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = Path(td) / "s"
+        shoot.mkdir()
+        rec, src, p_path = _fake_rec_and_preset(shoot)
+        only = ("crisp",)
+
+        assert P._frame_is_resumable(shoot, "IMG_0.jpg", rec, only), (
+            "every condition holds -- must be reusable")
+
+        # 1. the source changed underneath (reshoot / replaced file).
+        stale_src = dict(rec, src_sha256="0" * 16)
+        assert not P._frame_is_resumable(shoot, "IMG_0.jpg", stale_src, only)
+
+        # 2. a preset `only` now asks for was never rendered for this frame.
+        assert not P._frame_is_resumable(shoot, "IMG_0.jpg", rec, ("crisp", "asshot"))
+
+        # 3. the recorded preset's hash no longer matches the file on disk
+        #    (a partial/truncated write, or the file was edited).
+        tampered = copy.deepcopy(rec)
+        tampered["presets"]["crisp"]["sha256"] = "0" * 16
+        assert not P._frame_is_resumable(shoot, "IMG_0.jpg", tampered, only)
+
+        # 4. the recorded preset file is simply gone.
+        p_path.unlink()
+        assert not P._frame_is_resumable(shoot, "IMG_0.jpg", rec, only)
+
+
+def test_apply_checkpoints_the_manifest_after_each_frame_not_just_at_the_end():
+    """The whole point of #74 item 1: a killed --apply must orphan at most
+    the frame in flight, not every frame already rendered before it. Proven
+    by watching the number of frames with a `presets` entry climb across
+    successive save_manifest calls, rather than jumping from 0 to N once."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=3)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+
+        snapshots = []
+        real_save = P.save_manifest
+
+        def spy(shoot_arg, m, force=False):
+            snapshots.append(copy.deepcopy(
+                {k: v for k, v in m.items() if k != P.READ_FINGERPRINT}))
+            return real_save(shoot_arg, m, force=force)
+
+        with patch.object(P, "save_manifest", side_effect=spy):
+            P.run_apply(shoot, quiet=True)
+
+        assert len(snapshots) >= 3, (
+            f"expected at least one checkpoint per frame, got {len(snapshots)}")
+        rendered_counts = [
+            sum(1 for r in snap["photos"].values() if r.get("presets"))
+            for snap in snapshots
+        ]
+        assert rendered_counts[0] < rendered_counts[-1], rendered_counts
+        assert any(0 < c < 3 for c in rendered_counts), (
+            f"a checkpoint must exist with SOME but not all frames done "
+            f"(saw {rendered_counts}) -- otherwise nothing was incremental")
+
+
+def test_omitting_resume_always_rerenders_every_frame():
+    """resume=False (the default) must reproduce today's behaviour exactly:
+    every frame is re-rendered on every --apply, never skipped, no matter
+    what an earlier --apply already produced for it."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=2)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+        P.run_apply(shoot, quiet=True)
+
+        rendered = []
+        orig_save_bgr = P._save_bgr
+
+        def spy_save_bgr(path, bgr, quality=94):
+            rendered.append(Path(path).stem)
+            return orig_save_bgr(path, bgr, quality=quality)
+
+        with patch.object(P, "_save_bgr", side_effect=spy_save_bgr):
+            P.run_apply(shoot, quiet=True)          # resume defaults to False
+
+        assert sorted(rendered) == ["IMG_0", "IMG_1"], (
+            f"every frame must re-render without --resume, got {rendered}")
+
+
+def test_resume_skips_only_frames_whose_render_still_answers_the_question():
+    """The end-to-end case: an unchanged frame is skipped under --resume, a
+    frame whose source changed underneath is not -- proving the staleness
+    check is wired all the way through run_apply, not just unit-correct."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=2)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+        P.run_apply(shoot, quiet=True)
+
+        # A reshoot / replaced file for frame 1 only.
+        img, _ = _scene(seed=99)
+        cv2.imencode(".jpg", img)[1].tofile(str(shoot / "IMG_1.jpg"))
+
+        rendered = []
+        orig_save_bgr = P._save_bgr
+
+        def spy_save_bgr(path, bgr, quality=94):
+            rendered.append(Path(path).stem)
+            return orig_save_bgr(path, bgr, quality=quality)
+
+        with patch.object(P, "_save_bgr", side_effect=spy_save_bgr):
+            P.run_apply(shoot, quiet=True, resume=True)
+
+        assert "IMG_0" not in rendered, (
+            "an unchanged frame must not be re-rendered under --resume")
+        assert "IMG_1" in rendered, (
+            "a changed source must always re-render, even under --resume")
+
+
+def test_resume_ignores_a_stale_checkpoint_from_different_settings():
+    """A settings-hash mismatch (different `only`, in this case) must refuse
+    the WHOLE prior checkpoint, not just the frames that literally differ --
+    a resume that only rendered `crisp` before must not treat a now-wider
+    `only` as satisfied (docs/prep-resume-plan.md item 2)."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=1)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+        P.run_apply(shoot, quiet=True, only=("crisp",))
+
+        rendered = []
+        orig_save_bgr = P._save_bgr
+
+        def spy_save_bgr(path, bgr, quality=94):
+            rendered.append(Path(path).stem)
+            return orig_save_bgr(path, bgr, quality=quality)
+
+        with patch.object(P, "_save_bgr", side_effect=spy_save_bgr):
+            P.run_apply(shoot, quiet=True, resume=True, only=("asshot",))
+
+        assert "IMG_0" in rendered, (
+            "a settings change (a different `only`) must invalidate the "
+            "prior checkpoint even though nothing on disk for the frame "
+            "itself changed")
+
+
+def test_apply_always_stamps_a_fresh_apply_run_settings_hash():
+    """Written at the START of --apply (docs/prep-resume-plan.md item 2),
+    regardless of --resume -- it is what makes a LATER --resume trustworthy,
+    including the very first plain --apply of a shoot."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=1)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+        P.run_apply(shoot, quiet=True)
+
+        m = P.load_manifest(shoot)
+        assert "apply_run" in m
+        assert len(m["apply_run"]["settings_hash"]) == 16
+        assert m["apply_run"]["started_at"]

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -1980,6 +1980,29 @@ def test_frame_is_resumable_only_when_every_condition_holds():
         assert not P._frame_is_resumable(shoot, "IMG_0.jpg", rec, only)
 
 
+def test_frame_is_resumable_rejects_a_preset_path_that_escapes_the_shoot_dir():
+    """A hand-edited or corrupted manifest could point `presets.<name>.path`
+    outside the shoot directory (e.g. `../../../etc/passwd`). `shoot / entry
+    ["path"]` would join it anyway, so `_frame_is_resumable` must resolve and
+    check containment itself before hashing/reading -- resuming must never
+    read (or report as valid) a file outside the shoot it was asked about."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = Path(td) / "s"
+        shoot.mkdir()
+        rec, src, p_path = _fake_rec_and_preset(shoot)
+        only = ("crisp",)
+        assert P._frame_is_resumable(shoot, "IMG_0.jpg", rec, only), "sanity: unescaped path resumes"
+
+        outside = Path(td) / "outside.jpg"
+        outside.write_bytes(b"preset-bytes-v1")
+        escaped = copy.deepcopy(rec)
+        escaped["presets"]["crisp"]["path"] = "../outside.jpg"
+        escaped["presets"]["crisp"]["sha256"] = P._sha256(outside)
+        assert not P._frame_is_resumable(shoot, "IMG_0.jpg", escaped, only), (
+            "a path.. escaping the shoot dir must never be treated as resumable, "
+            "even when its hash matches")
+
+
 def test_apply_checkpoints_the_manifest_after_each_frame_not_just_at_the_end():
     """The whole point of #74 item 1: a killed --apply must orphan at most
     the frame in flight, not every frame already rendered before it. Proven


### PR DESCRIPTION
## Summary

Follow-up to #95 (which landed the friction-audit fixes for #74 items 1-2,
and deliberately shipped only a design doc for item 3). This PR implements
against that design doc, `docs/prep-resume-plan.md`, exactly steps 1-3 of
its "Suggested follow-up PR shape":

1. **Atomic `_save_bgr` write.** Writes to a sibling `.tmp` file and
   `os.replace()`s into place — the same tmp-and-rename shape
   `save_manifest()` already uses, for the same reason: a killed process
   must never leave a plausible-looking truncated JPEG at the real path.
2. **Incremental checkpointing in `run_apply()`.** The single end-of-loop
   `save_manifest(shoot, m)` call moves inside the per-frame loop, so the
   manifest is checkpointed after every frame instead of once at the very
   end. Relies on `save_manifest`'s existing compare-and-swap + fingerprint
   re-stamping rather than re-deriving anything.
3. **`--resume` flag + settings-hash/staleness check.** A new top-level
   manifest field `apply_run` (`settings_hash`, `started_at`) is written at
   the start of every `--apply`. `--resume` skips a frame's re-render only
   when ALL of the following hold — otherwise it's treated as not-done and
   re-rendered (conservative by construction):
   - `apply_run.settings_hash` on disk matches this invocation's hash of
     `(aspect, pad, pop, subject, category, sorted(only))`
   - the frame's recorded `src_sha256` still matches a fresh hash of the
     source file on disk
   - every preset name in `only` is already present in that frame's
     `presets` dict
   - the recorded preset's `path` exists and its `sha256` matches a fresh
     hash of that file

**Step 4 (`--jobs N` / `ProcessPoolExecutor`) is explicitly deferred** to a
separate future PR, per the design doc's own reasoning — it wants a real
peak-RSS measurement at `--jobs 4` on a representative shoot before a
default worker count is picked, which this PR is not in a position to
gather. `docs/prep-resume-plan.md` is updated to mark steps 1-3 done and
step 4 still pending.

`--resume` defaults off. Omitting it reproduces today's behavior exactly —
every frame renders every time, byte-for-byte the same code path as before
(the new checkpointing runs unconditionally, per the design, but never skips
a render unless `--resume` is passed AND the settings hash matches).

## Why

`run_apply()` used to render every frame's every preset in one loop and
only call `save_manifest()` once, at the end. A shoot that took longer than
the Bash tool's ~600s timeout got killed mid-loop: every already-rendered
JPEG was orphaned (the manifest never learned about it) and a re-run started
over from frame 1. Issue #74 measured ~8.4 hours of wasted wall-clock across
historical sessions from this.

## Test plan

- `python3 -m py_compile lib/photo_prep/prep.py tests/test_prep.py` — passes
  locally (this sandbox has neither `numpy`/`opencv-python` nor `pytest`
  installed, so this is the only local verification available; the real
  suite needs CI).
- Added to `tests/test_prep.py`, following its existing pattern of real
  synthetic-image runs (cv2-drawn frames) plus a couple of pure-function
  unit tests that don't need image codecs at all:
  - `test_save_bgr_writes_via_tmp_and_rename` / `..._leaves_no_trace_when_the_rename_fails`
  - `test_apply_settings_hash_is_deterministic_order_independent_and_sensitive`
  - `test_frame_is_resumable_only_when_every_condition_holds` (all 4 staleness
    conditions, individually)
  - `test_apply_checkpoints_the_manifest_after_each_frame_not_just_at_the_end`
  - `test_omitting_resume_always_rerenders_every_frame` (default-off parity)
  - `test_resume_skips_only_frames_whose_render_still_answers_the_question`
    (end-to-end: unchanged frame skipped, changed-source frame re-rendered)
  - `test_resume_ignores_a_stale_checkpoint_from_different_settings`
  - `test_apply_always_stamps_a_fresh_apply_run_settings_hash`
- **CI caveat**: I could not run the real test suite or the image pipeline
  locally (no numpy/cv2/pytest in this sandbox). GitHub Actions' `pytest`
  check has these deps and has passed on other recent PRs in this repo — I
  will check its result on this PR and iterate on any failures, per the
  task's instructions. If it's still red when a human picks this up, that
  will be called out explicitly rather than left silently unaddressed.

## Scope notes

- `run_check` is untouched (explicitly out of scope per the design doc).
- No second progress-tracking file — `prep.json` remains the only progress
  record.
- The approval/review gate logic is untouched; `--resume`/checkpointing are
  pure performance/reliability changes to how renders get produced, not to
  what gets approved. (One related tightening: `approved`/`approved_at` are
  now reset to `False`/`None` *before* the per-frame loop rather than after,
  so every checkpoint — not just the final write — already reflects that an
  in-flight or interrupted apply is not an approved one.)

Refs #74.


---
_Generated by [Claude Code](https://claude.ai/code/session_012ZdceZ9jcfPp4X5KX7F6rR)_