### PR TITLE
fix(report): totalMarketplaceFee is the final value fee only (#115)

### DIFF
--- a/lib/source_report.py
+++ b/lib/source_report.py
@@ -37,9 +37,14 @@ flagged. On a `channel` bucket it's *correct* — no ROI expected, no flag.
 WHAT THIS PAGE DOES NOT CLAIM
 
 `net_before_postage` is exactly that — before postage. `sales_ledger.csv` has
-no actual-postage column, so every "net" and "profit" figure here overstates
-what was actually kept. The page says so plainly rather than printing a number
-that quietly isn't a profit.
+no actual-postage column. It is also before ADVERTISING: the fee it subtracts
+comes from `totalMarketplaceFee`, which is the final value fee only, and
+promoted-listing fees are billed separately and never appear in the order
+payload (#115). So every "net" and "profit" figure here overstates what was
+actually kept, by postage AND by the whole ad bill — on one measured month the
+latter ran ~8% of item sales, about half the size of the final value fee. The
+page says so plainly rather than printing a number that quietly isn't a
+profit.
 """
 from __future__ import annotations
 
@@ -387,8 +392,9 @@ def render_table(d: dict) -> str:
                "a `channel` bucket (an ongoing habit, not a single purchase) has no ROI "
                "by design, not a missing one.")
     out.append("NET is net_before_postage — sales_ledger.csv carries no actual-postage "
-               "column, so every NET/PROFIT figure here is before postage, not a final "
-               "take-home number.")
+               "column, and the fee it subtracts (totalMarketplaceFee) is the final value "
+               "fee only, so ad spend is absent too. Every NET/PROFIT figure here is "
+               "before postage AND before advertising, not a final take-home number.")
     if u["sold_n"]:
         out.append(f"{u['sold_n']} sale(s) have no matching local folder — reported as "
                    f"their own line, not dropped.")
@@ -562,8 +568,10 @@ def draw(d: dict) -> str:
         '<p class="note">A <strong>bucket</strong> is the nearest ancestor directory that '
         'owns a <code>context.txt</code> — not path depth, so a re-org changes this table\'s '
         'contents, never its correctness. <strong>NET is net_before_postage</strong>: '
-        '<code>sales_ledger.csv</code> carries no actual-postage column, so PROFIT here is '
-        'before postage, not a final take-home figure. <strong>ROI</strong> (net / cost) is '
+        '<code>sales_ledger.csv</code> carries no actual-postage column, and the fee it '
+        'subtracts (<code>totalMarketplaceFee</code>) is the final value fee only, so '
+        'promoted-listing spend is absent as well. PROFIT here is before postage and '
+        'before advertising, not a final take-home figure. <strong>ROI</strong> (net / cost) is '
         'shown only for a <code>kind: event</code> bucket with a recorded <code>spend:</code> '
         '— never 0, never infinite, and never computed for a <code>channel</code> bucket '
         '(an ongoing habit has no single payback to measure). A bucket with '

--- a/prompts/promote.md
+++ b/prompts/promote.md
@@ -76,9 +76,11 @@ eBay offers are `autoSelectFutureInventory` (which listings) and
 performance.
 
 Nor can ROAS be computed locally: `ad_report_metadata` answers **403** on this
-account and orders carry one lump `totalMarketplaceFee` with no ad-fee line. A
-ROAS rule would therefore be acting on a number nobody has. Say so rather than
-approximating one.
+account, and `totalMarketplaceFee` is the final value fee only — ad fees are
+billed separately and are absent from the order payload entirely (#115), so
+there is no ad cost anywhere in local data to divide into. A ROAS rule would
+therefore be acting on a number nobody has. Say so rather than approximating
+one.
 
 ## Goal: MAXIMISE REVENUE — and what that means mechanically
 
@@ -150,9 +152,14 @@ Two funding models, and they are not interchangeable:
 
 ## Reading the result honestly
 
-Ad spend cannot be separated out of the fee column. The Fulfillment API returns
-one lump `totalMarketplaceFee` per order, so once a campaign is running, the
-blended fee rate REPORT prints (16.0%) absorbs the ad fees and no local
-computation can split them. If a campaign's real cost matters, it has to come
-from eBay's ad report, and `GET /ad_report_metadata` currently answers 403 on
-this account — an app-authorisation gap to resolve before relying on it.
+Ad spend is not in the fee column at all — and that is worse than it being
+blended in. `totalMarketplaceFee` is the final value fee ONLY; promoted-listing
+fees are billed separately and never appear in the order payload (#115). So the
+fee rate REPORT prints does NOT absorb the ad fees: the ad bill is simply
+missing, and every net is overstated by it. Measured over one month, advertised
+orders showed a 14.67% fee rate against 14.97% unadvertised — indistinguishable,
+where an embedded 9-10% bid would have shown a 9-10 point gap.
+
+A campaign's real cost has to come from eBay: `GET /ad_report_metadata` answers
+403 on this account (an app-authorisation gap), and Seller Hub's Listings Sales
+Report CSV carries the per-listing ad-fee columns today.

--- a/tools/sales_report.py
+++ b/tools/sales_report.py
@@ -18,10 +18,16 @@ Run it periodically. It does three things, in order:
 
 WHY PROMOTED LISTINGS GET THEIR OWN PANEL
 
-The Fulfillment API reports `totalMarketplaceFee` as a single number — there is
-no per-fee breakdown, so an ad fee cannot be separated from the final value fee
-on the order. Promoted performance therefore has to come from the Marketing API
-side: which listings carry an ad, in which campaign, at what bid, and whether
+`totalMarketplaceFee` is the FINAL VALUE FEE ONLY (#115). Promoted-listing fees
+are billed separately and appear nowhere in the order payload — so there is no
+ad fee in that number to separate out, and every "net" derived from it is
+overstated by the whole ad bill. Measured on one month of live orders: splitting
+clean single-line orders by `lineItems[].properties.soldViaAdCampaign` gives a
+fee rate of 14.67% advertised vs 14.97% not — indistinguishable, where an
+embedded 9-10% ad bid would show as a 9-10 point gap. Seller Hub's Listings
+Sales Report reconciles its monthly final-value-fee total to this field exactly.
+
+Promoted performance therefore has to come from the Marketing API side: which listings carry an ad, in which campaign, at what bid, and whether
 that campaign is actually RUNNING. Joining the ad set to the sold set is what
 turns that into "did promotion sell anything".
 
@@ -456,7 +462,8 @@ def draw(d: dict) -> str:
              f'<div class="stats">'
              + _stat(_money(d["gross"]), "gross realised", f'{d["count"]} sold line items')
              + _stat(_money(d["fee"]), "eBay fees", f'{d["fee_pct"]:.1f}% of gross')
-             + _stat(_money(d["net"]), "net before postage", "what reached the account")
+             + _stat(_money(d["net"]), "net before ads & postage",
+                     "gross minus final value fee only (#115)")
              + _stat(f'{d["avg_pct"]:.0f}%', "average of ask",
                      f'{len(d["below"])} of {d["count"]} sold below ask')
              + _stat(f'{d["median_days"]:.0f}d' if d["median_days"] is not None else "—",
@@ -524,9 +531,11 @@ def draw(d: dict) -> str:
         f'<th class="num">Ads</th></tr>{camp_rows}</table></div>'
         f'<p class="note">Ad states across all campaigns: {_e(mix) or "—"}. '
         'An ad on the listing is not proof the sale came through it — eBay attributes '
-        'that only in its own ad report, and the Fulfillment API returns one lump '
-        '<code>totalMarketplaceFee</code>, so ad spend cannot be split out of the fee '
-        'column here.</p></div></div>')
+        'that only in its own ad report. And <code>totalMarketplaceFee</code> is the '
+        'final value fee <em>only</em>: promoted-listing fees are billed separately and '
+        'are absent from the order payload entirely, so the ad bill is missing from '
+        'every fee and net figure on this page rather than blended into them '
+        '(#115).</p></div></div>')
 
     # pricing band — how the PRICE stage's justified tiers held up
     b = d["bands"]
@@ -628,7 +637,7 @@ def main() -> int:
     out.write_text(draw(d), encoding="utf-8")
 
     print(f"\n{d['count']} sales · {_money(d['gross'])} gross · {_money(d['net'])} net "
-          f"· {d['avg_pct']:.0f}% of ask")
+          f"(before ads & postage) · {d['avg_pct']:.0f}% of ask")
     print(f"promoted: {d['running_campaigns']} running campaign(s), "
           f"{d['live_with_running_ad']}/{d['live_count']} live listings actively promoted")
     print(f"[OK] {out}")


### PR DESCRIPTION
Closes #115. Feature half split out to #119.

## The correction

Four files carried the same claim: that the Fulfillment API returns one lump `totalMarketplaceFee` with no per-fee breakdown, so ad spend is blended in and cannot be separated.

It is not blended in. **`totalMarketplaceFee` is the final value fee only** — promoted-listing fees are billed separately and never appear in the order payload. That is worse than the old claim, not better: the fee rate the dashboard prints does not absorb the ad bill, the ad bill is simply *missing*, and every "net" is overstated by the whole of it. On the month measured in #115 that was ~8% of item sales — about half the size of the final value fee, and the same order of magnitude as all postage.

The old comment was the harmful part: it made the gap invisible by explaining why it was unavoidable.

## Evidence (from #115, against live account data)

- Splitting one month's clean single-line orders on `lineItems[].properties.soldViaAdCampaign`: **14.67%** fee rate advertised vs **14.97%** not. Indistinguishable — an embedded 9–10% bid would show as a 9–10 point gap.
- Seller Hub's Listings Sales Report reconciles its monthly final-value-fee total to this field exactly, with ad fees entirely outside the reconciliation.

I did not re-measure this; it needs live account data. The reconciliation is the issue author's and I've cited it as such.

## What changed

| File | What |
|---|---|
| `tools/sales_report.py` | Module docstring's "WHY PROMOTED LISTINGS GET THEIR OWN PANEL" premise; the promoted-panel note on the page |
| `lib/source_report.py` | "WHAT THIS PAGE DOES NOT CLAIM" header, plus both the text and HTML NET disclaimers |
| `prompts/promote.md` | Both places that reasoned from the lump-fee premise — including the ROAS section, where the real point is that there is no ad cost in local data to divide into at all |

And it stopped presenting the figure as final: the dashboard stat is now **"net before ads & postage" / "gross minus final value fee only"**, and the CLI summary says the same.

## One deliberate non-change

The `net_before_postage` **ledger column keeps its name.** It is a `sales_ledger.csv` field read by `lib/report.py`, `lib/source_report.py`, `lib/sync_actuals.py` and two test modules; renaming it is a data migration, not a docstring fix. The labels are the surface that misleads, and they are what moved.

## Verification

- **644 passed**
- `_stat` escapes its label through `_e()`, so the ampersand is passed raw and renders exactly once — checked, since passing `&amp;` there would have printed literally
- The HTML smoke-run needs `sales_ledger.csv`, which lives in the main checkout rather than this worktree, so the page itself was not rendered here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
