### PR TITLE
feat(source_report): writer + validation for spend/kind keys, spend_unit schema (#118)

### DIFF
--- a/lib/cli.py
+++ b/lib/cli.py
@@ -43,6 +43,9 @@ COMMANDS = {
                      "sales / fees / promotion dashboard"),
     "report":       ("lib.source_report",
                      "cross-directory bucket ROI — report --by-source [--html] (#56)"),
+    "context":      ("lib.context_write",
+                     "write kind:/spend:/spend_unit:/acquired: into a bucket's "
+                     "context.txt, preserving prose (#118)"),
     "promote":      ("tools.promote",
                      "paid-placement planner — proposes; every write needs --confirm"),
     "voice":        ("lib.voice_check",

--- a/lib/context_write.py
+++ b/lib/context_write.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""context_write — the writer for context.txt's kind:/spend:/spend_unit:/
+acquired: keys (#118).
+
+    python -m lib.cli context <bucket-dir> --spend 575 --kind event
+    python -m lib.cli context <bucket-dir> --spend 8 --spend-unit item
+    python -m lib.cli context <bucket-dir> --acquired 2026-07 --dry-run
+
+WHY THIS EXISTS
+
+lib/source_report.py's parser (`parse_context()`) has looked for these keys
+since #56 — but nothing ever WROTE them: no template, no writer, no
+validation step ever existed (#118). A tolerant parser that fell back to
+reading the existing prose ("Spend $575") would work directly against
+source_report.py's own documented reasoning — recovering a number by
+pattern-matching English is exactly what that module exists to stop doing.
+So the fix is this writer, plus the validation check wired into
+source_report.py's own report output (the "N bucket(s) need `ebz context
+--spend=...`" line) that tells you which buckets still need it run.
+
+WHAT IT DOES NOT DO
+
+It never reads a bucket's prose back out loud — it does not print
+context.txt's existing free-text to the terminal or a log (that prose can
+carry PII: named individuals, family relationships, home addresses of an
+estate sale). It only ever echoes the KEYS you asked it to set, never the
+surrounding file content. It also does not walk up the tree hunting for an
+existing bucket the way `bucket_for()` does — point it at the exact
+directory that should own (or already owns) context.txt; a sub-lot that
+should get its own basis needs its own context.txt, and this tool will
+happily create one there.
+
+IDEMPOTENT: running the same flags twice makes no further change to the
+file on the second run (and says so in its output), so it is safe to script
+against every real bucket without worrying about clobbering something on a
+re-run.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))       # sibling lib/ modules
+from source_report import _KEY_RE, _KINDS, _SPEND_UNITS, _to_float  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Canonical write order when a key has no existing line to update in place.
+_ORDER = ("kind", "spend", "spend_unit", "acquired")
+
+
+def _fmt_num(v: float) -> str:
+    """Canonical numeric text for a context.txt value: no `$`, no thousands
+    commas, no trailing `.0` on a whole number (575.0 -> "575", 8.5 -> "8.5")."""
+    s = f"{v:g}"
+    return "0" if s == "-0" else s
+
+
+def upsert_context_text(text: str, updates: dict) -> str:
+    """Return `text` with each `key: value` pair in `updates` set in place.
+
+    Mirrors `parse_context()`'s own "first occurrence wins" reading: an
+    existing `key:` line — the first one — is rewritten with the new value;
+    every other line (prose, blank lines, an unrecognised key, a second
+    occurrence of a key `parse_context()` would ignore anyway) passes
+    through completely unchanged, byte for byte. A key with no existing
+    line in the file is inserted at the very top, ahead of any prose, in
+    `_ORDER`, followed by one blank line before whatever content the file
+    already had (if it had any) — matching the "keys, then a blank line,
+    then the prose" shape already used by the real files that have keys.
+    """
+    lines = (text or "").splitlines()
+    remaining = dict(updates)
+    out: list[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        m = _KEY_RE.match(line)
+        key = m.group(1).lower() if m else None
+        if key in remaining and key not in seen:
+            out.append(f"{key}: {remaining[key]}")
+            seen.add(key)
+        else:
+            out.append(line)
+    new_keys = [k for k in _ORDER if k in remaining and k not in seen]
+    if new_keys:
+        prefix = [f"{k}: {remaining[k]}" for k in new_keys]
+        if out and any(ln.strip() for ln in out):
+            prefix.append("")
+        out = prefix + out
+    result = "\n".join(out)
+    if result and not result.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def write_context(bucket_dir: Path, *, kind: Optional[str] = None,
+                  spend: Optional[float] = None, spend_unit: Optional[str] = None,
+                  acquired: Optional[str] = None, dry_run: bool = False
+                  ) -> tuple[Path, bool, dict]:
+    """Set the given keys on `bucket_dir`/context.txt.
+
+    Only keyword args actually passed (not None) are touched — the rest of
+    the file, key or prose, is left exactly as it was. Returns
+    `(context_path, changed, keys_written)`; `keys_written` holds only the
+    `key: value` strings actually applied — safe to print, never the
+    surrounding prose. With `dry_run=True` nothing is written; `changed`
+    still reports whether writing WOULD have changed the file.
+    """
+    bucket_dir = Path(bucket_dir)
+    f = bucket_dir / "context.txt"
+    old = f.read_text(encoding="utf-8", errors="replace") if f.is_file() else ""
+
+    updates: dict = {}
+    if kind is not None:
+        updates["kind"] = kind
+    if spend is not None:
+        updates["spend"] = _fmt_num(spend)
+    if spend_unit is not None:
+        updates["spend_unit"] = spend_unit
+    if acquired is not None:
+        updates["acquired"] = acquired
+    if not updates:
+        raise ValueError("no keys given to write")
+
+    new = upsert_context_text(old, updates)
+    changed = new != old
+    if changed and not dry_run:
+        f.write_text(new, encoding="utf-8")
+    return f, changed, updates
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="context", description="Write kind:/spend:/spend_unit:/acquired: "
+        "keys into a bucket's context.txt (#118) — preserves any existing prose.")
+    ap.add_argument("bucket_dir", metavar="BUCKET_DIR",
+                    help="the directory that owns (or should own) context.txt — "
+                         "point it at the bucket itself, not an item folder inside it.")
+    ap.add_argument("--kind", choices=sorted(_KINDS),
+                    help="event (a single acquisition — has a real ROI) or "
+                         "channel (an ongoing habit, e.g. FREE/THRIFT — no ROI).")
+    ap.add_argument("--spend", type=str,
+                    help="cost basis, e.g. 575 or 12.50 or $1,200 — what it MEANS "
+                         "is set by --spend-unit (default lot if not given).")
+    ap.add_argument("--spend-unit", dest="spend_unit", choices=sorted(_SPEND_UNITS),
+                    help="what --spend means: lot (the whole acquisition, "
+                         "default), item (a per-item rate), or pair (a "
+                         "per-pair rate) — resolved by source_report.py "
+                         "against the bucket's own sold+live+pending count.")
+    ap.add_argument("--acquired", help="free-text acquisition date/marker, e.g. 2026-07.")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="show what would change without writing anything.")
+    args = ap.parse_args(argv)
+
+    bdir = Path(args.bucket_dir)
+    if not bdir.is_dir():
+        ap.error(f"not a directory: {bdir}")
+
+    spend_val = None
+    if args.spend is not None:
+        spend_val = _to_float(args.spend)
+        if spend_val is None:
+            ap.error(f"--spend: not a number: {args.spend!r}")
+
+    if not any(v is not None for v in (args.kind, spend_val, args.spend_unit, args.acquired)):
+        ap.error("nothing to set — pass at least one of "
+                 "--kind / --spend / --spend-unit / --acquired")
+
+    f, changed, keys = write_context(
+        bdir, kind=args.kind, spend=spend_val, spend_unit=args.spend_unit,
+        acquired=args.acquired, dry_run=args.dry_run)
+
+    try:
+        shown = f.resolve().relative_to(REPO)
+    except ValueError:
+        shown = f
+    for k, v in keys.items():
+        print(f"  {k}: {v}")
+    if changed:
+        print(f"[{'would write' if args.dry_run else 'OK'}] {shown}")
+    else:
+        print(f"[no change] {shown} — already set")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/source_report.py
+++ b/lib/source_report.py
@@ -26,13 +26,23 @@ WHY COST BASIS COMES FROM context.txt KEYS, NOT PROSE
 `context.txt` already carries the story of an acquisition in prose ("An estate
 sale in Social Circle Georgia. ... Spend $575"), and that prose stays the
 payload. But recovering the spend by pattern-matching English is exactly the
-kind of number this file exists to stop producing. `spend:` / `kind:` /
-`acquired:` are real, explicit keys a tool can branch on without guessing.
+kind of number this file exists to stop producing. `spend:` / `spend_unit:` /
+`kind:` / `acquired:` are real, explicit keys a tool can branch on without
+guessing — written by `lib/context_write.py` (`ebz context <bucket-dir>
+--spend=... --kind=...`, #118), never by hand-editing prose.
 `kind` matters because the two axes aren't comparable: an `event` bucket (a
 single purchase — SCJ, MAR) has a real ROI; a `channel` bucket (an ongoing
 habit — FREE, THRIFT) does not, and treating it as one manufactures a number
 that means nothing. A missing `spend:` on an `event` bucket is a *data gap* —
-flagged. On a `channel` bucket it's *correct* — no ROI expected, no flag.
+flagged. On a `channel` bucket it's *correct* — no ROI expected, no flag; it
+still surfaces in the separate, broader `needs_spend` validation line if it
+has sold anything, since COST/PROFIT need a real basis regardless of kind.
+`spend_unit` (#118) says what the number in `spend:` MEANS — `lot` (default,
+the whole acquisition) or a per-`item`/per-`pair` rate, resolved against the
+bucket's own sold+live+pending count by `resolve_cost_basis()`. Per-unit
+INHERITANCE across nested buckets (a parent's default rate reaching a child
+that doesn't set its own) is not implemented — real, underspecified design
+work left as a documented follow-up; see `resolve_cost_basis()`'s docstring.
 
 WHAT THIS PAGE DOES NOT CLAIM
 
@@ -129,8 +139,9 @@ def bucket_label(bucket_dir: Path, root: Optional[Path] = None) -> str:
 # context.txt — tolerant of empty / prose-only / keyed-plus-prose
 # --------------------------------------------------------------------------- #
 
-_KEY_RE = re.compile(r"^\s*(kind|spend|acquired)\s*:\s*(.*?)\s*$", re.I)
+_KEY_RE = re.compile(r"^\s*(kind|spend|spend_unit|acquired)\s*:\s*(.*?)\s*$", re.I)
 _KINDS = {"event", "channel"}
+_SPEND_UNITS = {"lot", "item", "pair"}
 
 
 def _to_float(v, default=None):
@@ -141,7 +152,8 @@ def _to_float(v, default=None):
 
 
 def parse_context(text: str) -> dict:
-    """Pull `kind:` / `spend:` / `acquired:` out of a context.txt body.
+    """Pull `kind:` / `spend:` / `spend_unit:` / `acquired:` out of a
+    context.txt body.
 
     Only an explicit `key: value` line counts — prose that happens to contain
     "Spend $575" is deliberately NOT read as the spend field (that is the whole
@@ -149,9 +161,19 @@ def parse_context(text: str) -> dict:
     empty file, a prose-only file, and a file mixing key lines with prose in
     any order — all three shapes already exist on disk under inventory/.
     First occurrence of a key wins; a bare `kind:` value outside {event,
-    channel} is treated as unset rather than trusted verbatim.
+    channel} is treated as unset rather than trusted verbatim, same for a
+    `spend_unit:` value outside {lot, item, pair}.
+
+    `spend_unit` closes the #118 schema gap: `spend: 575` alone can't say
+    whether that number is the whole lot, a per-item rate, or a per-pair
+    rate — real prose on disk uses all three shapes ("total lot cost me
+    $575", "assume item cost of $8 per item", a per-pair figure). It
+    defaults to `"lot"` when absent, which is both the natural reading of a
+    bare `spend:` and exactly the old single-scalar behaviour, so the one
+    real file that already has `acquired:` (and every fixture/test written
+    before #118) keeps working unchanged.
     """
-    kind = spend = acquired = None
+    kind = spend = spend_unit = acquired = None
     for line in (text or "").splitlines():
         m = _KEY_RE.match(line)
         if not m:
@@ -165,19 +187,24 @@ def parse_context(text: str) -> dict:
                 kind = v
         elif key == "spend" and spend is None:
             spend = _to_float(val)
+        elif key == "spend_unit" and spend_unit is None:
+            v = val.lower()
+            if v in _SPEND_UNITS:
+                spend_unit = v
         elif key == "acquired" and acquired is None:
             acquired = val
-    return {"kind": kind, "spend": spend, "acquired": acquired}
+    return {"kind": kind, "spend": spend, "spend_unit": spend_unit or "lot",
+            "acquired": acquired}
 
 
 def load_context(bucket_dir: Path) -> dict:
     f = Path(bucket_dir) / "context.txt"
     if not f.is_file():
-        return {"kind": None, "spend": None, "acquired": None}
+        return {"kind": None, "spend": None, "spend_unit": "lot", "acquired": None}
     try:
         text = f.read_text(encoding="utf-8", errors="replace")
     except OSError:
-        return {"kind": None, "spend": None, "acquired": None}
+        return {"kind": None, "spend": None, "spend_unit": "lot", "acquired": None}
     return parse_context(text)
 
 
@@ -205,6 +232,48 @@ def is_basis_gap(kind: Optional[str], spend: Optional[float]) -> bool:
     bucket with no recorded spend. A `channel` bucket (or unspecified kind)
     missing spend is correct, not a gap — no ROI was ever expected there."""
     return kind == "event" and spend is None
+
+
+def resolve_cost_basis(spend: Optional[float], spend_unit: Optional[str],
+                       unit_count: int) -> Optional[float]:
+    """Resolve a bucket's recorded `spend:` into a lot-total dollar figure —
+    the number `roi_for()` / `is_basis_gap()` / the COST column expect (#118).
+
+    `spend_unit` says what `spend` actually means: `lot` (default — the
+    whole acquisition) passes it through unchanged, which is also the old
+    single-scalar behaviour. `item` / `pair` are a RATE — multiplied by
+    `unit_count` (the bucket's own sold + live + pending listing count, the
+    only per-bucket unit count `gather()` already tracks) to get the same
+    lot-total figure.
+
+    This does NOT implement per-item/per-pair INHERITANCE across nested
+    buckets — a parent's "$8/item unless a child says otherwise" default
+    reaching a child that records no spend of its own. That is real,
+    currently-underspecified design work (a child overriding for its own
+    items while the parent's default still applies to *other* siblings) left
+    as a follow-up rather than guessed at here; each bucket resolves only
+    its own recorded `spend:` against its own `unit_count`, nothing more.
+    """
+    if spend is None:
+        return None
+    if (spend_unit or "lot").lower() in ("item", "pair"):
+        return spend * max(unit_count, 0)
+    return spend
+
+
+def missing_spend_with_sales(rows: list[dict]) -> list[str]:
+    """Bucket keys with at least one recorded sale but no resolved cost basis.
+
+    This is the #118 validation check — deliberately broader than (and
+    distinct from) `is_basis_gap()`: `is_basis_gap()` only ever flags
+    `kind: event` (a `channel` bucket missing spend is correct, no ROI was
+    ever expected), but ANY bucket that has already sold something needs a
+    recorded `spend:` to keep the COST/PROFIT columns honest, whatever its
+    `kind`. Not a hard failure — surfaced as one summary line in the report,
+    naming what to run (`ebz context --set ...`), not a per-row failure that
+    makes a `channel` bucket's routine thrift-store sales look broken.
+    """
+    return sorted(b["key"] for b in rows if b.get("sold_n", 0) > 0 and not b.get("cost_known"))
 
 
 def sell_through(sold_n: int, live_n: int) -> Optional[float]:
@@ -245,7 +314,8 @@ def _new_bucket(bucket_dir: Path) -> dict:
     ctx = load_context(bucket_dir)
     return {
         "path": bucket_dir, "key": bucket_label(bucket_dir),
-        "kind": ctx["kind"], "spend": ctx["spend"], "acquired": ctx["acquired"],
+        "kind": ctx["kind"], "spend": ctx["spend"], "spend_unit": ctx["spend_unit"],
+        "acquired": ctx["acquired"],
         "sold_n": 0, "gross": 0.0, "fee": 0.0, "net": 0.0,
         "ask_total": 0.0, "live_n": 0, "pending_n": 0,
     }
@@ -305,10 +375,15 @@ def gather() -> dict:
 
     rows = sorted(buckets.values(), key=lambda b: -b["net"])
     for b in rows:
-        b["cost_known"] = b["spend"] is not None
-        b["profit"] = (b["net"] - b["spend"]) if b["cost_known"] else None
-        b["roi"] = roi_for(b["net"], b["spend"], b["kind"])
-        b["gap"] = is_basis_gap(b["kind"], b["spend"])
+        # unit_count is the bucket's own sold+live+pending listing count —
+        # the only per-bucket unit count already tracked, and what a
+        # `spend_unit: item`/`pair` rate resolves against (#118).
+        b["unit_count"] = b["sold_n"] + b["live_n"] + b["pending_n"]
+        b["cost_basis"] = resolve_cost_basis(b["spend"], b["spend_unit"], b["unit_count"])
+        b["cost_known"] = b["cost_basis"] is not None
+        b["profit"] = (b["net"] - b["cost_basis"]) if b["cost_known"] else None
+        b["roi"] = roi_for(b["net"], b["cost_basis"], b["kind"])
+        b["gap"] = is_basis_gap(b["kind"], b["cost_basis"])
         b["sell_through"] = sell_through(b["sold_n"], b["live_n"])
 
     known = [b for b in rows if b["cost_known"]]
@@ -321,11 +396,12 @@ def gather() -> dict:
         "ask_total": sum(b["ask_total"] for b in rows),
         "live_n": sum(b["live_n"] for b in rows),
         "pending_n": sum(b["pending_n"] for b in rows),
-        "cost": sum(b["spend"] for b in known),
+        "cost": sum(b["cost_basis"] for b in known),
         "cost_bucket_n": len(known),
         "profit": sum(b["profit"] for b in known) if known else None,
     }
-    ev_net, ev_cost = sum(b["net"] for b in event_known), sum(b["spend"] for b in event_known)
+    ev_net = sum(b["net"] for b in event_known)
+    ev_cost = sum(b["cost_basis"] for b in event_known)
     total["roi"] = (ev_net / ev_cost) if ev_cost > 0 else None
     total["sell_through"] = sell_through(total["sold_n"], total["live_n"])
 
@@ -336,6 +412,7 @@ def gather() -> dict:
         "gaps": [b["key"] for b in rows if b["gap"]],
         "missing_basis_channel": [b["key"] for b in rows
                                   if b["cost_known"] is False and not b["gap"]],
+        "needs_spend": missing_spend_with_sales(rows),
     }
 
 
@@ -364,7 +441,7 @@ def render_table(d: dict) -> str:
 
     def row(key, b) -> str:
         gap = " *" if b.get("gap") else "  "
-        cost = _fmt_money(b["spend"]) + gap
+        cost = _fmt_money(b["cost_basis"]) + gap
         vals = [key[:22], str(b["live_n"]), _fmt_money(b["ask_total"]),
                 str(b["sold_n"]), _fmt_money(b["gross"]), _fmt_money(b["fee"]),
                 _fmt_money(b["net"]), cost, _fmt_money(b["profit"]),
@@ -375,16 +452,20 @@ def render_table(d: dict) -> str:
         lines.append(row(b["key"], b))
     u = d["unattributed"]
     if u["sold_n"]:
-        lines.append(row(u["key"], {**u, "spend": None, "profit": None, "roi": None,
+        lines.append(row(u["key"], {**u, "cost_basis": None, "profit": None, "roi": None,
                                     "gap": False, "ask_total": 0.0, "live_n": 0,
                                     "sell_through": None, "pending_n": 0}))
     t = d["total"]
     lines.append("-" * (sum(widths) + 2 * (len(widths) - 1)))
-    lines.append(row("TOTAL", {**t, "spend": t["cost"] or None, "gap": False}))
+    lines.append(row("TOTAL", {**t, "cost_basis": t["cost"] or None, "gap": False}))
 
     out = ["\n".join(lines), ""]
     if d["gaps"]:
         out.append(f"* basis not recorded (event, missing spend:): {', '.join(d['gaps'])}")
+    if d.get("needs_spend"):
+        out.append(f"{len(d['needs_spend'])} bucket(s) need `ebz context <dir> --spend=...` "
+                   f"(sold items, no recorded cost basis regardless of kind): "
+                   f"{', '.join(d['needs_spend'])}")
     out.append(f"cost/profit/ROI totals cover {t['cost_bucket_n']} bucket(s) with a "
                f"recorded spend: — buckets missing a basis are excluded, never counted "
                f"as zero cost or pure profit.")
@@ -488,14 +569,18 @@ def _stat(amt: str, lbl: str, sub: str = "") -> str:
 def _bucket_row(key: str, b: dict, *, total: bool = False, is_bucket: bool = True) -> str:
     kind = b.get("kind") or "unspecified"
     gap_pill = ' <span class="pill warn">GAP</span>' if b.get("gap") else ""
-    cost = f'{_money(b["spend"])}' if b.get("cost_known", b.get("spend") is not None) else \
+    cost = f'{_money(b.get("cost_basis"))}' if b.get("cost_known") else \
         '<span class="dim">basis not recorded</span>'
+    rate_note = ""
+    if is_bucket and not total and b.get("spend") is not None and b.get("spend_unit") not in (None, "lot"):
+        rate_note = f' · {_money(b["spend"])}/{_e(b["spend_unit"])} × {b.get("unit_count", 0)}'
     profit_cls = "warn" if (b.get("profit") is not None and b["profit"] < 0) else ""
     tr_open = '<tr class="total">' if total else '<tr>'
     return (
         f'{tr_open}<td>{_e(key)}'
         + (f'<div class="dim" style="font-size:11.5px">{_e(kind)}'
-           + (f' · acquired {_e(b["acquired"])}' if b.get("acquired") else "") + '</div>'
+           + (f' · acquired {_e(b["acquired"])}' if b.get("acquired") else "")
+           + rate_note + '</div>'
            if is_bucket and not total else "")
         + gap_pill + '</td>'
         f'<td class="num">{b["live_n"]}</td>'
@@ -520,13 +605,14 @@ def draw(d: dict) -> str:
     u = d["unattributed"]
     if u["sold_n"]:
         rows_html += _bucket_row(u["key"], {
-            "kind": None, "spend": None, "cost_known": None, "profit": None, "roi": None,
+            "kind": None, "spend": None, "cost_basis": None, "cost_known": False,
+            "profit": None, "roi": None,
             "gap": False, "sell_through": None, "ask_total": 0.0, "live_n": 0,
             "pending_n": 0, "sold_n": u["sold_n"], "gross": u["gross"], "fee": u["fee"],
             "net": u["net"],
         }, is_bucket=False)
     total_row = _bucket_row("TOTAL", {
-        "kind": None, "spend": t["cost"], "cost_known": t["cost_bucket_n"] > 0,
+        "kind": None, "spend": None, "cost_basis": t["cost"], "cost_known": t["cost_bucket_n"] > 0,
         "profit": t["profit"], "roi": t["roi"], "gap": False,
         "sell_through": sell_through(t["sold_n"], t["live_n"]),
         "ask_total": t["ask_total"], "live_n": t["live_n"], "pending_n": t["pending_n"],
@@ -537,6 +623,10 @@ def draw(d: dict) -> str:
                f'{len(d["gaps"])} bucket(s) flagged GAP — an <code>event</code> '
                f'acquisition with no recorded <code>spend:</code>: '
                f'{_e(", ".join(d["gaps"]))}.</p>' if d["gaps"] else "")
+    needs_spend_note = (f'<p class="note warn" style="border-top:0;padding-top:0">'
+               f'{len(d["needs_spend"])} bucket(s) have sales but no resolved cost basis '
+               f'(any <code>kind</code>) — run <code>ebz context &lt;dir&gt; --spend=...</code>: '
+               f'{_e(", ".join(d["needs_spend"]))}.</p>' if d.get("needs_spend") else "")
 
     body = (
         f'<div class="card"><div class="hdr">'
@@ -553,12 +643,14 @@ def draw(d: dict) -> str:
                 "channel buckets carry no ROI by design")
         + _stat(str(len(d["gaps"])), "GAP: event, no spend recorded",
                 "a real data gap, not free money")
+        + _stat(str(len(d["needs_spend"])), "sold, no cost basis (any kind)",
+                "run ebz context <dir> --spend=...")
         + '</div></div>'
     )
 
     body += (
         '<div class="card"><div class="pad"><h2>By bucket (context.txt ownership)</h2>'
-        f'{gap_note}'
+        f'{gap_note}{needs_spend_note}'
         '<div class="scroll"><table><tr><th>Bucket</th><th class="num">Live</th>'
         '<th class="num">Ask $</th><th class="num">Sold</th><th class="num">Gross $</th>'
         '<th class="num">Fees</th><th class="num">Net $</th><th class="num">Cost</th>'

--- a/tests/test_context_write.py
+++ b/tests/test_context_write.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Regression tests for lib/context_write.py — the context.txt writer (#118).
+
+Covers: correct key insertion/update, prose preservation, idempotency,
+dry-run, and the hard PII rule (a bucket's free-text prose must never be
+echoed back — to stdout, to a log, to anything — only the extracted keys).
+
+Run:  pytest tests/test_context_write.py
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "lib"))
+
+import context_write as cw  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# upsert_context_text — the pure text transform
+# --------------------------------------------------------------------------
+
+def test_new_keys_are_inserted_ahead_of_existing_prose():
+    text = "An estate sale. Loaded the truck twice.\n"
+    got = cw.upsert_context_text(text, {"kind": "event", "spend": "575"})
+    assert got == ("kind: event\nspend: 575\n\n"
+                   "An estate sale. Loaded the truck twice.\n")
+
+
+def test_an_existing_key_line_is_rewritten_in_place_not_duplicated():
+    text = "kind: event\nspend: 500\n\nSome prose.\n"
+    got = cw.upsert_context_text(text, {"spend": "575"})
+    assert got == "kind: event\nspend: 575\n\nSome prose.\n"
+    assert got.count("spend:") == 1
+
+
+def test_prose_is_never_altered_only_key_lines_change():
+    text = "kind: channel\n\nA thrift habit, ongoing, no single receipt.\n"
+    got = cw.upsert_context_text(text, {"acquired": "2026-01"})
+    assert "A thrift habit, ongoing, no single receipt." in got
+    assert "acquired: 2026-01" in got
+
+
+def test_empty_file_gets_just_the_key_lines():
+    got = cw.upsert_context_text("", {"kind": "event"})
+    assert got == "kind: event\n"
+
+
+def test_upsert_is_idempotent_second_call_is_a_no_op():
+    text = "An estate sale.\n"
+    once = cw.upsert_context_text(text, {"kind": "event", "spend": "575"})
+    twice = cw.upsert_context_text(once, {"kind": "event", "spend": "575"})
+    assert once == twice
+
+
+def test_unrelated_existing_keys_pass_through_untouched():
+    text = "kind: event\nacquired: 2026-01\n"
+    got = cw.upsert_context_text(text, {"spend": "575"})
+    assert "kind: event" in got
+    assert "acquired: 2026-01" in got
+    assert "spend: 575" in got
+
+
+# --------------------------------------------------------------------------
+# _fmt_num — canonical numeric text (no $, no commas, no trailing .0)
+# --------------------------------------------------------------------------
+
+def test_fmt_num_drops_trailing_zero_on_a_whole_number():
+    assert cw._fmt_num(575.0) == "575"
+
+
+def test_fmt_num_keeps_a_real_decimal():
+    assert cw._fmt_num(12.5) == "12.5"
+
+
+# --------------------------------------------------------------------------
+# write_context — the file-writing entry point
+# --------------------------------------------------------------------------
+
+def test_write_context_creates_a_new_file_with_the_given_keys(tmp_path):
+    f, changed, keys = cw.write_context(tmp_path, kind="event", spend=575.0,
+                                        acquired="2026-07")
+    assert changed is True
+    assert f.is_file()
+    text = f.read_text()
+    assert "kind: event" in text
+    assert "spend: 575" in text
+    assert "acquired: 2026-07" in text
+    assert keys == {"kind": "event", "spend": "575", "acquired": "2026-07"}
+
+
+def test_write_context_preserves_prose_already_on_disk(tmp_path):
+    (tmp_path / "context.txt").write_text(
+        "An estate sale in Social Circle Georgia hosted by my cousin Jane.\n")
+    cw.write_context(tmp_path, spend=575.0, kind="event")
+    text = (tmp_path / "context.txt").read_text()
+    assert "cousin Jane" in text                      # prose survives
+    assert "spend: 575" in text
+    assert "kind: event" in text
+
+
+def test_write_context_is_idempotent_second_call_reports_no_change(tmp_path):
+    cw.write_context(tmp_path, spend=575.0, kind="event", spend_unit="lot")
+    f, changed, _ = cw.write_context(tmp_path, spend=575.0, kind="event",
+                                     spend_unit="lot")
+    assert changed is False
+
+
+def test_write_context_dry_run_never_touches_the_file(tmp_path):
+    (tmp_path / "context.txt").write_text("kind: event\nspend: 500\n")
+    before = (tmp_path / "context.txt").read_text()
+    f, changed, keys = cw.write_context(tmp_path, spend=600.0, dry_run=True)
+    after = (tmp_path / "context.txt").read_text()
+    assert changed is True                             # WOULD have changed
+    assert after == before                              # but did not write
+    assert keys == {"spend": "600"}
+
+
+def test_write_context_only_touches_the_keys_it_is_given(tmp_path):
+    (tmp_path / "context.txt").write_text("kind: event\nspend: 500\nacquired: 2026-01\n")
+    cw.write_context(tmp_path, spend=575.0)
+    text = (tmp_path / "context.txt").read_text()
+    assert "kind: event" in text
+    assert "acquired: 2026-01" in text
+    assert "spend: 575" in text
+
+
+def test_write_context_writes_spend_unit(tmp_path):
+    cw.write_context(tmp_path, spend=8.0, spend_unit="item")
+    text = (tmp_path / "context.txt").read_text()
+    assert "spend_unit: item" in text
+
+
+def test_write_context_raises_when_nothing_is_given(tmp_path):
+    with pytest.raises(ValueError):
+        cw.write_context(tmp_path)
+
+
+# --------------------------------------------------------------------------
+# PII: prose must never be echoed — only extracted keys, anywhere
+# --------------------------------------------------------------------------
+
+_PII_MARKER = "cousin Jane Smith of 4501 Maple"
+
+
+def test_cli_main_never_prints_the_prose_it_read(tmp_path, capsys):
+    (tmp_path / "context.txt").write_text(
+        f"An estate sale hosted by my {_PII_MARKER} Street.\n")
+    rc = cw.main([str(tmp_path), "--spend", "575", "--kind", "event"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert _PII_MARKER not in out                      # prose never echoed
+    assert "kind: event" in out                         # only the keys
+    assert "spend: 575" in out
+
+
+def test_cli_dry_run_also_never_prints_the_prose(tmp_path, capsys):
+    (tmp_path / "context.txt").write_text(f"Hosted by my {_PII_MARKER} Street.\n")
+    cw.main([str(tmp_path), "--spend", "600", "--dry-run"])
+    out = capsys.readouterr().out
+    assert _PII_MARKER not in out
+
+
+def test_write_context_keys_written_never_contains_prose_text(tmp_path):
+    (tmp_path / "context.txt").write_text(f"Hosted by my {_PII_MARKER} Street.\n")
+    _, _, keys = cw.write_context(tmp_path, spend=575.0)
+    assert all(_PII_MARKER not in str(v) for v in keys.values())
+
+
+# --------------------------------------------------------------------------
+# CLI argument handling
+# --------------------------------------------------------------------------
+
+def test_cli_errors_on_a_nonexistent_directory(tmp_path, capsys):
+    missing = tmp_path / "nope"
+    with pytest.raises(SystemExit):
+        cw.main([str(missing), "--spend", "575"])
+
+
+def test_cli_errors_when_nothing_is_given(tmp_path):
+    with pytest.raises(SystemExit):
+        cw.main([str(tmp_path)])
+
+
+def test_cli_errors_on_an_unparseable_spend(tmp_path):
+    with pytest.raises(SystemExit):
+        cw.main([str(tmp_path), "--spend", "not-a-number"])
+
+
+def test_cli_accepts_dollar_and_comma_formatted_spend(tmp_path, capsys):
+    rc = cw.main([str(tmp_path), "--spend", "$1,250.50"])
+    assert rc == 0
+    text = (tmp_path / "context.txt").read_text()
+    assert "spend: 1250.5" in text

--- a/tests/test_source_report.py
+++ b/tests/test_source_report.py
@@ -87,7 +87,8 @@ def test_bucket_label_is_relative_to_root(tmp_path):
 # --------------------------------------------------------------------------
 
 def test_empty_file_parses_to_all_none():
-    assert sr.parse_context("") == {"kind": None, "spend": None, "acquired": None}
+    assert sr.parse_context("") == {"kind": None, "spend": None, "spend_unit": "lot",
+                                     "acquired": None}
 
 
 def test_prose_only_file_does_not_recover_spend_by_pattern_matching():
@@ -96,7 +97,7 @@ def test_prose_only_file_does_not_recover_spend_by_pattern_matching():
     text = ("An estate sale in Social Circle Georgia. Loaded truck twice. "
             "Spend $575 all told, worth every penny.")
     got = sr.parse_context(text)
-    assert got == {"kind": None, "spend": None, "acquired": None}
+    assert got == {"kind": None, "spend": None, "spend_unit": "lot", "acquired": None}
 
 
 def test_keyed_lines_plus_prose_parses_the_keys_and_keeps_the_prose_intact():
@@ -109,7 +110,7 @@ def test_keyed_lines_plus_prose_parses_the_keys_and_keeps_the_prose_intact():
         "Spend $575 all told, worth every penny.\n"
     )
     got = sr.parse_context(text)
-    assert got == {"kind": "event", "spend": 575.0, "acquired": "2026-07"}
+    assert got == {"kind": "event", "spend": 575.0, "spend_unit": "lot", "acquired": "2026-07"}
 
 
 def test_dollar_sign_and_commas_in_spend_are_tolerated():
@@ -120,8 +121,33 @@ def test_unrecognised_kind_value_is_treated_as_unset():
     assert sr.parse_context("kind: garage-sale\n")["kind"] is None
 
 
+# --------------------------------------------------------------------------
+# spend_unit — the #118 schema gap: lot (default) vs item vs pair
+# --------------------------------------------------------------------------
+
+def test_spend_unit_defaults_to_lot_when_absent():
+    # Backward compatible with every real file and every fixture written
+    # before #118 — a bare `spend:` means "the whole lot", same as always.
+    assert sr.parse_context("spend: 575\n")["spend_unit"] == "lot"
+
+
+def test_spend_unit_item_is_read_explicitly():
+    got = sr.parse_context("spend: 8\nspend_unit: item\n")
+    assert got["spend"] == 8.0
+    assert got["spend_unit"] == "item"
+
+
+def test_spend_unit_pair_is_read_explicitly():
+    assert sr.parse_context("spend_unit: pair\n")["spend_unit"] == "pair"
+
+
+def test_unrecognised_spend_unit_value_falls_back_to_lot():
+    assert sr.parse_context("spend_unit: box\n")["spend_unit"] == "lot"
+
+
 def test_load_context_missing_file_is_all_none(tmp_path):
-    assert sr.load_context(tmp_path) == {"kind": None, "spend": None, "acquired": None}
+    assert sr.load_context(tmp_path) == {"kind": None, "spend": None, "spend_unit": "lot",
+                                          "acquired": None}
 
 
 def test_load_context_reads_the_real_file(tmp_path):
@@ -176,6 +202,77 @@ def test_recorded_spend_on_an_event_bucket_is_not_a_gap():
 def test_sell_through_percentage():
     assert sr.sell_through(sold_n=3, live_n=1) == 75.0
     assert sr.sell_through(sold_n=0, live_n=0) is None
+
+
+# --------------------------------------------------------------------------
+# resolve_cost_basis — the #118 spend_unit division: lot / item / pair
+# --------------------------------------------------------------------------
+
+def test_resolve_cost_basis_lot_passes_spend_through_unchanged():
+    # Old single-scalar behaviour, unit_count is irrelevant for a lot.
+    assert sr.resolve_cost_basis(575.0, "lot", unit_count=0) == 575.0
+    assert sr.resolve_cost_basis(575.0, None, unit_count=7) == 575.0
+
+
+def test_resolve_cost_basis_item_multiplies_by_unit_count():
+    assert sr.resolve_cost_basis(8.0, "item", unit_count=12) == pytest.approx(96.0)
+
+
+def test_resolve_cost_basis_pair_multiplies_by_unit_count():
+    assert sr.resolve_cost_basis(15.0, "pair", unit_count=4) == pytest.approx(60.0)
+
+
+def test_resolve_cost_basis_item_with_zero_units_is_zero_not_none():
+    # No items counted yet is zero dollars of resolved basis so far, not an
+    # unknown one — a real, if provisional, number, distinct from "no spend:
+    # key recorded at all" (which stays None).
+    assert sr.resolve_cost_basis(8.0, "item", unit_count=0) == 0.0
+
+
+def test_resolve_cost_basis_missing_spend_is_none_regardless_of_unit():
+    assert sr.resolve_cost_basis(None, "item", unit_count=12) is None
+    assert sr.resolve_cost_basis(None, "lot", unit_count=0) is None
+
+
+def test_resolve_cost_basis_never_goes_negative_on_a_bad_unit_count():
+    assert sr.resolve_cost_basis(8.0, "item", unit_count=-3) == 0.0
+
+
+# --------------------------------------------------------------------------
+# missing_spend_with_sales — the #118 validation check
+# --------------------------------------------------------------------------
+
+def test_missing_spend_with_sales_flags_a_sold_bucket_with_no_cost_basis():
+    rows = [{"key": "FREE", "sold_n": 2, "cost_known": False}]
+    assert sr.missing_spend_with_sales(rows) == ["FREE"]
+
+
+def test_missing_spend_with_sales_does_not_flag_one_that_has_it():
+    rows = [{"key": "ESTATES/SCJ", "sold_n": 1, "cost_known": True}]
+    assert sr.missing_spend_with_sales(rows) == []
+
+
+def test_missing_spend_with_sales_ignores_a_bucket_with_no_sales_yet():
+    # No sales = nothing actionable yet, regardless of cost_known.
+    rows = [{"key": "ESTATES/NEW", "sold_n": 0, "cost_known": False}]
+    assert sr.missing_spend_with_sales(rows) == []
+
+
+def test_missing_spend_with_sales_is_not_limited_to_event_kind():
+    # Unlike is_basis_gap(), this check does not care about `kind` — a
+    # channel bucket that has already sold something still needs a
+    # recorded spend: to keep COST/PROFIT honest, even with no ROI shown.
+    rows = [{"key": "THRIFT", "sold_n": 3, "cost_known": False, "kind": "channel"}]
+    assert sr.missing_spend_with_sales(rows) == ["THRIFT"]
+
+
+def test_missing_spend_with_sales_sorts_and_names_every_flagged_bucket():
+    rows = [
+        {"key": "ZZZ", "sold_n": 1, "cost_known": False},
+        {"key": "AAA", "sold_n": 1, "cost_known": False},
+        {"key": "MMM", "sold_n": 1, "cost_known": True},
+    ]
+    assert sr.missing_spend_with_sales(rows) == ["AAA", "ZZZ"]
 
 
 # --------------------------------------------------------------------------
@@ -297,3 +394,132 @@ def test_render_table_never_shows_missing_basis_as_a_profit_number(fixture_repo)
     by_key = {b["key"]: b for b in d["buckets"]}
     assert by_key["FREE"]["profit"] is None
     assert "basis not recorded" in out or "—" in out
+
+
+def test_gather_needs_spend_flags_the_channel_bucket_that_sold_with_no_basis(fixture_repo):
+    # FREE (channel, no spend:) has a real sale in the fixture — the #118
+    # validation check must name it, unlike the strict event-only `gaps` list.
+    d = sr.gather()
+    assert d["needs_spend"] == ["FREE"]
+    assert "ESTATES/SCJ" not in d["needs_spend"]         # has a recorded spend
+
+
+def test_render_table_surfaces_one_needs_spend_summary_line(fixture_repo):
+    out = sr.render_table(sr.gather())
+    assert "ebz context" in out
+    assert "FREE" in out
+
+
+def test_draw_html_surfaces_the_needs_spend_note(fixture_repo):
+    html_out = sr.draw(sr.gather())
+    assert "ebz context" in html_out
+    assert "FREE" in html_out
+
+
+# --------------------------------------------------------------------------
+# nested buckets, end to end through gather() — not just bucket_for()
+# --------------------------------------------------------------------------
+#
+# The issue's own author made exactly this mistake against live data: an
+# `inventory/`-walker bounded by a shallow max-depth silently rolls a
+# sub-lot's sales up into its PARENT bucket instead of the sub-lot's own
+# context.txt. bucket_for() is unit-tested against this directly
+# (test_a_sub_lot_two_levels_deep_still_resolves_to_the_owning_bucket), but
+# that only proves the resolver is correct in isolation — this fixture runs
+# a sale under a sub-lot THAT HAS ITS OWN context.txt through the full
+# gather() pipeline (sales_ledger.csv -> bucket_for() -> per-bucket rows) to
+# confirm the sub-lot's sale rolls up to the sub-lot, not the parent,
+# end-to-end.
+
+@pytest.fixture
+def nested_fixture_repo(tmp_path, monkeypatch):
+    inv = tmp_path / "inventory"
+    # Parent: FREE, a channel bucket with its own sale.
+    (inv / "FREE" / "misc-item").mkdir(parents=True)
+    (inv / "FREE" / "context.txt").write_text("kind: channel\n")
+    # Sub-lot: FREE/more-mags-444, TWO levels under FREE, with its OWN
+    # context.txt — a real acquisition nested inside an ongoing channel.
+    (inv / "FREE" / "more-mags-444" / "item-1").mkdir(parents=True)
+    (inv / "FREE" / "more-mags-444" / "context.txt").write_text(
+        "kind: event\nspend: 40\n")
+
+    sales = tmp_path / "sales_ledger.csv"
+    rows = [
+        _sale("10", "inventory/FREE/misc-item", gross=12, fee=2, net=10),
+        _sale("11", "inventory/FREE/more-mags-444/item-1", gross=30, fee=4, net=26),
+    ]
+    with sales.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=_SALES_FIELDS)
+        w.writeheader()
+        w.writerows(rows)
+
+    monkeypatch.setattr(sr, "REPO", tmp_path)
+    monkeypatch.setattr(sr, "INVENTORY", inv)
+    monkeypatch.setattr(sr, "SALES_LEDGER", sales)
+    monkeypatch.setattr(sr._report, "REPO", tmp_path)
+    monkeypatch.setattr(sr._report, "INVENTORY", inv)
+    monkeypatch.setattr(sr._report, "LEDGER", tmp_path / "listings_ledger.csv")
+    return tmp_path
+
+
+def test_gather_rolls_a_nested_sub_lot_sale_up_to_the_sub_lot_not_the_parent(nested_fixture_repo):
+    d = sr.gather()
+    by_key = {b["key"]: b for b in d["buckets"]}
+    assert set(by_key) == {"FREE", "FREE/more-mags-444"}
+
+    # The parent's own sale stays on the parent, untouched by the sub-lot.
+    assert by_key["FREE"]["sold_n"] == 1
+    assert by_key["FREE"]["net"] == pytest.approx(10.0)
+
+    # The sub-lot's sale rolls up to ITSELF, not FREE — the exact mistake
+    # a shallow-max-depth context.txt walk would make against live data.
+    assert by_key["FREE/more-mags-444"]["sold_n"] == 1
+    assert by_key["FREE/more-mags-444"]["net"] == pytest.approx(26.0)
+    assert by_key["FREE/more-mags-444"]["kind"] == "event"
+    assert by_key["FREE/more-mags-444"]["cost_basis"] == pytest.approx(40.0)
+    assert by_key["FREE/more-mags-444"]["roi"] == pytest.approx(26 / 40)
+
+    # Neither bucket's sale total leaks into the other's.
+    assert by_key["FREE"]["net"] != by_key["FREE/more-mags-444"]["net"]
+
+
+# --------------------------------------------------------------------------
+# spend_unit end-to-end through gather() — item/pair rate x unit_count
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def spend_unit_fixture_repo(tmp_path, monkeypatch):
+    inv = tmp_path / "inventory"
+    (inv / "THRIFT" / "item-1").mkdir(parents=True)
+    (inv / "THRIFT" / "item-2").mkdir(parents=True)
+    # $5/item, resolved against however many listings THRIFT has (sold+live+pending).
+    (inv / "THRIFT" / "context.txt").write_text("kind: event\nspend: 5\nspend_unit: item\n")
+
+    sales = tmp_path / "sales_ledger.csv"
+    rows = [
+        _sale("20", "inventory/THRIFT/item-1", gross=20, fee=3, net=17),
+        _sale("21", "inventory/THRIFT/item-2", gross=18, fee=2, net=16),
+    ]
+    with sales.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=_SALES_FIELDS)
+        w.writeheader()
+        w.writerows(rows)
+
+    monkeypatch.setattr(sr, "REPO", tmp_path)
+    monkeypatch.setattr(sr, "INVENTORY", inv)
+    monkeypatch.setattr(sr, "SALES_LEDGER", sales)
+    monkeypatch.setattr(sr._report, "REPO", tmp_path)
+    monkeypatch.setattr(sr._report, "INVENTORY", inv)
+    monkeypatch.setattr(sr._report, "LEDGER", tmp_path / "listings_ledger.csv")
+    return tmp_path
+
+
+def test_gather_resolves_a_per_item_spend_against_the_buckets_own_unit_count(spend_unit_fixture_repo):
+    d = sr.gather()
+    b = next(x for x in d["buckets"] if x["key"] == "THRIFT")
+    # 2 sold listings, no live/pending -> unit_count 2 -> $5 x 2 = $10 basis.
+    assert b["unit_count"] == 2
+    assert b["cost_basis"] == pytest.approx(10.0)
+    assert b["cost_known"] is True
+    assert b["gap"] is False
+    assert b["roi"] == pytest.approx((17 + 16) / 10)


### PR DESCRIPTION
## What this does (option B from #118)

`lib/source_report.py`'s `parse_context()` looked for `spend:`/`kind:`/`acquired:` keys since #56, but nothing ever *wrote* them — no template, no writer, no validation. This PR implements the fix the issue author recommended: **a writer, plus validation**, not a tolerant prose-parser (which would work directly against the module's own documented reasoning for why cost basis comes from keys, not English pattern-matching).

### 1. The writer — `lib/context_write.py` (`ebz context <bucket-dir> ...`)
- New CLI subcommand registered in `lib/cli.py`'s `COMMANDS` table: `python -m lib.cli context <bucket-dir> --spend=575 --kind=event --spend-unit=lot --acquired=2026-07`.
- Sets `kind:`/`spend:`/`spend_unit:`/`acquired:` keys **in place**, inserting only missing keys (at the top, ahead of prose) and rewriting existing ones — every other line, including all prose, passes through byte-for-byte unchanged.
- **Idempotent**: running the same flags twice makes no further change (`[no change] ... — already set`).
- `--dry-run` shows what would change without writing.
- **Never echoes prose** — `context.txt` can carry PII (named individuals, family relationships); the writer's output is only ever the `key: value` pairs it set, verified by dedicated tests.

This is the tool the repo owner runs themselves against the real 14 `context.txt` files — **I could not do the option-A hand-backfill**, since `inventory/` is gitignored and doesn't exist in this worktree; I have no access to real business data.

### 2. The `spend_unit` schema gap — closed
`spend: 575` alone couldn't say whether that's a lot total, a per-item rate, or a per-pair rate — real prose on disk uses all three shapes. Added:
- `spend_unit: lot | item | pair` to `_KEY_RE`, defaulting to `"lot"` when absent (backward compatible with every existing file/fixture — a bare `spend:` still means "the whole lot", exactly as before).
- `resolve_cost_basis(spend, spend_unit, unit_count)` — for `item`/`pair`, multiplies the rate by the bucket's own `unit_count` (`sold_n + live_n + pending_n`, the only per-bucket unit count `gather()` already tracks) to get a lot-total dollar figure. `roi_for()`/`is_basis_gap()`/COST/PROFIT all now consume this resolved `cost_basis` rather than the raw scalar.

**Left as a follow-up, explicitly**: per-unit *inheritance* across nested buckets (a parent's "$8/item unless a child says otherwise" default reaching a child that records no spend of its own, while still applying to untouched siblings). This is real, underspecified design work not settled by the issue — implementing it here would mean guessing at semantics rather than following a decision, so `resolve_cost_basis()` only ever resolves a bucket's own recorded `spend:` against its own `unit_count`, documented as such in its docstring and the module docstring.

### 3. Validation check — `missing_spend_with_sales()`
Distinct from `is_basis_gap()` (which only ever flags `kind: event`): flags **any** bucket with a recorded sale but no resolved cost basis, regardless of kind — because a `channel` bucket that already sold something still needs a `spend:` to keep COST/PROFIT honest, even though it correctly gets no ROI. Wired into both the terminal table and the HTML report as one clear summary line:

> `N bucket(s) need \`ebz context <dir> --spend=...\` (sold items, no recorded cost basis regardless of kind): ...`

— instead of every bucket individually looking broken. Not a hard failure, matching `is_basis_gap()`'s existing "flag, don't fail" convention. Once the real 14 files are backfilled with the writer, the four buckets that genuinely record no cost at all will surface here as an honest, actionable gap.

### 4. `kind:` tri-state — confirmed already correct, no change needed
Checked `roi_for()`/`is_basis_gap()` against the module's own docstring (`event` = real ROI, `channel` = no ROI by design, unset = suppressed either way): both already branch correctly on `event`/`channel`/unset. The reason `kind:` currently "has no effect" in the real data is simply that no real file has ever set it — once populated via the writer, this logic starts mattering immediately. No code change was needed here beyond routing the new `cost_basis` through the same functions.

### 5. Nested-bucket regression test — through the full `gather()` pipeline
`bucket_for()` was already unit-tested in isolation for a sub-lot with its own `context.txt` resolving to itself, not its parent — but that only proves the resolver is correct alone. Added `test_gather_rolls_a_nested_sub_lot_sale_up_to_the_sub_lot_not_the_parent`: a synthetic fixture (`FREE/` channel bucket + `FREE/more-mags-444/` sub-lot with its own `context.txt`, each with a real sale) run through the **entire** `sales_ledger.csv → bucket_for() → gather()` pipeline, confirming the sub-lot's sale rolls up to itself end-to-end — exactly the mistake the issue's author made against live data with a bounded-depth walk.

### PII
Confirmed nowhere in this PR does anything print/log a `context.txt`'s free-text prose — only extracted keys. Covered by dedicated tests in `tests/test_context_write.py` (`test_cli_main_never_prints_the_prose_it_read`, etc.) using a synthetic PII marker string.

## Tests
- `tests/test_source_report.py`: existing 31 tests updated for the new `spend_unit` field in `parse_context()`'s return shape; +20 new tests (spend_unit parsing, `resolve_cost_basis` lot/item/pair, `missing_spend_with_sales`, the nested-bucket end-to-end test, a `spend_unit` end-to-end `gather()` test, `needs_spend` wired into `render_table`/`draw`).
- `tests/test_context_write.py` (new): 22 tests covering the text-upsert transform, prose preservation, idempotency, dry-run, PII non-echo, and CLI argument handling.
- Full suite: `python -m pytest tests/ -q` → 686 passed, 1 skipped (pre-existing, unrelated).
- `ruff check` and `python -m py_compile` clean on all touched files.

Addresses #118


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnrWxtKQStiTx1qFkqc5sm)_