### PR TITLE
feat(reporting): standardize on Pacific time for period bucketing (#122)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest numpy pillow pyyaml opencv-python
+          pip install pytest numpy pillow pyyaml opencv-python tzdata
 
       # bash on both legs: the Windows runner defaults to pwsh, which has no
       # xargs. Git Bash ships on windows-latest.

--- a/lib/report.py
+++ b/lib/report.py
@@ -30,8 +30,16 @@ So this reads BOTH the ledger and every `draft.md` / `draft_group.md` on disk,
 merges them on `ebay_listing_id`, and reports which source each row came from.
 Disk wins on conflict — the draft is what the publisher actually wrote.
 
-Times are stored UTC (`...Z`) and displayed in LOCAL time, because "listed
-today" means the user's today, not UTC's.
+Times are stored UTC (`...Z`) and displayed in PACIFIC TIME — eBay's own
+zone, the one Seller Hub reports, the seller invoice, and the 1099-K all use
+(#122). This used to render in whatever zone the machine running this script
+happened to be set to ("listed today" meant the user's today, not UTC's) —
+but that made a THIRD timezone in play alongside UTC storage and eBay's own
+Pacific truth, and "today" drifting with the operator's machine meant this
+report's day/month buckets could disagree with both the API and with eBay's
+own downloads. `REPORTING_TZ` / `to_report_date()` / `to_report_month()`
+below are the one conversion point: call them wherever a stored UTC
+timestamp becomes a reporting day, never truncate a timestamp by hand.
 """
 
 from __future__ import annotations
@@ -43,10 +51,21 @@ import sys
 from datetime import datetime, date, timedelta, timezone
 from pathlib import Path
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 REPO = Path(__file__).resolve().parent.parent
 LEDGER = REPO / "listings_ledger.csv"
 INVENTORY = REPO / "inventory"
+
+# The single reporting timezone (#122). eBay's Seller Hub reports, the seller
+# invoice, and the 1099-K are all built on this zone — an API read bucketed by
+# UTC (or by whatever zone a workstation happens to be set to) can disagree
+# with eBay's own numbers on order count for a day that straddles midnight.
+# An IANA zone, not a fixed offset: Pacific is PST (UTC-8) roughly Nov-Mar and
+# PDT (UTC-7) roughly Mar-Nov, and `ZoneInfo` gets the two changeover days
+# right where a fixed offset would silently misbucket them.
+REPORTING_TZ = ZoneInfo("America/Los_Angeles")
+REPORTING_TZ_LABEL = "Pacific Time"
 
 
 def _parse_utc(raw: str) -> Optional[datetime]:
@@ -62,8 +81,32 @@ def _parse_utc(raw: str) -> Optional[datetime]:
     return dt
 
 
+def to_report_date(raw: str) -> Optional[date]:
+    """A stored UTC timestamp -> the calendar date it falls on in Pacific
+    time (#122). THE boundary conversion: call this wherever a raw timestamp
+    becomes a day a report groups by, instead of slicing the ISO string or
+    taking `.date()` on a naive/UTC datetime — either of those puts a sale
+    made in the 00:00-07:00 UTC window (17:00-24:00 Pacific the evening
+    before, when people shop) on the wrong side of a month boundary. Storage
+    stays UTC; only the read side converts. Returns None for empty/unparsable
+    input."""
+    dt = _parse_utc(raw)
+    return dt.astimezone(REPORTING_TZ).date() if dt else None
+
+
+def to_report_month(raw: str) -> Optional[str]:
+    """`to_report_date`, truncated to `YYYY-MM` for month bucketing (#122)."""
+    d = to_report_date(raw)
+    return d.strftime("%Y-%m") if d else None
+
+
 def _local(dt: Optional[datetime]) -> Optional[datetime]:
-    return dt.astimezone() if dt else None
+    """Reporting-zone datetime (Pacific), for a caller that needs the
+    time-of-day and not just the bucketed date. Named `_local` for the
+    existing call site's sense of "the user's today" — that today is now
+    Pacific's, matching every other report, rather than the host machine's
+    zone (#122)."""
+    return dt.astimezone(REPORTING_TZ) if dt else None
 
 
 def _yaml_scalar(text: str, key: str) -> str:
@@ -162,15 +205,15 @@ def listed_between(rows: list[dict], start: date, end: date) -> list[dict]:
 
 def report_listed(rows: list[dict], start: date, end: date, *, verbose=False) -> str:
     hits = listed_between(rows, start, end)
-    label = ("today" if start == end == date.today()
+    label = ("today" if start == end == datetime.now(REPORTING_TZ).date()
              else f"{start.isoformat()}" if start == end
              else f"{start.isoformat()} .. {end.isoformat()}")
     if not hits:
-        return f"No items listed {label}."
+        return f"No items listed {label} ({REPORTING_TZ_LABEL})."
 
     total = sum(_money(r["price"]) for r in hits)
-    lines = [f"LISTED {label} — {len(hits)} item(s), ${total:,.2f} total ask",
-             ""]
+    lines = [f"LISTED {label} ({REPORTING_TZ_LABEL}) — {len(hits)} item(s), "
+             f"${total:,.2f} total ask", ""]
     w = max(len(r["title"][:52]) for r in hits)
     for r in hits:
         flag = " [GROUP]" if r.get("group") else ""
@@ -262,7 +305,10 @@ def categorize(title: str) -> str:
 def load_sales(days: Optional[int] = None) -> list[dict]:
     if not SALES.exists():
         return []
-    cutoff = (date.today() - timedelta(days=days)) if days else None
+    # "Today" for a --days window is Pacific's today (#122), matching the
+    # Pacific calendar day sold_at is now bucketed into — a host running in a
+    # different zone must not shift which sales fall inside the window.
+    cutoff = (datetime.now(REPORTING_TZ).date() - timedelta(days=days)) if days else None
     out = []
     with SALES.open(encoding="utf-8", newline="") as fh:
         for r in csv.DictReader(fh):
@@ -303,7 +349,8 @@ def report_performance(sales: list[dict], rows: list[dict], *, label: str = "") 
     # gross can legitimately be 0 (a fully-refunded window, a $0 replacement
     # order), and crashing on the headline would hide the rest of the report.
     fee_pct = f"{fees / gross * 100:.1f}%" if gross else "n/a"
-    out = [f"PERFORMANCE — {len(sales)} sold line item(s){label}", "",
+    out = [f"PERFORMANCE — {len(sales)} sold line item(s){label} "
+           f"(dates in {REPORTING_TZ_LABEL})", "",
            f"  gross ${gross:,.2f}   eBay fees ${fees:,.2f} ({fee_pct})   "
            f"net before postage ${net:,.2f}", ""]
 
@@ -342,9 +389,13 @@ def report_performance(sales: list[dict], rows: list[dict], *, label: str = "") 
     aged = []
     for r in sales:
         lr = byid.get(r.get("sku"))
-        pub = _parse_utc((lr or {}).get("published_at", ""))
+        # `to_report_date`, not `_parse_utc(...).date()`: `_sold` is already a
+        # Pacific calendar day (from sold_at, now Pacific-bucketed at write
+        # time — #122), so the publish side has to land on the same calendar
+        # to keep "days to sell" from picking up a spurious +/-1 near midnight.
+        pub = to_report_date((lr or {}).get("published_at", ""))
         if pub:
-            d = (r["_sold"] - pub.date()).days
+            d = (r["_sold"] - pub).days
             if d >= 0:
                 aged.append((d, r))
     if aged:
@@ -440,7 +491,7 @@ def _cli() -> None:
                     help="Show listing URLs and shoot paths.")
     args = ap.parse_args()
 
-    today = date.today()
+    today = datetime.now(REPORTING_TZ).date()
     if args.yesterday:
         start = end = today - timedelta(days=1)
     elif args.days:

--- a/lib/source_report.py
+++ b/lib/source_report.py
@@ -514,7 +514,9 @@ def _bucket_row(key: str, b: dict, *, total: bool = False, is_bucket: bool = Tru
 
 def draw(d: dict) -> str:
     from datetime import datetime
-    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    # Built-at stamp in the reporting timezone (Pacific, #122) rather than the
+    # host machine's local zone — one clock across every report page.
+    now = datetime.now(_report.REPORTING_TZ).strftime("%Y-%m-%d %H:%M")
     t = d["total"]
     rows_html = "".join(_bucket_row(b["key"], b) for b in d["buckets"])
     u = d["unattributed"]
@@ -542,7 +544,8 @@ def draw(d: dict) -> str:
         f'<div class="card"><div class="hdr">'
         f'<p class="eyebrow">ebaybiz · source</p>'
         f'<h1>Bucket ROI — realised by acquisition</h1>'
-        f'<div class="ct">built {_e(now)} local · read-only, local files only</div>'
+        f'<div class="ct">built {_e(now)} {_e(_report.REPORTING_TZ_LABEL)} · '
+        f'read-only, local files only</div>'
         f'</div>'
         f'<div class="stats">'
         + _stat(str(t["cost_bucket_n"]), "buckets with a recorded basis",

--- a/lib/sync_actuals.py
+++ b/lib/sync_actuals.py
@@ -49,6 +49,7 @@ from typing import Optional
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from ebay_client import api_send  # noqa: E402
+from report import REPORTING_TZ_LABEL, to_report_date  # noqa: E402
 
 REPO = Path(__file__).resolve().parent.parent
 SALES_LEDGER = REPO / "sales_ledger.csv"
@@ -111,6 +112,16 @@ def _norm(s: str) -> str:
 # source 1 — orders (the actuals)
 # --------------------------------------------------------------------------- #
 def _fetch_orders_window(days: int, verbose: bool) -> list[dict]:
+    # This cutoff is a rolling fetch WINDOW ("give me roughly the last N
+    # days"), not a reporting BOUNDARY — it decides how far back to ask eBay
+    # for orders, not which calendar day/month a fetched order is counted
+    # into. That bucketing happens once, correctly, in flatten_orders() below
+    # via to_report_date() (#122). Computing the cutoff in UTC vs Pacific
+    # shifts it by at most the 7-8h zone offset out of N*24h — immaterial for
+    # a "days" arg that already defaults to 90 and is commonly run as 180/365/
+    # 730 — and eBay's own `creationdate` filter is itself expressed in UTC,
+    # so a UTC cutoff is also the natural unit to hand the API. Left in UTC
+    # deliberately; see the PR description for the full reasoning.
     since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
     orders: list[dict] = []
     offset, limit = 0, 200
@@ -225,9 +236,20 @@ def flatten_orders(orders: list[dict]) -> tuple[list[dict], dict]:
             # nets out refunds and fee credits, so prefer it over our arithmetic.
             net = ((due * share).quantize(Decimal("0.01")) if has_due
                    else gross - refund_share - fee)
+            # `sold_at` is the reporting day this sale is bucketed into, so it
+            # is derived in the reporting timezone (Pacific, #122) rather than
+            # by slicing the first 10 chars of the UTC `creationDate` — that
+            # naive truncation put a sale made in the 00:00-07:00 UTC window
+            # (17:00-24:00 Pacific the evening before) on the wrong side of a
+            # month boundary, which is exactly the discrepancy #122 reports
+            # against eBay's own downloads. This changes only how NEW rows
+            # are written going forward; nothing already in sales_ledger.csv
+            # is touched or re-derived by this change.
+            creation = o.get("creationDate") or ""
+            sold_date = to_report_date(creation)
             rows.append({
                 "order_id": o.get("orderId", ""),
-                "sold_at": (o.get("creationDate") or "")[:10],
+                "sold_at": sold_date.isoformat() if sold_date else creation[:10],
                 "listing_id": li.get("legacyItemId", ""),
                 "sku": li.get("sku") or "",
                 "title": li.get("title", ""),
@@ -409,7 +431,7 @@ def report(rows: list[dict], drafts: list[dict], ledger: list[dict],
     fees = sum((r["ebay_fee"] for r in rows), Decimal(0))
     net = sum((r["net_before_postage"] for r in rows), Decimal(0))
 
-    print(f"\n=== ACTUALS — {len(rows)} sold line item(s)")
+    print(f"\n=== ACTUALS — {len(rows)} sold line item(s)  (sold_at dates in {REPORTING_TZ_LABEL})")
     print(f"  gross ${_money(gross)}  ·  eBay fees ${_money(fees)} "
           f"({(fees / gross * 100) if gross else 0:.1f}%)  ·  "
           f"net before postage ${_money(net)}")
@@ -496,7 +518,8 @@ def main() -> int:
         print(STORE_JS)
         return 0
 
-    print(f"Fetching orders (last {args.days} days)…")
+    print(f"Fetching orders (last {args.days} days, UTC fetch window; "
+          f"sold_at is bucketed in {REPORTING_TZ_LABEL})…")
     rows, excluded = flatten_orders(fetch_orders(args.days))
     drafts = scan_drafts()
     ledger = load_listings_ledger()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,9 @@
 # they're listed explicitly for clarity/pinning.
 #
 # The rest of the repo (apify_ebay, ebay_client, price_stats, etc.) remains
-# stdlib-only — these deps are only needed for the visual indexes.
+# stdlib-only — these deps are only needed for the visual indexes, with one
+# exception: tzdata below, needed by every module that reads REPORTING_TZ
+# (lib/report.py) on any platform without an OS-level IANA tzdata source.
 
 sentence-transformers>=5.6.0   # CLIP ViT-B/32 embeddings (vindex core)
 torch>=2.12.1                  # CPU build is sufficient
@@ -19,6 +21,12 @@ numpy>=2.4.6                   # embedding math / storage
 lxml>=6.1.1                    # HTML parsing (crawlers)
 opencv-python-headless>=4.13.0 # marble_crop.py auto-crop (Hough + contour blobs)
 scikit-learn>=1.9.0           # marble_classify.py prototype/kNN heads
+
+# --- Core, not just CLIP: stdlib zoneinfo has no bundled tzdata on Windows ---
+# (Linux/macOS ship it at the OS level; Windows does not). Every module that
+# imports lib/report.py's REPORTING_TZ = ZoneInfo("America/Los_Angeles") needs
+# this, on every platform this pipeline runs on — see .github/workflows/tests.yml.
+tzdata>=2025.1                 # IANA tz database for zoneinfo (required on Windows)
 
 # --- PREP photo stage (lib/photo_prep/prep.py) ---
 # Subject segmentation + the objective half of orientation. Both are optional at

--- a/tests/test_report_timezone.py
+++ b/tests/test_report_timezone.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Regression tests for the Pacific reporting-timezone conversion (#122).
+
+Three shapes, matching the issue's "Tests worth having":
+
+  * a fixture order timestamped inside the 00:00-07:00 UTC window lands in
+    the PREVIOUS Pacific day/month via to_report_date()/to_report_month();
+  * fixtures on each side of a real US DST transition (spring-forward and
+    fall-back), confirming ZoneInfo picks PST/PDT correctly rather than a
+    fixed offset silently misbucketing the changeover days;
+  * a reconciliation test: an API-shaped fixture (raw UTC `creationDate`
+    values) and a Seller-Hub-shaped fixture (eBay's own, already-Pacific
+    month total) agree on order count once boundary-converted -- where a
+    naive UTC truncation would disagree, reproducing the exact discrepancy
+    #122 reports against eBay's own downloads.
+
+Run:  pytest tests/test_report_timezone.py
+"""
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "lib"))
+
+import report as R  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# the core bug: 00:00-07:00 UTC falls in the PREVIOUS Pacific day
+# --------------------------------------------------------------------------
+
+def test_early_utc_order_lands_in_the_previous_pacific_day():
+    # 2026-08-01T05:00:00Z is 2026-07-31T22:00:00 Pacific (PDT, UTC-7) -- an
+    # evening sale that the naive `creationDate[:10]` truncation this PR
+    # replaces would have counted on August 1st instead of July 31st.
+    assert R.to_report_date("2026-08-01T05:00:00.000Z") == date(2026, 7, 31)
+
+
+def test_early_utc_order_lands_in_the_previous_pacific_month():
+    # Same order: July under Pacific bucketing, August under naive UTC
+    # truncation -- the exact discrepancy #122 reports against eBay's own
+    # Seller Hub month totals.
+    assert R.to_report_month("2026-08-01T05:00:00.000Z") == "2026-07"
+    naive_utc_truncation_month = "2026-08-01T05:00:00.000Z"[:7]
+    assert naive_utc_truncation_month == "2026-08"
+
+
+def test_utc_order_at_or_after_the_pacific_offset_stays_same_day():
+    # 08:00 UTC is past the PDT (UTC-7) rollover -> 01:00 Pacific, same
+    # calendar day as the UTC date -- confirms the window boundary itself,
+    # not just "always shift back a day".
+    assert R.to_report_date("2026-08-01T08:00:00.000Z") == date(2026, 8, 1)
+
+
+def test_empty_and_unparsable_input_returns_none():
+    assert R.to_report_date("") is None
+    assert R.to_report_date("not-a-date") is None
+    assert R.to_report_month("") is None
+    assert R.to_report_month("also not a date") is None
+
+
+# --------------------------------------------------------------------------
+# DST transitions -- must use the IANA zone, not a fixed offset
+# --------------------------------------------------------------------------
+
+def test_spring_forward_2026_uses_pst_before_and_pdt_after():
+    # US DST starts 2026-03-08 at 02:00 local (clocks jump to 03:00), which
+    # is 10:00 UTC. Just before the rollover: PST (UTC-8). Just after: PDT
+    # (UTC-7). A fixed offset gets one side of this pair wrong.
+    before = "2026-03-08T09:59:00.000Z"   # 01:59 PST
+    after = "2026-03-08T10:01:00.000Z"    # 03:01 PDT
+    dt_before = R._parse_utc(before).astimezone(R.REPORTING_TZ)
+    dt_after = R._parse_utc(after).astimezone(R.REPORTING_TZ)
+    assert dt_before.utcoffset().total_seconds() / 3600 == -8
+    assert dt_after.utcoffset().total_seconds() / 3600 == -7
+    # Both still land on the same Pacific calendar day (the rollover itself
+    # doesn't cross midnight this time) -- the offset is what must differ.
+    assert R.to_report_date(before) == R.to_report_date(after) == date(2026, 3, 8)
+
+
+def test_fall_back_2026_uses_pdt_before_and_pst_after():
+    # US DST ends 2026-11-01 at 02:00 local (PDT), clocks fall back to
+    # 01:00 (PST) -- the 09:00 UTC rollover.
+    before = "2026-11-01T08:59:00.000Z"   # 01:59 PDT
+    after = "2026-11-01T09:01:00.000Z"    # 01:01 PST (after falling back)
+    dt_before = R._parse_utc(before).astimezone(R.REPORTING_TZ)
+    dt_after = R._parse_utc(after).astimezone(R.REPORTING_TZ)
+    assert dt_before.utcoffset().total_seconds() / 3600 == -7
+    assert dt_after.utcoffset().total_seconds() / 3600 == -8
+
+
+def test_a_january_and_a_july_timestamp_pick_different_fixed_offsets():
+    # A hard-coded "PST" (UTC-8) would be right in January and wrong in
+    # July; ZoneInfo picks the correct one for each without being told
+    # which season it is.
+    winter = R._parse_utc("2026-01-15T20:00:00.000Z").astimezone(R.REPORTING_TZ)
+    summer = R._parse_utc("2026-07-15T20:00:00.000Z").astimezone(R.REPORTING_TZ)
+    assert winter.utcoffset().total_seconds() / 3600 == -8
+    assert summer.utcoffset().total_seconds() / 3600 == -7
+
+
+# --------------------------------------------------------------------------
+# reconciliation: API-derived Pacific month counts agree with Seller Hub's
+# own month counts, where naive UTC truncation would not (#122's core bug)
+# --------------------------------------------------------------------------
+
+def test_api_and_seller_hub_order_counts_agree_once_pacific_bucketed():
+    # "API" fixture: raw creationDate timestamps as the Fulfillment API
+    # actually returns them (UTC, trailing `Z`). Two of these are the exact
+    # #122 case -- created just after 00:00 UTC on the 1st, which is still
+    # the evening of the last day of the PREVIOUS month in Pacific.
+    api_orders_creation_dates = [
+        "2026-07-05T18:00:00.000Z",   # 11:00 Pacific -- unambiguous July
+        "2026-07-15T23:00:00.000Z",   # 16:00 Pacific -- unambiguous July
+        "2026-07-31T23:30:00.000Z",   # 16:30 Pacific -- unambiguous July
+        "2026-08-01T02:00:00.000Z",   # 19:00 Pacific, July 31 -- #122 case
+        "2026-08-01T06:00:00.000Z",   # 23:00 Pacific, July 31 -- #122 case
+    ]
+
+    # "Seller Hub" fixture: eBay's own month total, already in its native
+    # (Pacific) zone -- what the seller invoice / Listings Sales Report
+    # would actually show for July.
+    seller_hub_july_order_count = 5
+
+    naive_utc_july_count = sum(
+        1 for c in api_orders_creation_dates if c[:7] == "2026-07")
+    pacific_july_count = sum(
+        1 for c in api_orders_creation_dates if R.to_report_month(c) == "2026-07")
+
+    assert naive_utc_july_count == 3, (
+        "sanity check: the naive UTC-truncation bug this fixture is built "
+        "to demonstrate must actually reproduce here")
+    assert naive_utc_july_count != seller_hub_july_order_count, (
+        "a naive UTC-truncated count must NOT agree with eBay's own "
+        "Seller-Hub count -- reproducing the exact discrepancy #122 reports")
+    assert pacific_july_count == seller_hub_july_order_count, (
+        "the Pacific-bucketed order count must agree with eBay's own "
+        "Seller-Hub-shaped month total")

--- a/tests/test_sync_actuals.py
+++ b/tests/test_sync_actuals.py
@@ -106,6 +106,36 @@ def test_clean_order_survives_untouched():
 
 
 # --------------------------------------------------------------------------
+# sold_at is bucketed in Pacific time, not UTC-truncated (#122)
+# --------------------------------------------------------------------------
+def test_sold_at_lands_in_the_previous_pacific_day_for_an_early_utc_order():
+    # 2026-08-01T02:00:00Z is 19:00 Pacific on July 31 (PDT, UTC-7) -- the
+    # exact #122 case: an evening sale that a naive creationDate[:10] slice
+    # would have miscounted into August.
+    o = _order(oid="9-1", sku="pdt-case")
+    o["creationDate"] = "2026-08-01T02:00:00.000Z"
+    rows, _ = SA.flatten_orders([o])
+    assert len(rows) == 1
+    assert rows[0]["sold_at"] == "2026-07-31"
+
+
+def test_sold_at_matches_utc_date_when_well_clear_of_the_pacific_offset():
+    o = _order(oid="9-2", sku="midday-case")
+    o["creationDate"] = "2026-08-01T20:00:00.000Z"   # 13:00 Pacific, same day
+    rows, _ = SA.flatten_orders([o])
+    assert rows[0]["sold_at"] == "2026-08-01"
+
+
+def test_sold_at_falls_back_to_utc_truncation_for_an_unparsable_creation_date():
+    o = _order(oid="9-3", sku="garbage-case")
+    o["creationDate"] = "not-a-real-timestamp"
+    rows, _ = SA.flatten_orders([o])
+    # No crash, no dropped row -- degrades to the old behaviour rather than
+    # losing the sale.
+    assert rows[0]["sold_at"] == "not-a-real-timestamp"[:10]
+
+
+# --------------------------------------------------------------------------
 # shipping basis — must not double-count
 # --------------------------------------------------------------------------
 def test_buyer_paid_shipping_is_counted_exactly_once():

--- a/tools/sales_report.py
+++ b/tools/sales_report.py
@@ -55,6 +55,8 @@ sys.path.insert(0, str(REPO))
 sys.path.insert(0, str(REPO / "lib"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))   # sibling tools
 
+from report import REPORTING_TZ, REPORTING_TZ_LABEL  # noqa: E402
+
 REPORTS = REPO / "reports"
 ADS_JSON = REPORTS / "ebay_ads.json"
 OUT_HTML = REPORTS / "sales_dashboard.html"
@@ -195,6 +197,12 @@ def gather(days: int) -> dict:
 
     rows = []
     for r in sales:
+        # sold_at is written by sync_actuals.py already bucketed into a
+        # Pacific calendar day (#122) — a bare "YYYY-MM-DD", not a raw UTC
+        # instant. _date() tags it UTC purely because that's its fallback for
+        # an offset-less string; do NOT re-run it through a UTC->Pacific
+        # conversion downstream (to_report_date() et al) or the already-
+        # correct day gets shifted a second time.
         sold = _date(r.get("sold_at", ""))
         pub = published.get(r.get("listing_id", ""))
         rows.append({
@@ -230,7 +238,8 @@ def gather(days: int) -> dict:
     out["tracked"] = sum(1 for r in rows if r["shoot"])
     out["untracked"] = out["count"] - out["tracked"]
 
-    # by month
+    # by month — sold_at is already a Pacific day (#122), so grouping by its
+    # own "YYYY-MM" prefix (no further conversion) is the correct boundary.
     months = defaultdict(lambda: {"n": 0, "gross": 0.0})
     for r in rows:
         if r["sold_at"]:
@@ -452,13 +461,16 @@ def _itm(lid: str, text: str) -> str:
 
 def draw(d: dict) -> str:
     P = []
-    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    # Pacific throughout (#122): the built-at stamp, and every date this page
+    # buckets by, share one clock — eBay's own Seller Hub/invoice/1099-K zone.
+    now = datetime.now(REPORTING_TZ).strftime("%Y-%m-%d %H:%M")
     pulled = d["ads"].get("pulled_at") or "never"
 
     P.append(f'<div class="card"><div class="hdr">'
              f'<p class="eyebrow">ebaybiz · sales</p><h1>Sales &amp; promotion dashboard</h1>'
-             f'<div class="ct">built {_e(now)} local · order window {d["days"]} days · '
-             f'ads pulled {_e(pulled)}</div></div>'
+             f'<div class="ct">built {_e(now)} {_e(REPORTING_TZ_LABEL)} · '
+             f'order window {d["days"]} days (UTC fetch; dates shown in '
+             f'{_e(REPORTING_TZ_LABEL)}) · ads pulled {_e(pulled)}</div></div>'
              f'<div class="stats">'
              + _stat(_money(d["gross"]), "gross realised", f'{d["count"]} sold line items')
              + _stat(_money(d["fee"]), "eBay fees", f'{d["fee_pct"]:.1f}% of gross')
@@ -492,7 +504,9 @@ def draw(d: dict) -> str:
             f'<div class="fill" style="height:{m[1]["gross"] / top * 100:.1f}%"></div>'
             f'<div class="cap">{_e(m[0][2:])}</div></div>'
             for m in d["months"])
-        P.append(f'<div class="card"><div class="pad"><h2>Gross by month</h2>'
+        P.append(f'<div class="card"><div class="pad"><h2>Gross by month '
+                 f'<span class="dim" style="text-transform:none;letter-spacing:0;'
+                 f'font-weight:400">({_e(REPORTING_TZ_LABEL)})</span></h2>'
                  f'<div class="bars">{bars}</div></div></div>')
 
     # promoted listings


### PR DESCRIPTION
## Problem

Three timezones were in play (per #122): storage/API is UTC, `lib/report.py` deliberately rendered in whatever zone the host machine was set to, and eBay's own truth (Seller Hub, seller invoice, 1099-K) is Pacific. Nothing used Pacific, so a month-end report built from the API could disagree with eBay's own downloads on order count — an order created just after 00:00 UTC on the 1st (evening, Pacific, the day before) landed in the wrong month.

This PR implements the **going-forward half only**. No historical data exists in this worktree and none was touched — see "Not in this PR" below.

## What changed

**`lib/report.py`** — the new shared home for the conversion:
- `REPORTING_TZ = ZoneInfo("America/Los_Angeles")` and `REPORTING_TZ_LABEL`.
- `to_report_date(raw_utc) -> date | None` — the one boundary conversion: a stored UTC timestamp to the Pacific calendar date it falls on.
- `to_report_month(raw_utc) -> str | None` — same, truncated to `YYYY-MM`, since month bucketing is common enough across these files to warrant its own function.
- `_local()` (used by `listed_between()`) now converts to `REPORTING_TZ` instead of the host machine's local zone.
- `load_sales()`'s `--days` cutoff and `_cli()`'s `today` are now Pacific-`today`, not machine-local `today`.
- The SPEED (days-to-sell) calc now derives the publish-side date via `to_report_date()` instead of a raw UTC `.date()`, so both sides of that subtraction share one calendar.
- Report headers (`LISTED …`, `PERFORMANCE …`) now say `(Pacific Time)` / name `REPORTING_TZ_LABEL` explicitly, per the issue's point 4.
- I put these in `lib/report.py` rather than `lib/config.py` or a new module: `lib/config.py` is YAML/credentials loading, not reporting, and `lib/report.py` already owns the module's own `_parse_utc`/`_local` time-conversion helpers plus the "times are stored UTC, displayed in \_\_\_" docstring note the issue quotes directly — it's the natural, already-shared convergence point, and `lib/source_report.py` already imports it as `_report`.

**`lib/sync_actuals.py`** (imports `to_report_date`, `REPORTING_TZ_LABEL` from `report`):
- `sold_at` is now `to_report_date(o.get("creationDate")).isoformat()` instead of `creationDate[:10]` — falls back to the old slice if the timestamp is unparsable, so a row is never dropped.
- Report/stdout text now says `(sold_at dates in Pacific Time)` and that the `--days` fetch window is a UTC cutoff.

**`lib/source_report.py`**, **`tools/sales_report.py`**: the "built at …" caption on both HTML report pages now reads Pacific and says so; `tools/sales_report.py`'s "Gross by month" header and top banner now name the zone too. Neither file does its own day/month bucketing independent of `sold_at` (source_report.py has none at all; sales_report.py's month grouping already just reads `sold_at`'s own `YYYY-MM` prefix), so no bucketing-logic changes were needed there beyond what `sync_actuals.py`'s fix upstream already provides — I added a code comment in `tools/sales_report.py` flagging this explicitly, since `sold_at` is now a pre-bucketed Pacific date (not a raw UTC instant), so it must **not** be run back through `to_report_date()` a second time (that would double-convert and shift it a day).

## The `--days N` filter decision

`_fetch_orders_window()`'s cutoff (`datetime.now(timezone.utc) - timedelta(days=days)`) is **left in UTC**, deliberately. Reasoning:

- It's a rolling **fetch window** ("get me roughly the last N days of orders from eBay"), not a **reporting boundary** — it doesn't decide which day/month a fetched order is counted into. That correctness comes entirely from `to_report_date()` applied to each order's `creationDate` afterward, independent of how the window itself was computed.
- eBay's own `creationdate` API filter is expressed in UTC, so a UTC cutoff is the natural unit to hand it.
- The skew between a UTC cutoff and a Pacific one is at most the 7-8h zone offset out of `N * 24h` — for a `--days` value that defaults to 90 and is commonly run as 180/365/730, that's inconsequential to which orders get fetched, and `write_sales_ledger()` merges (never drops rows outside the window) so an off-by-a-few-hours window edge can't silently lose a sale either.
- Moving it to Pacific would add complexity (a Pacific-day-aligned cutoff converted back to a UTC instant for the API call) without fixing anything the issue actually reports.

Left as-is with an inline comment explaining this; happy to revisit if the owner wants an exactly Pacific-day-aligned window.

## Tests (`tests/test_report_timezone.py`, additions to `tests/test_sync_actuals.py`)

- An order in the 00:00–07:00 UTC window asserted into the *previous* Pacific day and month via `to_report_date()`/`to_report_month()`, plus the same case end-to-end through `sync_actuals.flatten_orders()`'s `sold_at` field.
- Fixtures on each side of the 2026 US DST transitions (spring-forward 2026-03-08, fall-back 2026-11-01) asserting the resolved UTC offset is exactly -8 (PST) vs -7 (PDT) on each side — catches a fixed-offset regression that a same-day assertion alone wouldn't.
- A reconciliation test: a synthetic "API" fixture (raw UTC `creationDate` values, two of them just after UTC midnight) vs a synthetic "Seller Hub" fixture (an already-Pacific month total) — asserts the Pacific-bucketed count agrees with Seller Hub's count (5) while a naive UTC-truncated count does not (3), reproducing the exact discrepancy #122 describes.

`python -m pytest tests/ -q` → 655 passed, 1 skipped (no regressions). `ruff check` on touched files shows only 3 pre-existing `F541` warnings unrelated to this change (verified identical on `origin/main` before this branch). `python -m py_compile` clean on all touched files.

## Not in this PR

- **The historical re-derive of `sales_ledger.csv`.** Per the issue's own framing, this is the owner's separate decision, not an implementation detail — this PR makes Pacific the convention going forward only; old rows are unaffected until/unless the owner decides to re-derive them. No real ledger data exists in this worktree and none was touched or simulated.
- **No dry-run diagnostic tool**, deliberately. I considered a read-only "how many existing rows would move to a different month under Pacific" report, but `sold_at` is stored as a bare `YYYY-MM-DD` with no time-of-day — the information needed to redo the bucketing was already thrown away at write time. A local diagnostic over `sales_ledger.csv` alone can't answer that question; answering it would require re-fetching each historical order's original `creationDate` from the API by `order_id`, which is the re-derive itself, just staged differently. Per the task's own guidance ("if in doubt, leave migration tooling out of this PR entirely and just say so") — leaving it out.

Addresses #122


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnrWxtKQStiTx1qFkqc5sm)_