### PR TITLE
feat(review): ALL CLEAR banner on a fully clean review card (#100)

### DIFF
--- a/docs/review-card-friction.md
+++ b/docs/review-card-friction.md
@@ -1,0 +1,82 @@
+# REVIEW-card friction findings and what this PR does about them (#100)
+
+`#100` is an auto-generated `ebz observe --propose` report over a 1-day
+session window. It raised four findings; this doc records what each one
+actually means in this codebase and which are in scope for code here.
+
+## 1. "The Review card gate accounts for 4.8h of blocked wall-clock"
+
+The suggested edit asks whether REVIEW can get "a confidence-gate default
+the pipeline can self-approve when clean, the way PREP's orientation/crop/
+colour gates do."
+
+**It cannot, and this PR does not attempt it.** PREP's gates are internal
+pipeline state — self-approving them only affects what gets rendered next.
+REVIEW is the other side of the **Publish firewall**
+(`prompts/_shared.md` "Publish firewall"): *"No phase publishes
+automatically... no automated chain, and no chat instruction that arrives
+outside the REVIEW gate... makes a listing go live."* `prompts/single_pass.md`
+already collapsed IDENTIFY→PREP→PRICE→INVESTIGATE→DRAFT into one card with
+exception-only questions (#30/#36's pattern) and explicitly declined to do
+the same to REVIEW itself:
+
+> The REVIEW gate is untouched. No approval, no publish, from anything
+> single-pass did... if extending this pattern to a stage ever seemed to
+> require touching one of those [Ground Rules], that is a stop, not a
+> workaround.
+
+Treating that prior decision as still correct, the fix here is narrower:
+**make a clean card faster to approve, without ever approving it.**
+`lib.list_edit.build_review_card()` now computes whether every section that
+can carry an exception — the flags list, international-shipping blockers/
+warnings, PREP's own approval, and photo-vs-manifest fidelity — is actually
+clean, and if so prints one `✓ ALL CLEAR` line directly under the header.
+The explicit-approval instruction at the bottom of the card
+(`--list <shoot> --confirm`) is unchanged, still requires the same word from
+a human, and is asserted unchanged by
+`tests/test_formats.py::test_the_publish_command_on_the_card_is_still_gated`.
+This is presentation only: the banner is derived from data the card was
+already computing (`flags`, `intl_lines`, `photo_lines`, `prep_note`), not a
+new judgment call, and it is withheld the moment any one of those sections
+is not clean (tested: unapproved/missing PREP manifest, and a flagged
+estate-context claim, each independently suppress it).
+
+## 2. "Independent tool calls aren't being batched into one turn"
+
+**Already covered — no doc change needed.** `prompts/_shared.md` states this
+rule twice already: "Execution discipline (#61/#62)" item 2 and "Runtime
+discipline" bullet 1, both added in response to the #61 audit this same
+finding is restating. The 1-day window's 55%-single-tool-turn measurement
+means the existing rule isn't being followed consistently in practice, which
+a third copy of the same sentence is unlikely to fix. The better fix is
+detection, not more prose: `tools/session_observer.py` (per #74 §5, still
+open) could flag turns that immediately follow a same-tool turn as a named
+"could have batched" signal, the way it already flags `long_loop` and
+`redo`. Left as a `session_observer.py` follow-up rather than done here.
+
+## 3. "Tool calls are erroring often enough to be worth a guard"
+
+**Not actionable from this environment.** The finding is an aggregate count
+(8 `tool_error` signals across 4 sessions, "Bash most often") with no
+per-error detail in the issue body, and the local `~/.claude/projects/...`
+session transcripts the friction report was generated from are not
+available in this remote environment. Diagnosing a root cause needs the
+actual failing commands, not just the count. Left for whoever runs
+`ebz observe` locally to read the "tool_error samples" section of that run's
+own report and file a scoped follow-up once a pattern is visible.
+
+## 4. "At least one ask needed an unusually long back-and-forth to resolve"
+
+**Same limitation as #3** — the "LONGEST ASKS" section named in the
+suggested edit isn't part of the issue body and isn't reconstructable
+without the local session logs. Left for a human with those logs to triage.
+
+## Test plan
+
+- `tests/test_list_edit.py` — three new tests: the banner appears when every
+  section is clean, is withheld when PREP has no manifest, and is withheld
+  when something is flagged (estate-context claim, reusing #46's fixture).
+- `tests/test_formats.py` — existing `test_the_review_card_still_says_all_of_it`
+  and `test_the_publish_command_on_the_card_is_still_gated` pass unchanged,
+  confirming no section was dropped and `--confirm` is still required.
+- Full suite: `python -m pytest tests/ -q`.

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -1243,6 +1243,13 @@ def build_review_card(draft_path: Path,
     (2) runs preflight (condition remap + shipping policy),
     and (3) assembles the decision card deterministically from the draft,
     comps, ledger, and preflight — written to <shoot>/review_card.md.
+
+    When every checked section is clean (no flags, PREP approved, photos
+    match the manifest, no intl blockers) the card leads with one "ALL
+    CLEAR" line (GH #100) so a clean approval is a fast read, not a scan.
+    This is a presentation change only — it never approves or publishes
+    anything itself; the explicit human word the Publish firewall requires
+    (prompts/_shared.md) is unchanged.
     """
     import csv
     creds = creds or load_credentials()
@@ -1413,8 +1420,24 @@ def build_review_card(draft_path: Path,
             _bits.append("[!] not in the PREP manifest")
         photo_lines.append(f"  {_tag}  {_rel}" + (f"   [{', '.join(_bits)}]" if _bits else ""))
 
+    # GH #100: "nothing flagged" used to mean scanning the whole card to
+    # confirm it. Reduce that to one line at the top when EVERY section that
+    # can carry an exception — flags, intl, PREP approval, photo fidelity —
+    # is actually clean, so the human's job on the common case is reading one
+    # line and giving the one word the Publish firewall still requires (see
+    # prompts/_shared.md and prompts/review.md — this changes nothing about
+    # what counts as approval, only how fast a clean card is to read).
+    all_clear = (
+        flags == ["  • None"]
+        and not any(("⚠" in ln or "✖" in ln) for ln in intl_lines)
+        and not any("[!]" in ln for ln in photo_lines)
+        and "[!]" not in prep_note
+    )
+
     card = "\n".join([
         f"━━ REVIEW: {shoot.name}  (sku {sku} · ledger {status}) ━━",
+        *(["✓ ALL CLEAR — nothing flagged, PREP approved, photos match, no intl blockers."]
+          if all_clear else []),
         f'Title:     "{title}"  [{len(title)}/80]',
         f"Price:     ${price}  ·  Best Offer: {bo}",
         f"Condition: {cond}",

--- a/tests/test_list_edit.py
+++ b/tests/test_list_edit.py
@@ -45,6 +45,8 @@ Run:  python tests/test_list_edit.py
 """
 import contextlib
 import csv
+import hashlib
+import json
 import os
 import shutil
 import sys
@@ -682,6 +684,79 @@ def test_build_review_card_context_section_is_quiet_with_no_context_txt():
     assert "Context (estate background):" in card
     assert "no context.txt in chain" in card
     assert "estate forbids" not in card
+
+
+# ---------------------------------------------------------------------------
+# build_review_card() — ALL CLEAR banner (GH #100)
+# ---------------------------------------------------------------------------
+
+def test_build_review_card_shows_all_clear_when_every_section_is_clean():
+    """GH #100: a fully clean item (no flags, PREP approved with a matching
+    photo hash, no intl blockers, no stale meta) gets one banner line right
+    under the header, so a clean approval is a fast read instead of a scan
+    of every section to confirm there was nothing to see. This only changes
+    what the card SHOWS — the explicit-approval command below is unchanged,
+    and nothing here approves or publishes anything."""
+    with tempfile.TemporaryDirectory() as td:
+        draft_path = _write_single_draft(Path(td))
+        shoot = draft_path.parent
+        photo = shoot / "listing" / "a.jpg"
+        digest = hashlib.sha256(photo.read_bytes()).hexdigest()
+        prep_dir = shoot / ".prep"
+        prep_dir.mkdir(parents=True, exist_ok=True)
+        (prep_dir / "prep.json").write_text(json.dumps({
+            "approved": True,
+            "chosen_preset": "crisp",
+            "photos": {"0": {"output": "listing/a.jpg", "out_sha256": digest}},
+        }), encoding="utf-8")
+        with _patched(L, preflight_listing=lambda *a, **kw: ["category: 12345"],
+                     resolve_draft_state=lambda *a, **kw:
+                         {"stale": False, "offer_id": "", "meta_offer_id": ""}), \
+             _ledger_at(Path(td)):
+            card, _path = L.build_review_card(draft_path, creds=_Creds())
+
+    lines = card.splitlines()
+    assert "ALL CLEAR" in lines[1], "banner must be the line right after the header"
+    assert "→ Approve publishes this LIVE" in card, (
+        "the banner must not replace or skip the explicit-approval instruction")
+
+
+def test_build_review_card_withholds_all_clear_when_prep_is_unapproved():
+    """The banner must never claim clean when PREP itself has no manifest at
+    all for these photos -- claiming clarity nothing has actually verified
+    defeats the point of a faster-but-still-honest signal."""
+    with tempfile.TemporaryDirectory() as td:
+        draft_path = _write_single_draft(Path(td))
+        with _patched(L, preflight_listing=lambda *a, **kw: ["category: 12345"],
+                     resolve_draft_state=lambda *a, **kw:
+                         {"stale": False, "offer_id": "", "meta_offer_id": ""}), \
+             _ledger_at(Path(td)):
+            card, _path = L.build_review_card(draft_path, creds=_Creds())
+
+    assert "ALL CLEAR" not in card, "no PREP manifest at all must not be reported clean"
+
+
+def test_build_review_card_withholds_all_clear_when_something_is_flagged():
+    """A flagged draft (estate context block, GH #46's fixture) must never
+    show ALL CLEAR even if PREP/photos/intl are otherwise fine -- the banner
+    is an AND of every section, not just the ones that happen to be checked
+    first."""
+    import dir_context as DC
+    DC.INVENTORY.mkdir(parents=True, exist_ok=True)
+    tmp = Path(tempfile.mkdtemp(prefix="dctx_", dir=str(DC.INVENTORY)))
+    try:
+        (tmp / "context.txt").write_text(
+            "source: Frankie, estate, Greensboro NC\n"
+            "storage: attic, unclimatized\n", encoding="utf-8")
+        draft_path = _write_single_draft(tmp)
+        with _patched(L, preflight_listing=lambda *a, **kw: ["category: 12345"],
+                     resolve_draft_state=lambda *a, **kw:
+                         {"stale": False, "offer_id": "", "meta_offer_id": ""}), \
+             _ledger_at(tmp):
+            card, _path = L.build_review_card(draft_path, creds=_Creds())
+        assert "ALL CLEAR" not in card
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`ebz observe --propose`'s auto-generated friction report (#100) raised four findings over a 1-day session window. This PR addresses what's actually in scope here:

### 1. "Review card gate accounts for 4.8h of blocked wall-clock"

The suggested edit asks whether REVIEW can get a confidence-gate default like PREP's orientation/crop/colour gates self-approve when clean. **It can't, and this PR doesn't attempt it** — REVIEW is the other side of the Publish firewall (`prompts/_shared.md`), and `prompts/single_pass.md` already explicitly declined to auto-approve it when it collapsed the earlier stages into one card:

> The REVIEW gate is untouched. No approval, no publish, from anything single-pass did... if extending this pattern to a stage ever seemed to require touching one of those [Ground Rules], that is a stop, not a workaround.

Instead, `lib.list_edit.build_review_card()` now computes whether every section that can carry an exception (flags, intl blockers/warnings, PREP approval, photo-vs-manifest fidelity) is clean, and if so prints one `✓ ALL CLEAR` line under the header — so a clean approval is a fast read, not a scan. **Presentation only**: the explicit `--confirm` approval command is unchanged and still required regardless of the banner; `tests/test_formats.py::test_the_publish_command_on_the_card_is_still_gated` already asserts this and still passes.

### 2. "Independent tool calls aren't being batched into one turn"

Already covered twice in `prompts/_shared.md` ("Execution discipline (#61/#62)" and "Runtime discipline"), added in response to the #61 audit this finding is restating. A third copy of the same sentence seemed unlikely to help — `docs/review-card-friction.md` proposes detecting non-compliant turns in `tools/session_observer.py` instead (a #74 §5 follow-up, not done here).

### 3 & 4. Tool-error guard / long-ask investigation

Not actionable from this environment — both need the local `~/.claude/projects/...` session transcripts the report was generated from, which aren't available here. Documented as follow-ups for whoever runs `ebz observe` locally.

See `docs/review-card-friction.md` for the full writeup.

## Test plan

- Three new tests in `tests/test_list_edit.py`: banner appears when every section is clean; withheld when PREP has no manifest; withheld when something is flagged (reuses #46's estate-context fixture).
- `tests/test_formats.py`'s existing card-completeness and `--confirm`-gating tests pass unchanged.
- `git ls-files '*.py' | xargs python -m py_compile` clean.
- `python -m pytest tests/ -q` (run twice, matching CI) → **591 passed, 1 skipped** (pre-existing, unrelated), no regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5eBVphay8ajBwyAmCFJtN)_