### PR TITLE
fix(observer): slugify '.' so transcripts resolve in a worktree (#103)

### DIFF
--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -18,12 +18,17 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from tools.session_observer import (  # noqa: E402
-    _classify, _clean_prompt, _command_bucket, _match_open_issue,
-    _model_rates, _open_idea_issues, _prep_item_dir, _ts, _tool_signature,
-    _turn_context, _turn_cost_usd, aggregate_friction, cost_per_listing,
-    economics_aggregate, economics_report, file_proposals, format_idea_issue,
-    main, parse_economics, parse_session, propose_fixes, report, transcripts_dir,
+    REPO, _classify, _clean_prompt, _command_bucket, _match_open_issue,
+    _model_rates, _near_miss_hint, _open_idea_issues, _prep_item_dir, _slug,
+    _ts, _tool_signature, _turn_context, _turn_cost_usd, aggregate_friction,
+    cost_per_listing, economics_aggregate, economics_report, file_proposals,
+    format_idea_issue, main, parse_economics, parse_session, propose_fixes,
+    report, transcripts_dir,
 )
+
+# _near_miss_hint matches on the repo's own slugified basename, so the fixture
+# directories have to be named after whatever checkout the suite runs from.
+REPO_NAME = _slug(REPO.name)
 
 T0 = "2026-08-27T10:00:0{}.000Z"
 
@@ -63,6 +68,42 @@ def test_transcripts_dir_slugifies_the_repo_path():
     d = transcripts_dir(Path("C:/x/y"))
     assert d.name == "C--x-y"
     assert d.parent.name == "projects"
+
+
+def test_transcripts_dir_slugifies_dots_so_worktrees_resolve():
+    # The '.' in `.claude` is the whole bug: a main checkout has no dot in its
+    # path, so leaving '.' out of the class looks correct until the cwd is a
+    # worktree — which CLAUDE.md requires for any git-state change.
+    cases = [
+        # (cwd, expected directory name)
+        ("C:/p/ebaybiz", "C--p-ebaybiz"),
+        ("C:/p/ebaybiz/.claude/worktrees/wt-1",
+         "C--p-ebaybiz--claude-worktrees-wt-1"),
+        # a worktree whose own name carries a dot
+        ("C:/p/ebaybiz/.claude/worktrees/v1.2-fix",
+         "C--p-ebaybiz--claude-worktrees-v1-2-fix"),
+    ]
+    for cwd, expected in cases:
+        assert transcripts_dir(Path(cwd)).name == expected, cwd
+
+
+def test_missing_transcripts_dir_names_the_near_misses(tmp_path, capsys):
+    # A wrong slug and a quiet week must not print the same thing.
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    (projects / f"C--p-{REPO_NAME}").mkdir()
+    (projects / f"C--p-{REPO_NAME}--claude-worktrees-wt-1").mkdir()
+    (projects / "C--p-unrelated").mkdir()
+
+    hint = _near_miss_hint(projects / "does-not-exist")
+    assert hint, "sibling dirs match the repo — the miss must not be silent"
+    assert any(REPO_NAME in line for line in hint)
+    assert not any("unrelated" in line for line in hint)
+
+    # Genuinely nothing matching -> no hint, so a quiet week stays quiet.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert _near_miss_hint(empty / "does-not-exist") == []
 
 
 def test_clean_prompt_drops_image_placeholders():

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -145,10 +145,44 @@ def _turn_cost_usd(usage: dict, model) -> float:
             + cache_r * in_rate * CACHE_READ_MULT) / 1_000_000
 
 
+def _slug(text: str) -> str:
+    """Claude Code slugifies a path: every ':', '\\', '/' and '.' becomes '-'.
+
+    The '.' matters. A worktree cwd is `<repo>/.claude/worktrees/<name>`, and
+    `.claude` slugifies to `-claude`, giving `...ebaybiz--claude-worktrees-...`
+    with a doubled dash. Leaving '.' out of the class resolves to a directory
+    that does not exist — invisible in the main checkout, which has no dot in
+    its path, and wrong in every worktree, which is where CLAUDE.md requires
+    any session that changes git state to work.
+    """
+    return re.sub(r"[:\\/.]", "-", text)
+
+
 def transcripts_dir(repo: Path) -> Path:
-    """Claude Code slugifies the cwd: every ':', '\\' and '/' becomes '-'."""
-    slug = re.sub(r"[:\\/]", "-", str(repo))
-    return Path.home() / ".claude" / "projects" / slug
+    return Path.home() / ".claude" / "projects" / _slug(str(repo))
+
+
+def _near_miss_hint(missing: Path, limit: int = 5) -> list[str]:
+    """Lines naming real project dirs that match this repo, or [] if none.
+
+    Any future slug quirk — a space, an underscore, an upstream rule change —
+    fails the same silent way this one did, so the check is on the shape of
+    the answer (nothing resolved, yet siblings match) rather than on '.'.
+    """
+    stem = _slug(REPO.name)
+    try:
+        near = sorted(p.name for p in missing.parent.iterdir()
+                      if p.is_dir() and stem in p.name)
+    except OSError:
+        return []
+    if not near:
+        return []
+    out = [f"  {len(near)} directory(ies) there do match {stem!r} — the slug is "
+           f"probably wrong, not the history. Try --dir with one of:"]
+    out += [f"    {missing.parent / n}" for n in near[:limit]]
+    if len(near) > limit:
+        out.append(f"    ... and {len(near) - limit} more")
+    return out
 
 
 def _ts(rec: dict):
@@ -1100,7 +1134,13 @@ def main(argv=None) -> int:
 
     root = Path(args.dir) if args.dir else transcripts_dir(REPO)
     if not root.is_dir():
+        # "no transcripts" reads as "you have not worked much lately", not "I
+        # computed the wrong path" — which is how the missing '.' in the slug
+        # survived. If sibling directories do match this repo, say so: a wrong
+        # slug and a quiet week must not look the same.
         print(f"no transcripts at {root}")
+        for line in _near_miss_hint(root):
+            print(line)
         return 2
     files = sorted(root.glob("*.jsonl"), key=os.path.getmtime, reverse=True)
     if not args.all:


### PR DESCRIPTION
Closes #103.

## The bug

`transcripts_dir()` replaced `:`, `\` and `/` with `-`, but not `.`. Claude Code slugifies the dot too, so a worktree cwd of `<repo>/.claude/worktrees/<name>` must become `...ebaybiz--claude-worktrees-<name>` — doubled dash. Without `.` in the class it resolved to a directory that does not exist.

The main checkout has no dot in its path, which is why this survived: it was correct exactly where it was tested and wrong in every worktree — and CLAUDE.md requires a worktree for any session that changes git state.

Verified live from this worktree. Before: `no transcripts at ...ebaybiz-.claude-worktrees-...`. After: `observer: OK 1/1 sessions, 1 flagged, 4 signals`.

## Consequence worth naming

`observe` is the feedback loop behind #36/#61/#62. Every friction report and economics table it has produced was drawn from a non-random subset — the sessions that did *not* need a worktree.

## The changes

1. **`_slug()`** — the rule extracted out of `transcripts_dir()` with the reason in its docstring, so the next reader sees why `.` is in the class.
2. **`_near_miss_hint()`** — when the computed directory is absent but sibling dirs under `~/.claude/projects/` match the repo's basename, print them and point at `--dir`. `no transcripts` read as *you have not worked much lately* rather than *I computed the wrong path*, which is what let a one-character bug last. The check keys on the shape of the answer — nothing resolved, yet siblings match — so a future slug quirk (a space, an underscore, an upstream rule change) surfaces the same way instead of failing silently. Guarded on `OSError`, and returns nothing when nothing matches, so a genuinely quiet week stays quiet.

## Tests

`transcripts_dir` had one case, the no-dot one, which passes both before and after. Added a table over the three cwd shapes — main checkout, worktree, and a worktree whose own name carries a dot — plus both `_near_miss_hint` branches. Fixture dirs are named from the live `REPO.name` so the suite passes from any checkout. `73 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
