### PR TITLE
fix(observer): transcript-dir slug drops '.', blind in every worktree (#103)

### DIFF
--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -65,6 +65,75 @@ def test_transcripts_dir_slugifies_the_repo_path():
     assert d.parent.name == "projects"
 
 
+# #103: Claude Code slugifies ':', '\\', '/' AND '.' in the cwd. That last
+# one never showed up from the main checkout (no dot in that path), so it
+# was invisible until the cwd became a worktree — this repo's own CLAUDE.md
+# convention for any session that changes git state. Table test over three
+# cwd shapes so the fix (and any future regression) is pinned without
+# needing any real transcripts on disk.
+TRANSCRIPTS_DIR_CASES = [
+    ("main checkout, no dot",
+     "/home/user/ebaybiz",
+     "-home-user-ebaybiz"),
+    ("worktree cwd (the #103 bug: '.claude' has a dot)",
+     "/home/user/ebaybiz/.claude/worktrees/fix-slug",
+     "-home-user-ebaybiz--claude-worktrees-fix-slug"),
+    ("worktree name itself contains a dot",
+     "/home/user/ebaybiz/.claude/worktrees/fr-great-courses.dvd-obs",
+     "-home-user-ebaybiz--claude-worktrees-fr-great-courses-dvd-obs"),
+]
+
+
+def test_transcripts_dir_handles_dots_in_every_cwd_shape():
+    for label, repo, expected_slug in TRANSCRIPTS_DIR_CASES:
+        d = transcripts_dir(Path(repo))
+        assert d.name == expected_slug, label
+        assert d.parent.name == "projects", label
+
+
+def test_main_lists_near_matching_dirs_when_transcripts_dir_is_missing(
+        monkeypatch, capsys):
+    # #103's "make the miss loud" fallback: when the computed transcripts
+    # dir doesn't exist, scan ~/.claude/projects/ for directories whose name
+    # contains the repo's slugified basename and suggest them via --dir,
+    # instead of a dead-end "no transcripts" with nothing else to try.
+    home = Path(tempfile.mkdtemp())
+    projects = home / ".claude" / "projects"
+    match_dir = "-home-user--claude-worktrees-ebaybiz-issue-103"
+    other_dir = "-home-user-some-unrelated-repo"
+    (projects / match_dir).mkdir(parents=True)
+    (projects / other_dir).mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr("tools.session_observer.REPO", Path("/home/user/ebaybiz"))
+
+    missing_dir = home / "nope-does-not-exist"
+    rc = main(["--dir", str(missing_dir)])
+    out = capsys.readouterr().out
+
+    assert rc == 2
+    assert f"no transcripts at {missing_dir}" in out
+    assert "1 directory(ies) here do match 'ebaybiz'" in out
+    assert f"~/.claude/projects/{match_dir}" in out
+    assert other_dir not in out
+
+
+def test_main_no_transcripts_without_projects_dir_never_raises(monkeypatch, capsys):
+    # Graceful degradation, same as the rest of this module: no
+    # ~/.claude/projects/ at all (fresh machine, wiped cache) must not crash
+    # the fallback scan — just fall back to the plain "no transcripts" line.
+    home = Path(tempfile.mkdtemp())   # no .claude/projects under here
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr("tools.session_observer.REPO", Path("/home/user/ebaybiz"))
+
+    missing_dir = home / "nope-does-not-exist"
+    rc = main(["--dir", str(missing_dir)])
+    out = capsys.readouterr().out
+
+    assert rc == 2
+    assert f"no transcripts at {missing_dir}" in out
+    assert "match" not in out
+
+
 def test_clean_prompt_drops_image_placeholders():
     txt = "[Image: original 4000x3000, displayed at 2000x1500.]\nprice this lot"
     assert _clean_prompt(txt) == "price this lot"

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -146,8 +146,13 @@ def _turn_cost_usd(usage: dict, model) -> float:
 
 
 def transcripts_dir(repo: Path) -> Path:
-    """Claude Code slugifies the cwd: every ':', '\\' and '/' becomes '-'."""
-    slug = re.sub(r"[:\\/]", "-", str(repo))
+    """Claude Code slugifies the cwd: every ':', '\\', '/' and '.' becomes '-'.
+
+    The '.' matters: a worktree cwd is <repo>/.claude/worktrees/<name>, and
+    '.claude' slugifies to '-claude', giving '…ebaybiz--claude-worktrees-…'.
+    Leaving '.' out silently resolves to a directory that does not exist.
+    """
+    slug = re.sub(r"[:\\/.]", "-", str(repo))
     return Path.home() / ".claude" / "projects" / slug
 
 
@@ -1101,6 +1106,16 @@ def main(argv=None) -> int:
     root = Path(args.dir) if args.dir else transcripts_dir(REPO)
     if not root.is_dir():
         print(f"no transcripts at {root}")
+        projects_dir = Path.home() / ".claude" / "projects"
+        if projects_dir.is_dir():
+            stem = re.sub(r"[:\\/.]", "-", REPO.name)
+            near = sorted(p.name for p in projects_dir.iterdir()
+                          if p.is_dir() and stem in p.name)
+            if near:
+                print(f"  {len(near)} directory(ies) here do match '{stem}' — the slug is "
+                      f"probably wrong, not the history. Try --dir with one of:")
+                for n in near[:5]:
+                    print(f"    ~/.claude/projects/{n}")
         return 2
     files = sorted(root.glob("*.jsonl"), key=os.path.getmtime, reverse=True)
     if not args.all:


### PR DESCRIPTION
## Bug

`ebz observe` returned "no transcripts" from inside every worktree. `tools/session_observer.py`'s `transcripts_dir()` slugified `':'`, `'\\'` and `'/'` in the cwd but missed `'.'`. Claude Code's own slugification replaces `.` with `-` too, so a worktree cwd (`<repo>/.claude/worktrees/<name>` — this repo's own CLAUDE.md convention for any session that changes git state) resolved to a directory that never existed. That never showed up from the main checkout (no dot in that path), so it was invisible until the cwd was a worktree — i.e. every session doing git work.

## Fix

- Added `.` to the slug regex's character class (`[:\\/.]`) and corrected the docstring to explain why the dot matters (the `.claude` segment specifically, and worktree names in general).

## Fallback: make the miss loud

When the computed transcripts dir still doesn't exist, `main()` now scans `~/.claude/projects/` for directories whose name contains the repo's slugified basename, and prints up to 5 as `--dir` candidates — turning a dead end into a list of likely fixes instead of a silent "no transcripts". Degrades gracefully (no crash, just the plain "no transcripts" line) when `~/.claude/projects/` doesn't exist at all, matching this file's existing graceful-degradation style for missing paths.

## Test plan

- `tests/test_session_observer.py::test_transcripts_dir_handles_dots_in_every_cwd_shape` — table test over three cwd shapes: (a) main checkout (no dot, sanity baseline — still resolves the same as before), (b) a worktree path (`<repo>/.claude/worktrees/<name>`, previously broken, now correct), (c) a worktree name that itself contains a dot (`fr-great-courses.dvd-obs`), confirming the fix is the character class generally, not a `.claude`-specific patch.
- `test_main_lists_near_matching_dirs_when_transcripts_dir_is_missing` — synthetic `~/.claude/projects/`-shaped temp dir (via `monkeypatch.setattr(Path, "home", ...)`), asserts the near-match listing fires and filters out unrelated dirs.
- `test_main_no_transcripts_without_projects_dir_never_raises` — no `~/.claude/projects/` at all doesn't crash the fallback.
- Existing `test_transcripts_dir_slugifies_the_repo_path` test kept as-is (still passes unchanged).
- `python -m pytest tests/ -q` → 645 passed, 1 skipped (no regressions).
- `ruff check tools/session_observer.py tests/test_session_observer.py` → all checks passed.
- `python -m py_compile` on both touched files → OK.

Closes #103.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnrWxtKQStiTx1qFkqc5sm)_