### PR TITLE
ci: run the suite on Windows too (#105)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,16 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    # The pipeline is operated from Windows, so Linux-only CI was half a guard:
+    # test_dir_context.py compared a path against a hardcoded "books/context.txt"
+    # and had failed on Windows for its entire life without CI ever seeing it
+    # (found and fixed in #101, #105). fail-fast is off so a break on one OS
+    # still reports the other's result instead of cancelling it.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -23,16 +32,21 @@ jobs:
           python-version: "3.11"
           cache: pip
 
-      # Verified against a clean venv + clean checkout: this exact set gives
-      # 53 passed, 1 skipped, 0 failed in ~5s. The skip is tests/test_marble_gate.py,
-      # which runs the real CLIP gate and needs sentence-transformers (torch, ~2GB,
-      # plus a model download on first use) — deliberately not a CI dependency.
+      # Deliberately only what the tests import. The one skip is
+      # tests/test_marble_gate.py, which runs the real CLIP gate and needs
+      # sentence-transformers (torch, ~2GB, plus a model download on first
+      # use) — not a CI dependency. No count named here on purpose: the last
+      # one said "53 passed" long after the suite had grown past 600, and a
+      # number that specific and that stale invites someone to trust it.
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pytest numpy pillow pyyaml opencv-python
 
+      # bash on both legs: the Windows runner defaults to pwsh, which has no
+      # xargs. Git Bash ships on windows-latest.
       - name: Compile every tracked module
+        shell: bash
         run: git ls-files '*.py' | xargs python -m py_compile
 
       - name: Run the suite


### PR DESCRIPTION
Closes #105.

## Why

The workflow's own header says it exists because "the suite was red for weeks without anyone noticing." It ran `ubuntu-latest` only — so it guarded a platform nobody operates the pipeline from. `tests/test_dir_context.py` compared `str(path.relative_to(root))` against a hardcoded `"books/context.txt"`, which is `books\context.txt` on Windows; it had failed on this machine for its entire life and CI never reported it. (That test was fixed in #101 — the point here is the blind spot, not the test.)

## Changes

- **`windows-latest` added to the matrix**, `fail-fast: false` so a break on one OS still reports the other's result instead of cancelling it.
- **`shell: bash` on the compile step.** The Windows runner defaults to pwsh, which has no `xargs`. Git Bash ships on the image, so one line keeps the step identical on both legs.
- **The stale count comment is gone.** It claimed "53 passed, 1 skipped, 0 failed in ~5s"; the suite is past 600 tests. Per the issue's acceptance criterion I removed the number rather than updating it — it will go stale again. The reason for the one skip (`test_marble_gate.py` needs CLIP/torch, ~2GB) is kept, since that is the part worth knowing.

## Pre-verified, so this should land green

Rather than adding the leg and seeing what breaks, I ran the full suite on Windows first — this repo is operated from a Windows machine, so the new leg's environment was already available:

```
645 passed, 1 warning in 484.96s
```

Zero failures. The issue anticipated finding more path-separator bugs; on this checkout there are none left after #101. So no follow-up triage issue is needed, and the acceptance box for "whatever it turns up is fixed or triaged" is satisfied by there being nothing.

One thing to watch: the local Windows run took ~8 minutes against the Linux leg's ~1m20s, and CI runners are slower than this machine. If the Windows leg becomes annoying, the issue's own fallback — run it on `main` pushes only, not every PR — is the cheap fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
