### PR TITLE
chore: remove dead get_anthropic_key() config surface (#107)

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -51,7 +51,6 @@ secrets; a missing optional secret is not a failure:
 ```
 [OK] ebay credentials: ok
 [--] APIFY_API_TOKEN: not set (optional -- lens_id.py only)
-[--] ANTHROPIC_API_KEY: not set (optional -- unused today)
 ```
 
 ---
@@ -81,7 +80,6 @@ This means:
 |---|---|---|
 | `get_apify_token()` | str | `ConfigError` if missing everywhere |
 | `get_lens_actor()` | str | never raises — has a built-in default |
-| `get_anthropic_key()` | str | `ConfigError` if missing everywhere |
 
 `get_apify_token()` / `get_lens_actor()` serve `lens_id.py` only — the Google
 Lens reverse-image lookup. Apify is not a comp source; see the Stage B section

--- a/lib/config.example.yaml
+++ b/lib/config.example.yaml
@@ -31,15 +31,6 @@ apify:
   # lens_actor: "borderline/google-lens"
 
 # ---------------------------------------------------------------------------
-# Anthropic — Claude API. Optional: nothing in the repo reads this today (the
-# phases run inside Claude Code rather than calling the API themselves). Kept
-# for a script that needs its own key.
-# ---------------------------------------------------------------------------
-anthropic:
-  # Get a key at: https://console.anthropic.com/settings/keys
-  api_key: "sk-ant-REPLACE_ME"
-
-# ---------------------------------------------------------------------------
 # eBay Sell API — credentials for Function 6 (LIST/EDIT) + schema discovery
 # ---------------------------------------------------------------------------
 # Sandbox and Production are separate worlds with separate keysets. This

--- a/lib/config.py
+++ b/lib/config.py
@@ -226,34 +226,10 @@ def get_lens_actor() -> str:
     return DEFAULT_LENS_ACTOR
 
 
-def get_anthropic_key() -> str:
-    """Anthropic API key. Precedence: env var > config file > error.
-
-    Raises:
-        ConfigError if no key is available anywhere.
-    """
-    env = os.environ.get("ANTHROPIC_API_KEY")
-    if env:
-        return env
-
-    config = load_config()
-    key = _nested(config, "anthropic", "api_key")
-    if key:
-        return str(key)
-
-    raise ConfigError(
-        f"Anthropic API key not found.\n"
-        f"  Set the ANTHROPIC_API_KEY environment variable, OR\n"
-        f"  add this to {config_path()}:\n"
-        f"      anthropic:\n"
-        f"        api_key: \"<your-key>\""
-    )
-
-
 def get_easypost_key() -> str:
     """EasyPost API key. Precedence: env var > config file > error.
 
-    Same precedence contract as get_apify_token() / get_anthropic_key().
+    Same precedence contract as get_apify_token().
     EasyPost issues test and production keys from the same dashboard; which
     one is configured decides whether a confirmed buy_label() call hits real
     carriers or EasyPost's no-charge test mode — that is an account-setup
@@ -387,7 +363,7 @@ def _cli() -> None:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Verify required secrets (Apify token, Anthropic key) load",
+        help="Verify required secrets (Apify token) load",
     )
     args = parser.parse_args()
 
@@ -415,12 +391,6 @@ def _cli() -> None:
         print(f"apify.lens_actor: {get_lens_actor()}")
 
         try:
-            anth_key = get_anthropic_key()
-            print(f"anthropic.api_key: {_redact(anth_key)}")
-        except ConfigError:
-            print("anthropic.api_key: (not set)")
-
-        try:
             ep_key = get_easypost_key()
             print(f"easypost.api_key: {_redact(ep_key)}")
         except ConfigError:
@@ -445,10 +415,10 @@ def _cli() -> None:
 
     if args.check:
         # Required: the eBay Sell API credentials. Every phase that touches the
-        # account needs them. The other two secrets are optional and are
-        # reported, not enforced -- Apify serves lens_id.py alone (Stage B runs
-        # through ebay_sold_browse.py) and nothing in the repo reads the
-        # Anthropic key. A missing optional secret must not fail the check.
+        # account needs them. Apify is optional and is reported, not enforced
+        # -- it serves lens_id.py alone (Stage B runs through
+        # ebay_sold_browse.py). A missing optional secret must not fail the
+        # check.
         errors = []
         try:
             get_ebay_credentials()
@@ -459,7 +429,6 @@ def _cli() -> None:
 
         for name, getter, note in (
             ("APIFY_API_TOKEN", get_apify_token, "lens_id.py only"),
-            ("ANTHROPIC_API_KEY", get_anthropic_key, "unused today"),
         ):
             try:
                 getter()


### PR DESCRIPTION
## Summary

#101 already fixed the misleading part of this dead config surface (`--check` no longer fails when the Anthropic key is absent; the accessor and example block were labelled optional/unused). This PR is the actual removal that issue left out on purpose.

**Pre-delete check (per the issue's explicit ask):** ran
```
grep -rn "get_anthropic_key|ANTHROPIC_API_KEY|anthropic" --include="*.py" lib/ tools/ tests/
```
plus a repo-wide case-insensitive grep for `anthropic`. Result: no live caller anywhere. The only hits were `config.py`'s own definition/CLI (removed here), the doc mentions removed here, and two unrelated matches that don't reach the accessor:
- `tools/session_observer.py` — a comment about Anthropic's token-rate multipliers, unrelated to the config key.
- `docs/webapp-architecture.md` — a forward-looking design note about a *future* phase ("Claude as an invoked backend service") that would need its own server-side Anthropic key; it doesn't call `get_anthropic_key()` today and isn't part of the current config surface.

Confirms the issue author's own lean ("delete") — proceeding with delete, same grounds as the earlier `get_apify_actor()` removal.

## What was removed

- `lib/config.py`: `get_anthropic_key()` accessor, the `--show` print block for `anthropic.api_key`, and the `--check` row for `ANTHROPIC_API_KEY` (including its docstring/help-text mentions).
- `lib/config.example.yaml`: the whole `anthropic:` block.
- `lib/README.md`: the `get_anthropic_key()` row in the accessor table and the `ANTHROPIC_API_KEY` line in the `--check` sample output.

No test in `tests/` referenced `get_anthropic_key()`, so nothing needed updating there.

## Test plan

- [x] `python -m lib.config --check` — runs clean, no Anthropic reference, exit 0
- [x] `python -m lib.config --show` — runs clean, no Anthropic reference, exit 0
- [x] `python -m pytest tests/ -q` — 642 passed, 1 skipped (no regressions)
- [x] `ruff check lib/config.py` — all checks passed
- [x] `python -m py_compile lib/config.py` — OK
- [x] `python -c "import yaml; yaml.safe_load(open('lib/config.example.yaml'))"` — parses fine after block removal

Closes #107


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnrWxtKQStiTx1qFkqc5sm)_