### PR TITLE
chore: add .gitattributes so line endings are a repo decision (#108)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Line endings are a repo decision, not a per-clone one. Without this file the
+# behaviour depends on each machine's core.autocrlf, so a CI runner, a cloud
+# agent and a second workstation can each normalize differently (#108).
+#
+# Committed blobs were already LF and consistent; what this fixes is working
+# files going mixed — editing a CRLF file with a tool that writes \n leaves the
+# untouched lines CRLF and the new ones LF, and nothing catches it, because
+# normalization only happens at commit time.
+
+* text=auto eol=lf
+
+*.py    text eol=lf
+*.md    text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.json  text eol=lf
+*.txt   text eol=lf
+*.html  text eol=lf
+
+# Deliberate: tools/marble_index_next.cmd is run by the Windows scheduled task
+# (MarbleIndexNext), and cmd.exe is happier with CRLF.
+*.cmd   text eol=crlf
+
+# Git's heuristics get these right nearly always, which is not the same as
+# always. Upper-case variants included — inventory frames come off the camera
+# as .JPG, and #97 established that sample photos can be tracked.
+*.pdf   binary
+*.jpg   binary
+*.JPG   binary
+*.jpeg  binary
+*.JPEG  binary
+*.png   binary
+*.gif   binary
+*.webp  binary
+*.tiff  binary
+*.heic  binary


### PR DESCRIPTION
Closes #108.

Rebased onto current `main` (after #109/#116/#117 landed) and completed against the issue's four acceptance boxes.

## What changed from the original commit

The file was the issue's proposal verbatim. Three additions:

- **`*.html`** — 2 tracked files it missed (`git ls-files` extension census: `.py .md .jpg .pdf .json .yaml .txt .html .yml .cmd`).
- **Upper-case image variants** (`.JPG`, `.JPEG`). Inventory frames come off the camera upper-case, and #97 established that sample photos can be tracked, so the pattern should not depend on `core.ignorecase`.
- **Comments** explaining the file's reason and the deliberate `*.cmd` CRLF exception (`tools/marble_index_next.cmd` is run by the `MarbleIndexNext` scheduled task).

## Acceptance

- [x] **`.gitattributes` committed**
- [x] **`git add --renormalize .` run** — **it is a genuine no-op: zero files changed.** The issue predicted this ("committed blobs are LF and consistent — the warnings are cosmetic") and it is confirmed, so there is no second commit to make. That is the finding, not a skipped step.
- [x] **A subsequent edit produces no CRLF warning** — verified in a throwaway `--no-local` clone of this branch, under the same `core.autocrlf=input`: 0 of the tracked text files check out with CRLF, and appending a line then `git add`-ing it prints nothing.
- [x] **Suite still green** — no behaviour change; blobs are byte-identical, which is what the no-op renormalize proves.

## One caveat worth knowing

This fixes *fresh checkouts*. An existing working copy that already holds CRLF on disk — like the one I am writing from — keeps printing `CRLF will be replaced by LF` until those files are re-checked-out, because the warning is git correctly reporting what it will do at commit time. Nothing is wrong when you see it; a fresh clone, or re-checking-out the affected files, ends it.

## Note on provenance

This branch was opened by a parallel session; I rebased and completed it rather than duplicating the work. Its siblings #111–#114 covered #103/#105/#106/#107, which were already closed by #109, #116 and #117, so those four are being closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
