### PR TITLE
ci: add Windows to the test matrix, fix stale test-count comment (#105)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,11 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -23,8 +27,10 @@ jobs:
           python-version: "3.11"
           cache: pip
 
-      # Verified against a clean venv + clean checkout: this exact set gives
-      # 53 passed, 1 skipped, 0 failed in ~5s. The skip is tests/test_marble_gate.py,
+      # Verified against a clean venv + clean checkout: this exact set passes
+      # everything except one skip, whatever the current test count in
+      # tests/ happens to be — trust the summary line the suite itself
+      # prints, not a number pinned here. The skip is tests/test_marble_gate.py,
       # which runs the real CLIP gate and needs sentence-transformers (torch, ~2GB,
       # plus a model download on first use) — deliberately not a CI dependency.
       - name: Install test dependencies
@@ -33,6 +39,9 @@ jobs:
           pip install pytest numpy pillow pyyaml opencv-python
 
       - name: Compile every tracked module
+        # xargs isn't a pwsh builtin (the default shell on windows-latest),
+        # so pin this one to bash — Windows runners ship Git Bash for it.
+        shell: bash
         run: git ls-files '*.py' | xargs python -m py_compile
 
       - name: Run the suite

--- a/lib/list_edit.py
+++ b/lib/list_edit.py
@@ -1283,7 +1283,7 @@ def build_review_card(draft_path: Path,
     comps: list[str] = []
     cpath = shoot / "comps.csv"
     if cpath.exists():
-        for r in list(csv.DictReader(cpath.open(encoding="utf-8")))[:8]:
+        for r in list(csv.DictReader(cpath.open(encoding="utf-8", newline="")))[:8]:
             if r.get("url"):
                 comps.append(f"  • ${r.get('price','')} — {(r.get('title') or '')[:55]} — {r['url']}")
     if not comps and (shoot / "price.txt").exists():
@@ -1371,7 +1371,7 @@ def build_review_card(draft_path: Path,
     status = "?"
     lp = _ledger_path()
     if lp.exists():
-        for r in csv.DictReader(lp.open(encoding="utf-8")):
+        for r in csv.DictReader(lp.open(encoding="utf-8", newline="")):
             if r.get("sku") == sku:
                 status = r.get("status") or "?"
                 break

--- a/tools/prep_assess.py
+++ b/tools/prep_assess.py
@@ -24,8 +24,8 @@ def main() -> int:
     live_only = "--all" not in sys.argv
     creds = L.load_credentials()
 
-    led = {r["sku"]: r for r in csv.DictReader(open(ROOT / "listings_ledger.csv", encoding="utf-8"))}
-    sold = {r["sku"] for r in csv.DictReader(open(ROOT / "sales_ledger.csv", encoding="utf-8")) if r.get("sku")}
+    led = {r["sku"]: r for r in csv.DictReader(open(ROOT / "listings_ledger.csv", encoding="utf-8", newline=""))}
+    sold = {r["sku"] for r in csv.DictReader(open(ROOT / "sales_ledger.csv", encoding="utf-8", newline="")) if r.get("sku")}
 
     rows = []
     for d in sorted(ROOT.joinpath("inventory").rglob("draft.md")):

--- a/tools/prep_push.py
+++ b/tools/prep_push.py
@@ -34,7 +34,7 @@ sys.path.insert(0, str(ROOT))
 
 def ledger() -> dict:
     out = {}
-    with open(ROOT / "listings_ledger.csv", encoding="utf-8") as f:
+    with open(ROOT / "listings_ledger.csv", encoding="utf-8", newline="") as f:
         for r in csv.DictReader(f):
             out[r["sku"]] = r
     return out

--- a/tools/price_audit.py
+++ b/tools/price_audit.py
@@ -68,7 +68,7 @@ def days_since(iso: str) -> int | None:
 
 
 def scan(audit_rows: list[dict], days: int) -> list[dict]:
-    led = {r["sku"]: r for r in csv.DictReader(LEDGER.open(encoding="utf-8-sig"))}
+    led = {r["sku"]: r for r in csv.DictReader(LEDGER.open(encoding="utf-8-sig", newline=""))}
     out = []
     for r in audit_rows:
         if r.get("state") != "LIVE" or r.get("group") or not r.get("dir"):


### PR DESCRIPTION
Closes #105.

**Update:** this PR's own CI has now run both legs of the new matrix clean — `pytest (ubuntu-latest)` and `pytest (windows-latest)` both completed with `success` on the first run (run [33414967709](https://github.com/rfair404/claude-ebay-prompts-etc/actions/runs/33414967709)). That's the real signal the issue asked for: the suite goes green on the platform this pipeline is actually operated on, and CI now proves it on every push/PR instead of staying silent about it.

## What changed

**`.github/workflows/tests.yml`**
- Added a `windows-latest` leg to the matrix alongside `ubuntu-latest`, with `fail-fast: false` so a Windows-only failure doesn't hide the Linux result (or vice versa).
- The "Compile every tracked module" step pipes `git ls-files` through `xargs`, which isn't a `pwsh` builtin (pwsh is the default shell on `windows-latest` runners) — pinned that one step to `shell: bash`, which Windows GitHub-hosted runners provide via Git Bash. Confirmed working in this PR's own Windows run. Every other `run:` step in the file is a single plain command with nothing bash-specific, so those are left on the per-OS default shell.
- Replaced the stale "53 passed, 1 skipped, 0 failed" comment. Actual current count in this worktree is **642 passed, 1 skipped** (`python -m pytest tests/ -q`) — already well past the "591" the issue mentioned, confirming the issue's own point that a hardcoded number goes stale fast. Reworded to point at the suite's own summary line instead of pinning a number.

**Windows-unsafe patterns found via static inspection (grep across `lib/`, `tools/`, `tests/`), fixed with high confidence:**
- Five `csv.DictReader(...)` / `open(...)` call sites were reading CSVs without `newline=""`: `lib/list_edit.py` (×2), `tools/prep_assess.py` (×2), `tools/prep_push.py`, `tools/price_audit.py`. Python's `csv` module docs require `newline=""` on every platform for quoted fields containing embedded newlines to parse correctly — without it, Windows' text-mode newline translation can also produce inconsistent results. Every *writer* call site in the repo already had `newline=""`; only these reader-side calls were missing it. Fixed by adding `newline=""` — mechanical, no behavior change for the common case (no embedded newlines in current data).
- `tests/test_dir_context.py::test_chain_for_walks_root_to_item_outermost_first`, the test named in the issue, was already fixed by #101 (uses `.as_posix()` rather than `str()`).

**Checked and found clean (no fix needed):**
- No `NamedTemporaryFile` usage anywhere in the repo.
- No hardcoded `/tmp` filesystem paths (one `tmpfiles.org` URL string is unrelated).
- No `os.path.join`/pathlib mixing that would produce a separator mismatch — the one `os.path.join` use (`tools/osd_audit.py`) builds a `glob.glob()` pattern, which is the correct idiom.
- No `shell=True` subprocess calls, no POSIX-only OS calls (`fcntl`, `os.symlink`, `os.chmod`, `os.fork`, etc.).
- No `.rename()`/`os.rename()` calls (which would break on Windows when the destination exists) — all atomic writes already use `os.replace()`, which is safe on both platforms.
- Every `Path.relative_to(...)` result that's stored, compared, or written to a tracked file already normalizes with `.as_posix()` or `.replace("\\", "/")` (this is the pattern #101 established). Two remaining bare `str(...relative_to(...))` uses are in `lib/photo_prep/prep.py` and `tools/prep_gc.py`, but both are human-facing `print()` progress output in manual CLI tools, not compared against anything — a backslash there is normal, native Windows console output, not a bug.

**Found via grep, not verified — surfaced no failure on this PR's own Windows run, but wasn't specifically exercised either:**
- `tempfile.TemporaryDirectory()` is used as a context manager in ~20+ places across the test suite. A known Windows-only failure mode is `PermissionError` on cleanup if any file handle opened inside the directory is still open when the `with` block exits (Windows won't delete a file that's still open, unlike POSIX). I did not find an instance I could confirm is actually broken this way by reading the code, and fixing 20+ call sites speculatively risked masking a real signal. The Windows leg's full test run passed clean, which is good evidence these are fine, but future changes to any of those tests should keep this in mind.

## Verification
- `python -m pytest tests/ -q` (this Linux worktree): **642 passed, 1 skipped** — unchanged before/after these edits, confirming the cross-platform tweaks didn't regress the Linux path.
- `git ls-files '*.py' | xargs python -m py_compile`: passes.
- Workflow YAML parses cleanly (`yaml.safe_load`).
- **This PR's own CI**: both `pytest (ubuntu-latest)` and `pytest (windows-latest)` completed `success` on the first run.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
