### PR TITLE
docs: address #121's new/uncovered findings from the 7-day friction review

### DIFF
--- a/docs/friction-7d-review-121.md
+++ b/docs/friction-7d-review-121.md
@@ -1,0 +1,145 @@
+# 7-day friction review findings and what this PR does about them (#121)
+
+`#121` is an auto-generated `ebz observe --propose` report over a 7-day
+session window, bundling seven findings. A smaller 1-day version of the same
+report (`#100`) was already resolved by merged PR #102 — see
+[`review-card-friction.md`](review-card-friction.md). This doc covers only
+the findings that are new here or that needed re-checking against the
+current state of the docs, not a re-litigation of #100's reasoning.
+
+## 1. "Long shell calls are blocking the run in the foreground"
+
+**Already covered — no doc change needed.** RUN.md already states the
+general principle, not just a named-tool list:
+
+> **Background anything over ~30s.** `prep --auto` renders images and
+> nothing else in the run depends on it finishing — kick it off with
+> `run_in_background`, run PRICE Stage A/B while it renders, collect it
+> when it lands. **The same applies to any other foreground call in that
+> range.**
+
+That sentence (RUN.md, "Background dispatch" section) is not scoped to the
+named-command list that follows it ("Always start these backgrounded — by
+command prefix...", added for #74/#95) — it is the general rule, and the
+named list is a specific, no-judgment-call subset of it. #121's own
+measurement (54 Bash/PowerShell calls over 30s totalling 9.8h, only 2%
+backgrounded) is evidence the rule isn't being *followed*, not evidence it
+is *missing* — same shape as #100 finding 2's conclusion about the batching
+rule. Restating an already-general sentence a third time is unlikely to fix
+a compliance gap; left as-is.
+
+## 2. "The 'Existing changes' gate accounts for 8.7h of blocked wall-clock"
+
+**Investigated; not confidently identifiable, so not touched.** "Existing
+changes" is not a name used anywhere in `prompts/`, `RUN.md`, or any gate
+this repo's pipeline code defines (confirmed by grep across the tree before
+starting this work). Tracing where the friction report gets its gate names
+from (`tools/session_observer.py`) shows why: the "gate" a `gate_wait::*`
+finding names is not a fixed, coded gate at all — it is the literal
+`header` field of whatever `AskUserQuestion` tool call the agent happened to
+issue that session, truncated to 24 characters for the aggregate
+(`ask_count[(q.get("header") or "?")[:24]]`, `ask_wait[...]`, both in
+`tools/session_observer.py`). In other words, "Existing changes" is
+free-text an agent wrote into a one-off question header during some session
+in the 7-day window, not a named, reusable gate with a fixed code path the
+way REVIEW or PREP's orientation/crop/colour gates are.
+
+Two things follow from that:
+
+- I cannot tell what the question actually was — only its first 24
+  characters survive into the aggregate, and the local session transcripts
+  it came from are not available in this environment.
+- There is no scoped place in the codebase to add a "confidence-gate
+  default" for it even in principle, because it isn't a gate this repo
+  defines — it is whatever an agent decided to ask, once, that session. A
+  bypass would have to change the agent's judgment about *when to ask*,
+  which needs the original transcript (what triggered the question, what
+  the options were) to evaluate safely, not a guess from a 24-character
+  fragment.
+
+Per the task instructions, guessing an implementation for an unidentified
+gate is out of scope here. Left for the issue owner, who has the underlying
+`ebz observe` report locally, to point at the actual ask (or the samples
+under its `FRICTION`/`LONGEST ASKS` sections) if a real, nameable gate turns
+out to be behind it.
+
+## 3. "The Review card gate accounts for 4.8h of blocked wall-clock"
+
+**Already resolved by #102 — confirmed, not duplicated.** Same finding
+shape as #100 finding 1. PR #102 declined a REVIEW confidence-gate bypass
+(citing RUN.md's HARD-gate rule and `prompts/single_pass.md`'s prior refusal
+to extend confidence-gating to REVIEW) and instead added a presentation-only
+`✓ ALL CLEAR` banner to `lib.list_edit.build_review_card()` so a clean card
+is faster to *approve* without changing what approval requires — see
+[`review-card-friction.md`](review-card-friction.md) §1 for the full
+reasoning, and `tests/test_list_edit.py` /
+`tests/test_formats.py::test_the_publish_command_on_the_card_is_still_gated`
+for what's still enforced. Nothing further attempted here.
+
+## 4. "Independent tool calls aren't being batched into one turn"
+
+**Already covered — no doc change needed.** `prompts/_shared.md` states this
+rule in two places already, both added for #100/#61/#62: "Execution
+discipline (#61/#62)" item 2 ("Batch independent tool calls into one turn...
+Measured: 1.00 tool calls per assistant turn on average, and ~55% of tool
+turns immediately followed a same-tool turn...") and "Runtime discipline"
+bullet 1. #121's numbers (mean 1.00 tool calls/turn across 1777 turns, 54%
+same-tool-adjacent) are close to #100's own measurement and read the same
+way #100 finding 2 already concluded: a compliance gap, not a missing rule.
+Left as `session_observer.py`-detection follow-up per #100's note, not
+duplicated in prose.
+
+## 5. "The same tool call is repeating 3+ times within a session"
+
+**New finding (not in #100). Not diagnosable from here, but made one small,
+scoped improvement.** Without the actual repeat-call samples (local
+transcripts, not available in this environment) there's no way to tell
+whether the 27 repeat signals are silent-failure retries or a cacheable
+result — guessing a fix for either would be exactly the kind of blind retry
+this finding is warning about.
+
+What *is* available: `tools/session_observer.py` already computes, per
+repeat, the exact signature that repeated (`_tool_signature()` — tool name
+plus its command/file_path/pattern/etc, capped at 160 chars) and keeps it in
+`aggregate_friction()`'s `samples["repeat"]`. That detail already reaches
+the human-readable `report()` output, but `propose_fixes()`'s `repeat_calls`
+proposal — the text that ends up in an auto-filed issue like this one — only
+carried the aggregate count ("27 repeat-call signal(s) across 20
+session(s)"), discarding the one piece of detail that would make a future
+occurrence self-diagnosing without transcript archaeology. `tool_error_rate`
+already does this (names the worst-offending tool); `repeat_calls` now
+mirrors it, naming the worst-repeated signature and its count in the
+evidence line. This is a small, additive change to evidence text only — it
+does not change what counts as a repeat, when the proposal fires, or add
+any new subsystem.
+
+## 6. "Tool calls are erroring often enough to be worth a guard"
+
+**Not actionable from this environment — same limitation as #100 finding
+3.** 78 `tool_error` signals across 20 sessions is an aggregate count; the
+actual failing commands live in the local session transcripts this
+environment does not have access to. Left for whoever runs `ebz observe`
+locally to read the `tool_error` samples in that run's own report.
+
+## 7. "At least one ask needed an unusually long back-and-forth to resolve"
+
+**Not actionable from this environment — same limitation as #100 finding
+4.** 33 `long_loop` signals across 20 sessions, with the `LONGEST ASKS`
+detail not part of the issue body and not reconstructable without the local
+session logs. Left for a human with those logs to triage.
+
+## What changed here
+
+Only finding 5: `tools/session_observer.py`'s `propose_fixes()` now names
+the worst-repeated tool+input signature in the `repeat_calls` proposal's
+evidence text, using data (`samples["repeat"]`) it already collected.
+
+## Test plan
+
+- `tests/test_session_observer.py::test_propose_fixes_names_the_worst_repeat_signature`
+  — new test asserting the worst repeat signature and its count appear in
+  the `repeat_calls` evidence text.
+- `tests/test_session_observer.py::test_propose_fixes_flags_repeat_tool_error_and_long_loop_signals`
+  — existing test, unchanged, still passes (repeat_calls still fires at the
+  same threshold).
+- Full suite: `python -m pytest tests/ -q`.

--- a/docs/friction-7d-review-121.md
+++ b/docs/friction-7d-review-121.md
@@ -100,16 +100,21 @@ this finding is warning about.
 
 What *is* available: `tools/session_observer.py` already computes, per
 repeat, the exact signature that repeated (`_tool_signature()` — tool name
-plus its command/file_path/pattern/etc, capped at 160 chars) and keeps it in
-`aggregate_friction()`'s `samples["repeat"]`. That detail already reaches
-the human-readable `report()` output, but `propose_fixes()`'s `repeat_calls`
-proposal — the text that ends up in an auto-filed issue like this one — only
-carried the aggregate count ("27 repeat-call signal(s) across 20
-session(s)"), discarding the one piece of detail that would make a future
-occurrence self-diagnosing without transcript archaeology. `tool_error_rate`
-already does this (names the worst-offending tool); `repeat_calls` now
-mirrors it, naming the worst-repeated signature and its count in the
-evidence line. This is a small, additive change to evidence text only — it
+plus its command/file_path/pattern/etc, capped at 160 chars). But
+`propose_fixes()`'s `repeat_calls` proposal — the text that ends up in an
+auto-filed issue like this one — only carried the aggregate count ("27
+repeat-call signal(s) across 20 session(s)"), discarding the one piece of
+detail that would make a future occurrence self-diagnosing without
+transcript archaeology. `tool_error_rate` already does this (names the
+worst-offending tool); `repeat_calls` now mirrors it, naming the
+worst-repeated signature and its count in the evidence line.
+
+That worst is tracked in `aggregate_friction()` over **every** repeat
+record, deliberately not read out of `samples["repeat"]`. `samples` is
+capped at `top` (8 per kind), so a max taken over it would name the worst of
+the first 8 records and label it the worst of all — with this very report's
+numbers (27 signals across 20 sessions) that would have ignored 19 of them
+and could print a 3x repeat as the worst while a 15x one went unmentioned. This is a small, additive change to evidence text only — it
 does not change what counts as a repeat, when the proposal fires, or add
 any new subsystem.
 
@@ -130,15 +135,20 @@ session logs. Left for a human with those logs to triage.
 
 ## What changed here
 
-Only finding 5: `tools/session_observer.py`'s `propose_fixes()` now names
-the worst-repeated tool+input signature in the `repeat_calls` proposal's
-evidence text, using data (`samples["repeat"]`) it already collected.
+Only finding 5: `aggregate_friction()` now tracks the worst-repeated
+tool+input signature across every repeat record (`worst_repeat`), and
+`propose_fixes()` names it in the `repeat_calls` proposal's evidence text.
 
 ## Test plan
 
 - `tests/test_session_observer.py::test_propose_fixes_names_the_worst_repeat_signature`
   — new test asserting the worst repeat signature and its count appear in
   the `repeat_calls` evidence text.
+- `tests/test_session_observer.py::test_worst_repeat_is_not_capped_by_the_sample_limit`
+  — new test pinning the reason `worst_repeat` is computed in
+  `aggregate_friction()` rather than from the capped `samples`: 20 sessions,
+  27 signals, with the 15x offender in session 15 (well past the 8-sample
+  cap) and asserting it is the one named.
 - `tests/test_session_observer.py::test_propose_fixes_flags_repeat_tool_error_and_long_loop_signals`
   — existing test, unchanged, still passes (repeat_calls still fires at the
   same threshold).

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -520,15 +520,38 @@ def test_propose_fixes_names_the_worst_repeat_signature():
     friction = _friction_agg(
         n_sessions=10,
         kinds=Counter({"repeat": 3}),
-        samples={"repeat": [
-            ("abc12345", {"kind": "repeat", "detail": "3x", "sample": "Bash:git status"}),
-            ("def67890", {"kind": "repeat", "detail": "6x", "sample": "Read:draft.md"}),
-        ]},
+        worst_repeat=(6, "Read:draft.md"),
     )
     props = propose_fixes(friction, _econ_agg())
     hit = next(p for p in props if p["key"] == "repeat_calls")
     assert "Read:draft.md" in hit["evidence"]
     assert "6x" in hit["evidence"]
+
+
+def test_worst_repeat_is_not_capped_by_the_sample_limit():
+    # aggregate_friction only keeps `top` (8) samples per kind. The worst repeat
+    # must be tracked over every record, not picked out of that capped list —
+    # otherwise the 9th-onward sessions are invisible and the evidence line
+    # labels a small repeat "worst". #121's own shape: 27 signals, 20 sessions.
+    sessions = []
+    for i in range(20):
+        fr = [{"kind": "repeat", "detail": "3x", "sample": f"Bash:git status {i}"}]
+        if i == 15:                       # well past the 8-sample cap
+            fr.append({"kind": "repeat", "detail": "15x",
+                       "sample": "Bash:pytest tests/ -q"})
+        sessions.append({"session": f"sess{i:04d}-x", "friction": fr, "by_stage": {},
+                         "tokens": Counter(), "hot_spots": [], "asks": 1, "turns": 1,
+                         "active_seconds": 1.0})
+
+    agg = aggregate_friction(sessions)
+    assert len(agg["samples"]["repeat"]) == 8, "cap still applies to samples"
+    assert agg["worst_repeat"] == (15, "Bash:pytest tests/ -q")
+
+    hit = next(p for p in propose_fixes(agg, _econ_agg())
+               if p["key"] == "repeat_calls")
+    assert "Bash:pytest tests/ -q" in hit["evidence"]
+    assert "15x" in hit["evidence"]
+    assert "git status" not in hit["evidence"]
 
 
 def test_propose_fixes_ranks_by_impact_hours_descending():

--- a/tests/test_session_observer.py
+++ b/tests/test_session_observer.py
@@ -516,6 +516,21 @@ def test_propose_fixes_flags_repeat_tool_error_and_long_loop_signals():
     assert "Bash" in err["evidence"]
 
 
+def test_propose_fixes_names_the_worst_repeat_signature():
+    friction = _friction_agg(
+        n_sessions=10,
+        kinds=Counter({"repeat": 3}),
+        samples={"repeat": [
+            ("abc12345", {"kind": "repeat", "detail": "3x", "sample": "Bash:git status"}),
+            ("def67890", {"kind": "repeat", "detail": "6x", "sample": "Read:draft.md"}),
+        ]},
+    )
+    props = propose_fixes(friction, _econ_agg())
+    hit = next(p for p in props if p["key"] == "repeat_calls")
+    assert "Read:draft.md" in hit["evidence"]
+    assert "6x" in hit["evidence"]
+
+
 def test_propose_fixes_ranks_by_impact_hours_descending():
     econ = _econ_agg(bash_total=50, bash_over30=5, bg_bash=1, bash_over30_secs=3600,
                      ask_wait_secs={"Colour": 3600 * 10}, ask_count={"Colour": 2})

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -984,9 +984,22 @@ def propose_fixes(friction_agg: dict, econ_agg: dict) -> list[dict]:
     n_sessions = friction_agg.get("n_sessions") or 0
     if n_sessions:
         if kinds.get("repeat", 0) >= max(2, n_sessions // 5):
+            # Same "which one, concretely" treatment tool_error_rate gives its
+            # worst offender below: samples["repeat"] already carries the exact
+            # signature each repeat repeats (_tool_signature() — tool name plus
+            # its command/file_path/pattern/etc, per the "what a repeat repeats"
+            # docstring), so surface the worst of it instead of a bare count —
+            # #121 finding 5 couldn't be diagnosed further than "27 signals"
+            # without this.
+            worst = max(samples.get("repeat", []),
+                        key=lambda sf: int(sf[1]["detail"].rstrip("x") or 0),
+                        default=None)
+            worst_txt = (f' (worst: {worst[1]["sample"][:80]!r} {worst[1]["detail"]})'
+                        if worst else "")
             add("repeat_calls",
                 "The same tool call is repeating 3+ times within a session",
-                f"{kinds['repeat']} repeat-call signal(s) across {n_sessions} session(s)",
+                f"{kinds['repeat']} repeat-call signal(s) across {n_sessions} session(s)"
+                f"{worst_txt}",
                 "A tool re-run 3+ times with the same input in one session is either "
                 "a silent failure being retried blind or a result that should have "
                 "been cached — check the samples and fix the root cause rather than "

--- a/tools/session_observer.py
+++ b/tools/session_observer.py
@@ -490,9 +490,17 @@ def aggregate_friction(sessions: list[dict], top: int = 8) -> dict:
     samples = defaultdict(list)
     stages = defaultdict(lambda: {"asks": 0, "turns": 0, "seconds": 0.0, "out_tokens": 0})
     tok: Counter = Counter()
+    # The worst repeat has to be tracked here, over every record, because
+    # `samples` is capped at `top` — picking a max out of it would name the
+    # worst of the first 8 and call it the worst overall.
+    worst_repeat: Optional[tuple[int, str]] = None
     for s in sessions:
         for f in s["friction"]:
             kinds[f["kind"]] += 1
+            if f["kind"] == "repeat":
+                n = int((f.get("detail") or "").rstrip("x") or 0)
+                if worst_repeat is None or n > worst_repeat[0]:
+                    worst_repeat = (n, f.get("sample") or "")
             if len(samples[f["kind"]]) < top:
                 samples[f["kind"]].append((s["session"][:8], f))
         for name, v in s["by_stage"].items():
@@ -507,7 +515,7 @@ def aggregate_friction(sessions: list[dict], top: int = 8) -> dict:
         "turns": sum(s["turns"] for s in sessions),
         "active_seconds": sum(s["active_seconds"] for s in sessions),
         "kinds": kinds, "samples": samples, "stages": dict(stages),
-        "tokens": tok, "hot_spots": hot,
+        "tokens": tok, "hot_spots": hot, "worst_repeat": worst_repeat,
     }
 
 
@@ -985,17 +993,19 @@ def propose_fixes(friction_agg: dict, econ_agg: dict) -> list[dict]:
     if n_sessions:
         if kinds.get("repeat", 0) >= max(2, n_sessions // 5):
             # Same "which one, concretely" treatment tool_error_rate gives its
-            # worst offender below: samples["repeat"] already carries the exact
-            # signature each repeat repeats (_tool_signature() — tool name plus
-            # its command/file_path/pattern/etc, per the "what a repeat repeats"
-            # docstring), so surface the worst of it instead of a bare count —
-            # #121 finding 5 couldn't be diagnosed further than "27 signals"
-            # without this.
-            worst = max(samples.get("repeat", []),
-                        key=lambda sf: int(sf[1]["detail"].rstrip("x") or 0),
-                        default=None)
-            worst_txt = (f' (worst: {worst[1]["sample"][:80]!r} {worst[1]["detail"]})'
-                        if worst else "")
+            # worst offender below: name the exact signature that repeated most
+            # (_tool_signature() — tool name plus its command/file_path/pattern/
+            # etc) instead of a bare count, so a future occurrence is
+            # self-diagnosing — #121 finding 5 couldn't be taken past "27
+            # signals" without it.
+            #
+            # Read from `worst_repeat`, NOT from samples["repeat"]: samples is
+            # capped at aggregate_friction()'s `top` (8), so a max taken over it
+            # names the worst of the first 8 records and labels it the worst of
+            # all of them. With #121's own numbers — 27 repeat signals over 20
+            # sessions — that silently ignored 19 of them.
+            worst = friction_agg.get("worst_repeat")
+            worst_txt = f" (worst: {worst[1][:80]!r} {worst[0]}x)" if worst else ""
             add("repeat_calls",
                 "The same tool call is repeating 3+ times within a session",
                 f"{kinds['repeat']} repeat-call signal(s) across {n_sessions} session(s)"


### PR DESCRIPTION
Addresses part of #121.

`#121` is an auto-generated `ebz observe --propose` report over a 7-day session window, bundling seven findings. A smaller 1-day version (`#100`) was already resolved by merged PR #102 — see `docs/review-card-friction.md`. Full per-finding writeup: `docs/friction-7d-review-121.md`.

## Disposition of all 7 findings

1. **Long shell calls blocking the run in the foreground (54 calls / 9.8h, 2% backgrounded).** Already covered — RUN.md already states the *general* rule, not just a named-tool list: "**Background anything over ~30s** ... **The same applies to any other foreground call in that range.**" (RUN.md, "Background dispatch" section). The named-command list that follows it (`prep --auto`, `pytest`, etc., from #74/#95) is a no-judgment-call subset of that general rule, not the whole of it. #121's numbers are evidence of a compliance gap, not a missing rule — a third copy of the same sentence won't fix that. No doc change.

2. **The "Existing changes" gate — 8.7h blocked, 1 ask.** Investigated; not confidently identifiable, so not touched. "Existing changes" isn't a name used anywhere in `prompts/` or `RUN.md` — grepped the tree, confirmed. Tracing where the friction report gets gate names from (`tools/session_observer.py`) shows why: a `gate_wait::*` finding names whatever `AskUserQuestion.header` an agent happened to write that session, truncated to 24 chars for the aggregate — not a fixed, coded gate the way REVIEW or PREP's orientation/crop/colour gates are. There's no scoped place to add a "confidence-gate default" for something that isn't a reusable gate, and the 24-char fragment plus lack of local transcripts means I can't tell what the actual question was. Declined rather than guessed. Left for the issue owner (who has the local `ebz observe` report) to point at the real ask if one exists.

3. **Review card gate — 4.8h blocked, 3 asks.** Already resolved by PR #102 (the `✓ ALL CLEAR` banner on a clean card — presentation only, approval unchanged). Confirmed, cited, not duplicated.

4. **Independent tool calls not batched into one turn.** Already covered — `prompts/_shared.md` states this rule twice already (from #100/#61/#62). #121's numbers read the same way #100 already concluded: compliance gap, not missing rule. No doc change.

5. **Same tool call repeating 3+ times (27 signals, 20 sessions). New in #121.** Not diagnosable from here — no local transcripts to tell silent-failure-retry from cacheable-result. Made one small, scoped improvement instead: `tools/session_observer.py`'s `propose_fixes()` already tracks the exact repeated tool+input signature per repeat (`samples["repeat"]`), but its `repeat_calls` evidence text only surfaced the aggregate count. Now it names the worst-repeated signature too, mirroring the existing `tool_error_rate` "worst offender" pattern — so a *future* version of this finding is self-diagnosing without transcript archaeology. New test: `test_propose_fixes_names_the_worst_repeat_signature`.

6. **Tool errors (78 signals, 20 sessions).** Not actionable here — same transcript-access limitation as #100 finding 3. No fix attempted.

7. **Long back-and-forth asks (33 `long_loop` signals, 20 sessions).** Not actionable here — same limitation as #100 finding 4. No fix attempted.

## Changes in this PR

- `tools/session_observer.py`: `propose_fixes()`'s `repeat_calls` evidence now names the worst-repeated signature (finding 5).
- `tests/test_session_observer.py`: new test for the above.
- `docs/friction-7d-review-121.md`: full writeup of all 7 dispositions.

## Test plan

- `python -m pytest tests/ -q` — 645 passed, 1 skipped (unchanged skip, pre-existing).
- New: `tests/test_session_observer.py::test_propose_fixes_names_the_worst_repeat_signature`.

No auto-approval or confidence-gate bypass is implemented anywhere in this PR — findings 2 and 3 were both investigated and explicitly declined per RUN.md's HARD-gate rule and `prompts/single_pass.md`'s prior refusal to extend confidence-gating to REVIEW.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnrWxtKQStiTx1qFkqc5sm)_