### PR TITLE
feat(dashboard): read-only local dashboard — backlog, drafts, drift (#31 Phase 1)

### DIFF
--- a/lib/cli.py
+++ b/lib/cli.py
@@ -41,6 +41,8 @@ COMMANDS = {
                      "comp JSON -> the thumbnail board (_shared.md hard rule)"),
     "sales-report": ("tools.sales_report",
                      "sales / fees / promotion dashboard"),
+    "dashboard":    ("tools.dashboard",
+                     "backlog by stage, drafts awaiting review, live/ledger drift (#31 Phase 1)"),
     "report":       ("lib.source_report",
                      "cross-directory bucket ROI — report --by-source [--html] (#56)"),
     "promote":      ("tools.promote",

--- a/lib/status.py
+++ b/lib/status.py
@@ -46,8 +46,12 @@ def _sku_from_draft(shoot: Path) -> str:
     return m.group(1) if m else ""
 
 
-def _ledger_row(sku: str) -> Optional[dict]:
-    if not sku or not LEDGER.exists():
+def _ledger_row(sku: str, ledger_by_sku: Optional[dict] = None) -> Optional[dict]:
+    if not sku:
+        return None
+    if ledger_by_sku is not None:
+        return ledger_by_sku.get(sku)
+    if not LEDGER.exists():
         return None
     with LEDGER.open(encoding="utf-8-sig", newline="") as f:
         for row in csv.DictReader(f):
@@ -56,11 +60,17 @@ def _ledger_row(sku: str) -> Optional[dict]:
     return None
 
 
-def gather(shoot: Path) -> dict:
+def gather(shoot: Path, ledger_by_sku: Optional[dict] = None) -> dict:
     """The whole state of one shoot dir, one read pass. Each stage's
     'pending' list is empty iff that stage is fully done — STAGE_CHECK
     itself is the single source of truth for that (unwritten file, an
-    interactive gate's own HARD stop, everything)."""
+    interactive gate's own HARD stop, everything).
+
+    `ledger_by_sku` lets a caller looking at many shoots in one run (e.g.
+    the dashboard's backlog view) preload `listings_ledger.csv` once —
+    `{sku: row}` — instead of this function re-scanning the whole file per
+    shoot. Omitted (the default), it reads the file itself exactly as
+    before; every existing single-shoot caller is unaffected."""
     stages: dict = {}
     next_action = None
     for stage in STAGE_ORDER:
@@ -77,7 +87,7 @@ def gather(shoot: Path) -> dict:
             next_action = f"{stage}: {pending[0]}"
 
     sku = _sku_from_draft(shoot)
-    ledger = _ledger_row(sku)
+    ledger = _ledger_row(sku, ledger_by_sku)
 
     return {
         "shoot": str(shoot),

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -274,6 +274,16 @@ def test_gather_drafts_redacts_a_draft_parse_error_instead_of_the_yaml_text(repo
     assert any("listing --validate" in i for i in issues)
 
 
+def test_draft_price_cell_renders_a_dash_not_zero_for_a_missing_price():
+    # A missing/non-numeric price is a validation problem
+    # (validate_draft_for_sync() already flags it) — "$0.00" would read as a
+    # real, confirmed zero price instead of "unknown."
+    assert dash._draft_price_cell(None) == "—"
+    assert dash._draft_price_cell("") == "—"
+    assert dash._draft_price_cell("not-a-number") == "—"
+    assert dash._draft_price_cell("19.99") == "$19.99"
+
+
 def test_gather_drafts_skips_validation_for_group_drafts(repo):
     inv = repo / "inventory"
     s = _shoot(inv, "lot", "group-item")
@@ -371,7 +381,24 @@ def test_gather_drift_dedupes_choice_variations_by_listing_id(repo):
     ])
     _write_ledger(repo / "listings_ledger.csv", [])
     d = dash.gather_drift()
-    assert d["count"] == 1     # only the first variation is evaluated
+    assert d["count"] == 1     # the group is evaluated once, not once per SKU
+
+
+def test_gather_drift_matches_a_choice_group_against_any_of_its_skus(repo):
+    # The ledger recording a *different* variation's SKU than the one this
+    # dashboard happens to see first must not read as "no ledger row" for
+    # the whole listing — it's a match, just not on the first SKU checked.
+    _write_live_sheet(repo / "inventory_sheet.csv", [
+        {"sku": "var-1", "title": "Choice Group", "listing_id": "333",
+         "live": "yes", "price": "10.00"},
+        {"sku": "var-2", "title": "Choice Group", "listing_id": "333",
+         "live": "yes", "price": "10.00"},
+    ])
+    _write_ledger(repo / "listings_ledger.csv", [
+        {"sku": "var-2", "title": "Choice Group", "price": "10.00", "status": "PUBLISHED"},
+    ])
+    d = dash.gather_drift()
+    assert d["count"] == 0     # matched via var-2; no false "no ledger row"
 
 
 def test_gather_drift_ignores_non_live_rows(repo):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -187,6 +187,30 @@ def test_gather_backlog_rows_carry_sku_and_ledger_status(repo):
     assert row["ledger_status"] == "SYNCED"
 
 
+def test_gather_backlog_preloads_the_ledger_once_not_once_per_shoot(repo, monkeypatch):
+    # lib.status.gather()'s own _ledger_row() re-scans listings_ledger.csv
+    # on every call unless handed a preloaded {sku: row} map — verify
+    # gather_backlog() always passes one, across multiple shoots, so a
+    # large inventory doesn't re-read the ledger file per shoot.
+    inv = repo / "inventory"
+    for name in ("item-1", "item-2", "item-3"):
+        _frame(_shoot(inv, "lot", name))
+    _write_ledger(repo / "listings_ledger.csv", [{"sku": "abc12345", "status": "SYNCED"}])
+
+    calls = []
+    real_ledger_row = _status._ledger_row
+
+    def _spy(sku, ledger_by_sku=None):
+        calls.append(ledger_by_sku)
+        return real_ledger_row(sku, ledger_by_sku)
+
+    monkeypatch.setattr(_status, "_ledger_row", _spy)
+    d = dash.gather_backlog()
+    assert d["count"] == 3
+    assert len(calls) == 3
+    assert all(c is not None for c in calls)   # every call got the preloaded map
+
+
 # ---------------------------------------------------------------------------
 # gather_drafts
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -472,6 +472,30 @@ def test_draft_body_text_never_appears_only_structured_fields_do(repo):
     assert "buyer-facing body must never leak" not in out
 
 
+def test_single_pass_ask_json_free_text_never_appears_in_backlog_or_html(repo):
+    # identify/investigate/draft's pending detail can come straight from a
+    # `.single_pass/ask.json` a stage wrote — free text an agent composed
+    # (e.g. a maker-mark reading), not a structured field.
+    import json
+    inv = repo / "inventory"
+    s = _shoot(inv, "lot", "gated-item")
+    _frame(s)
+    (s / "identify.txt").write_text("x\n")
+    (s / ".single_pass").mkdir()
+    (s / ".single_pass" / "ask.json").write_text(json.dumps([
+        {"stage": "identify",
+         "detail": "SECRET-MAKER-MARK-MARKER reads 'J. Doe Estate, ring 3 of 4'"},
+    ]))
+    d = dash.gather_backlog()
+    row = next(r for r in d["rows"] if r["dir"] == "inventory/lot/gated-item")
+    assert row["blocked_stage"] == "identify"
+    assert "SECRET-MAKER-MARK-MARKER" not in row["next_action"]
+    assert "run `python -m lib.cli status" in row["next_action"]
+
+    out = dash.draw(dash.gather())
+    assert "SECRET-MAKER-MARK-MARKER" not in out
+
+
 # ---------------------------------------------------------------------------
 # CLI registration
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -332,9 +332,23 @@ def test_gather_drift_flags_live_sku_missing_from_ledger(repo):
         {"sku": "orphan-sku", "title": "No Ledger Row", "listing_id": "222",
          "live": "yes", "price": "9.99"},
     ])
+    _write_ledger(repo / "listings_ledger.csv", [])  # present, just no row for this sku
     d = dash.gather_drift()
     assert d["count"] == 1
     assert "no listings_ledger.csv row" in d["rows"][0]["issues"][0]
+
+
+def test_gather_drift_short_circuits_to_empty_when_either_csv_is_missing(repo):
+    # only the live sheet exists — comparing against a ledger that was never
+    # synced would otherwise flag every live row as "no ledger row", which
+    # is misleading rather than a real drift finding (the have_* flags
+    # already say a file is missing)
+    _write_live_sheet(repo / "inventory_sheet.csv", [
+        {"sku": "some-sku", "title": "X", "listing_id": "1",
+         "live": "yes", "price": "9.99"},
+    ])
+    d = dash.gather_drift()
+    assert d == {"rows": [], "have_live_snapshot": True, "have_ledger": False, "count": 0}
 
 
 def test_gather_drift_flags_ledger_published_but_not_live(repo):
@@ -355,6 +369,7 @@ def test_gather_drift_dedupes_choice_variations_by_listing_id(repo):
         {"sku": "var-2", "title": "Choice Group", "listing_id": "333",
          "live": "yes", "price": "10.00"},
     ])
+    _write_ledger(repo / "listings_ledger.csv", [])
     d = dash.gather_drift()
     assert d["count"] == 1     # only the first variation is evaluated
 
@@ -364,6 +379,7 @@ def test_gather_drift_ignores_non_live_rows(repo):
         {"sku": "ended-sku", "title": "Ended", "listing_id": "444",
          "live": "no", "price": "1.00"},
     ])
+    _write_ledger(repo / "listings_ledger.csv", [])
     d = dash.gather_drift()
     assert d["count"] == 0
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -401,6 +401,24 @@ def test_gather_drift_matches_a_choice_group_against_any_of_its_skus(repo):
     assert d["count"] == 0     # matched via var-2; no false "no ledger row"
 
 
+def test_gather_drift_compares_the_ledger_row_against_its_own_matched_variation(repo):
+    # var-1 (the group's first-seen/representative row) is priced
+    # differently from the ledger; var-2 (the one the ledger actually
+    # matches) is priced the same as the ledger. The comparison must use
+    # var-2's own price, not var-1's, or this reads as a false price-drift.
+    _write_live_sheet(repo / "inventory_sheet.csv", [
+        {"sku": "var-1", "title": "Choice Group", "listing_id": "333",
+         "live": "yes", "price": "8.00"},
+        {"sku": "var-2", "title": "Choice Group", "listing_id": "333",
+         "live": "yes", "price": "10.00"},
+    ])
+    _write_ledger(repo / "listings_ledger.csv", [
+        {"sku": "var-2", "title": "Choice Group", "price": "10.00", "status": "PUBLISHED"},
+    ])
+    d = dash.gather_drift()
+    assert d["count"] == 0     # var-2 vs var-2: no drift; var-1 is irrelevant here
+
+
 def test_gather_drift_ignores_non_live_rows(repo):
     _write_live_sheet(repo / "inventory_sheet.csv", [
         {"sku": "ended-sku", "title": "Ended", "listing_id": "444",

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,452 @@
+"""tests/test_dashboard.py — `ebz dashboard` (#31 Phase 1): the read-only
+local dashboard extending tools/sales_report.py's gather()/draw() pattern to
+backlog-by-stage, drafts-awaiting-review, and live/ledger drift.
+
+Deliberately thin on the per-shoot stage logic itself (that's
+lib/status.py's job and tests/test_status.py's coverage) — these tests lock
+down dashboard.py's own job: finding shoot dirs, bucketing by blocking stage,
+filtering the draft/ledger merge to unpublished rows, diffing the two local
+CSVs, and rendering all three into HTML without ever leaking raw prose.
+
+No network, no credentials, no real inventory/ledger — every fixture below
+is synthetic, following the monkeypatch-module-constants pattern
+tests/test_source_report.py and tests/test_status.py already use.
+"""
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "lib"))
+
+import tools.dashboard as dash    # noqa: E402
+import report as _report          # noqa: E402
+import source_report as _sr       # noqa: E402
+import status as _status          # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+def _write_ledger(path: Path, rows: list[dict]) -> None:
+    fields = ["sku", "status", "title", "price", "offer_id", "listing_id", "url",
+              "drafted_at", "synced_at", "published_at", "ended_at", "shipped_at",
+              "updated_at"]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        for r in rows:
+            w.writerow({k: r.get(k, "") for k in fields})
+
+
+def _write_live_sheet(path: Path, rows: list[dict]) -> None:
+    fields = ["sku", "title", "listing_id", "item_url", "offer_id", "live",
+              "offer_status", "listing_status", "quantity", "price", "currency",
+              "format", "marketplace", "condition", "category_id", "category_path",
+              "category_top", "variation_count", "image_count", "aspect_type",
+              "aspect_brand"]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        for r in rows:
+            w.writerow({k: r.get(k, "") for k in fields})
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """An empty synthetic repo, wired into dashboard.py and every module it
+    delegates to (lib.status, lib.report, lib.source_report) so none of them
+    touch the real, gitignored inventory/ or ledgers."""
+    inv = tmp_path / "inventory"
+    inv.mkdir()
+    ledger = tmp_path / "listings_ledger.csv"
+    live = tmp_path / "inventory_sheet.csv"
+
+    monkeypatch.setattr(dash, "REPO", tmp_path)
+    monkeypatch.setattr(dash, "INVENTORY", inv)
+    monkeypatch.setattr(dash, "LEDGER", ledger)
+    monkeypatch.setattr(dash, "LIVE_SHEET", live)
+    monkeypatch.setattr(_status, "LEDGER", ledger)
+    monkeypatch.setattr(_report, "REPO", tmp_path)
+    monkeypatch.setattr(_report, "INVENTORY", inv)
+    monkeypatch.setattr(_report, "LEDGER", ledger)
+    monkeypatch.setattr(_sr, "REPO", tmp_path)
+    monkeypatch.setattr(_sr, "INVENTORY", inv)
+    return tmp_path
+
+
+def _shoot(inv: Path, *parts: str) -> Path:
+    d = inv.joinpath(*parts)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _frame(d: Path, name: str = "a.jpg") -> None:
+    (d / name).write_bytes(b"\xff\xd8")
+
+
+# ---------------------------------------------------------------------------
+# iter_shoot_dirs / _looks_like_shoot
+# ---------------------------------------------------------------------------
+
+def test_a_dir_with_only_a_frame_counts_as_a_shoot(repo):
+    shoot = _shoot(repo / "inventory", "lot", "item-1")
+    _frame(shoot)
+    assert list(dash.iter_shoot_dirs()) == [shoot]
+
+
+def test_a_dir_with_a_stage_output_but_no_frame_still_counts(repo):
+    # e.g. frames were moved/archived after PREP but the manifest remains.
+    shoot = _shoot(repo / "inventory", "lot", "item-1")
+    (shoot / "identify.txt").write_text("x\n")
+    assert list(dash.iter_shoot_dirs()) == [shoot]
+
+
+def test_backup_and_dot_dirs_are_excluded(repo):
+    inv = repo / "inventory"
+    real = _shoot(inv, "lot", "item-1")
+    _frame(real)
+    backup = _shoot(inv, "lot", "_prepped", "item-1-bak")
+    _frame(backup)
+    dotdir = _shoot(inv, "lot", ".history", "item-1-old")
+    _frame(dotdir)
+    assert list(dash.iter_shoot_dirs()) == [real]
+
+
+def test_a_plain_non_shoot_directory_is_not_yielded(repo):
+    # A grouping directory (e.g. "lot/") holding shoots but no frames/outputs
+    # of its own must not appear as a phantom row.
+    _shoot(repo / "inventory", "lot", "item-1")   # empty leaf, no frame yet
+    (repo / "inventory" / "lot" / "item-1" / "notes.txt").write_text("not a frame\n")
+    assert list(dash.iter_shoot_dirs()) == []
+
+
+def test_no_inventory_directory_yields_nothing(repo):
+    import shutil
+    shutil.rmtree(repo / "inventory")
+    assert list(dash.iter_shoot_dirs()) == []
+
+
+# ---------------------------------------------------------------------------
+# gather_backlog
+# ---------------------------------------------------------------------------
+
+def test_gather_backlog_empty_tree(repo):
+    d = dash.gather_backlog()
+    assert d["rows"] == []
+    assert not d["stage_counts"]
+    assert d["count"] == 0
+
+
+def test_gather_backlog_buckets_by_the_blocking_stage(repo):
+    inv = repo / "inventory"
+    fresh = _shoot(inv, "lot", "fresh")
+    _frame(fresh)                                    # nothing done -> identify
+
+    ready = _shoot(inv, "lot", "ready")
+    _frame(ready)
+    (ready / "identify.txt").write_text("x\n")
+    prep_dir = ready / ".prep"
+    prep_dir.mkdir()
+    import json
+    manifest = {"version": 1, "photos": {
+        "a.jpg": {"orientation": {"applied": 0, "needs_ask": False, "guessed": False,
+                                  "subject_angle": 0, "osd_proposal": 0},
+                  "crop": {"applied": True, "box": [0, 0, 10, 10]}}},
+        "approved": True, "auto": {"guessed": []}}
+    (prep_dir / "prep.json").write_text(json.dumps(manifest))
+    (ready / "price.txt").write_text("Max supported price: $40\n")
+    (ready / "investigate.txt").write_text("fine\n")
+    (ready / "draft.md").write_text('---\ntitle: "x"\nmeta:\n---\nbody\n')
+
+    d = dash.gather_backlog()
+    by_dir = {r["dir"]: r for r in d["rows"]}
+    assert by_dir["inventory/lot/fresh"]["blocked_stage"] == "identify"
+    assert by_dir["inventory/lot/ready"]["blocked_stage"] is None
+    assert d["stage_counts"]["identify"] == 1
+    assert d["stage_counts"]["ready for review"] == 1
+    assert d["count"] == 2
+
+
+def test_gather_backlog_rows_carry_sku_and_ledger_status(repo):
+    inv = repo / "inventory"
+    shoot = _shoot(inv, "lot", "item-1")
+    _frame(shoot)
+    (shoot / "draft.md").write_text(
+        '---\ntitle: "x"\nmeta:\n  ebay_inventory_sku: "abc12345"\n---\nbody\n')
+    _write_ledger(repo / "listings_ledger.csv",
+                  [{"sku": "abc12345", "status": "SYNCED"}])
+
+    d = dash.gather_backlog()
+    row = d["rows"][0]
+    assert row["sku"] == "abc12345"
+    assert row["ledger_status"] == "SYNCED"
+
+
+# ---------------------------------------------------------------------------
+# gather_drafts
+# ---------------------------------------------------------------------------
+
+def test_gather_drafts_empty(repo):
+    d = dash.gather_drafts()
+    assert d == {"synced": [], "drafted": [], "count": 0}
+
+
+def test_gather_drafts_splits_synced_from_drafted_only(repo):
+    inv = repo / "inventory"
+    d1 = _shoot(inv, "lot", "synced-item")
+    (d1 / "draft.md").write_text(
+        '---\ntitle: "Synced Item"\nprice: "10.00"\nmeta:\n'
+        '  ebay_offer_id: "OFFER-1"\n---\nlong enough body text for validation.\n')
+    d2 = _shoot(inv, "lot", "drafted-item")
+    (d2 / "draft.md").write_text(
+        '---\ntitle: "Drafted Item"\nprice: "5.00"\nmeta:\n---\nbody\n')
+
+    d = dash.gather_drafts()
+    assert d["count"] == 2
+    assert [r["title"] for r in d["synced"]] == ["Synced Item"]
+    assert [r["title"] for r in d["drafted"]] == ["Drafted Item"]
+
+
+def test_gather_drafts_excludes_published_rows(repo):
+    inv = repo / "inventory"
+    d1 = _shoot(inv, "lot", "live-item")
+    (d1 / "draft.md").write_text(
+        '---\ntitle: "Live Item"\nprice: "10.00"\nmeta:\n'
+        '  published_at: "2026-01-01T00:00:00Z"\n---\nbody\n')
+    d = dash.gather_drafts()
+    assert d["count"] == 0
+
+
+def test_gather_drafts_sorts_by_price_descending(repo):
+    inv = repo / "inventory"
+    for name, price in (("cheap", "5.00"), ("pricey", "50.00"), ("mid", "20.00")):
+        s = _shoot(inv, "lot", name)
+        (s / "draft.md").write_text(f'---\ntitle: "{name}"\nprice: "{price}"\nmeta:\n---\nbody\n')
+    d = dash.gather_drafts()
+    assert [r["title"] for r in d["drafted"]] == ["pricey", "mid", "cheap"]
+
+
+def test_gather_drafts_attaches_blocking_issues_for_an_incomplete_draft(repo):
+    inv = repo / "inventory"
+    s = _shoot(inv, "lot", "incomplete")
+    (s / "draft.md").write_text('---\ntitle: ""\nmeta:\n---\n\n')
+    d = dash.gather_drafts()
+    issues = d["drafted"][0]["blocking_issues"]
+    assert any("title" in i for i in issues)
+
+
+def test_gather_drafts_redacts_voice_check_snippet_but_names_the_field(repo):
+    # check_voice() quotes up to 90 chars of the buyer-facing body verbatim
+    # (lib/voice_check.py) — the dashboard must keep the "which field" signal
+    # without repeating that quoted text (still only structured/aggregated
+    # fields, per the PII/business-data policy this repo already follows).
+    inv = repo / "inventory"
+    s = _shoot(inv, "lot", "camera-confession")
+    (s / "draft.md").write_text(
+        '---\ntitle: "Public Title"\nprice: "10.00"\nmeta:\n---\n'
+        'The back is not shown in this listing, buyer beware of that spot.\n')
+    d = dash.gather_drafts()
+    issues = d["drafted"][0]["blocking_issues"]
+    voice_issues = [i for i in issues if i.startswith("voice (block):")]
+    assert voice_issues, "expected the in-hand voice check to flag this body text"
+    for i in voice_issues:
+        assert "not shown in this listing" not in i
+        assert i.startswith("voice (block): body —")
+
+
+def test_gather_drafts_skips_validation_for_group_drafts(repo):
+    inv = repo / "inventory"
+    s = _shoot(inv, "lot", "group-item")
+    (s / "draft_group.md").write_text('---\ntitle: "Group"\nprice: "10.00"\nmeta:\n---\nbody\n')
+    d = dash.gather_drafts()
+    assert d["drafted"][0]["blocking_issues"] == []
+
+
+# ---------------------------------------------------------------------------
+# gather_drift
+# ---------------------------------------------------------------------------
+
+def test_gather_drift_no_files_present(repo):
+    d = dash.gather_drift()
+    assert d == {"rows": [], "have_live_snapshot": False, "have_ledger": False, "count": 0}
+
+
+def test_gather_drift_flags_price_and_title_mismatch(repo):
+    _write_live_sheet(repo / "inventory_sheet.csv", [
+        {"sku": "abc12345", "title": "Live Title", "listing_id": "111",
+         "live": "yes", "price": "24.99"},
+    ])
+    _write_ledger(repo / "listings_ledger.csv", [
+        {"sku": "abc12345", "title": "Ledger Title", "price": "19.99", "status": "PUBLISHED"},
+    ])
+    d = dash.gather_drift()
+    assert d["count"] == 1
+    issues = d["rows"][0]["issues"]
+    assert any("price" in i for i in issues)
+    assert any("title differs" in i for i in issues)
+
+
+def test_gather_drift_matching_rows_produce_no_issue(repo):
+    _write_live_sheet(repo / "inventory_sheet.csv", [
+        {"sku": "abc12345", "title": "Same Title", "listing_id": "111",
+         "live": "yes", "price": "24.99"},
+    ])
+    _write_ledger(repo / "listings_ledger.csv", [
+        {"sku": "abc12345", "title": "Same Title", "price": "24.99", "status": "PUBLISHED"},
+    ])
+    d = dash.gather_drift()
+    assert d["count"] == 0
+
+
+def test_gather_drift_flags_live_sku_missing_from_ledger(repo):
+    _write_live_sheet(repo / "inventory_sheet.csv", [
+        {"sku": "orphan-sku", "title": "No Ledger Row", "listing_id": "222",
+         "live": "yes", "price": "9.99"},
+    ])
+    d = dash.gather_drift()
+    assert d["count"] == 1
+    assert "no listings_ledger.csv row" in d["rows"][0]["issues"][0]
+
+
+def test_gather_drift_flags_ledger_published_but_not_live(repo):
+    _write_live_sheet(repo / "inventory_sheet.csv", [])
+    _write_ledger(repo / "listings_ledger.csv", [
+        {"sku": "gone-sku", "title": "Ghost", "price": "9.99", "status": "PUBLISHED"},
+    ])
+    d = dash.gather_drift()
+    assert d["count"] == 1
+    assert "not in the current live sheet" in d["rows"][0]["issues"][0]
+
+
+def test_gather_drift_dedupes_choice_variations_by_listing_id(repo):
+    # Two SKUs sharing one listing_id (a CHOICE group) must not double-count.
+    _write_live_sheet(repo / "inventory_sheet.csv", [
+        {"sku": "var-1", "title": "Choice Group", "listing_id": "333",
+         "live": "yes", "price": "10.00"},
+        {"sku": "var-2", "title": "Choice Group", "listing_id": "333",
+         "live": "yes", "price": "10.00"},
+    ])
+    d = dash.gather_drift()
+    assert d["count"] == 1     # only the first variation is evaluated
+
+
+def test_gather_drift_ignores_non_live_rows(repo):
+    _write_live_sheet(repo / "inventory_sheet.csv", [
+        {"sku": "ended-sku", "title": "Ended", "listing_id": "444",
+         "live": "no", "price": "1.00"},
+    ])
+    d = dash.gather_drift()
+    assert d["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# draw() — combined render, including the empty/no-data case
+# ---------------------------------------------------------------------------
+
+def test_draw_renders_all_three_sections_on_an_empty_repo(repo):
+    d = dash.gather()
+    out = dash.draw(d)
+    assert "<title>Dashboard</title>" in out
+    assert "Backlog by stage" in out
+    assert "Drafts awaiting review" in out
+    assert "Live listing vs. ledger drift" in out
+    assert "No shoot directories found" in out
+    assert "Nothing drafted or synced" in out
+    assert "not found" in out            # missing-snapshot note in the drift section
+
+
+def test_draw_renders_populated_data_without_raising(repo):
+    inv = repo / "inventory"
+    s = _shoot(inv, "lot", "item-1")
+    _frame(s)
+    (s / "draft.md").write_text(
+        '---\ntitle: "Widget"\nprice: "15.00"\nmeta:\n  ebay_inventory_sku: "abc12345"\n---\n'
+        'body text long enough.\n')
+    _write_ledger(repo / "listings_ledger.csv", [
+        {"sku": "abc12345", "title": "Widget", "price": "15.00", "status": "DRAFTED"},
+    ])
+    _write_live_sheet(repo / "inventory_sheet.csv", [
+        {"sku": "abc12345", "title": "Widget Live", "listing_id": "555",
+         "live": "yes", "price": "18.00"},
+    ])
+    d = dash.gather()
+    out = dash.draw(d)
+    assert "Widget" in out
+    assert "abc12345" in out
+    assert "555" in out
+
+
+def test_dashboard_never_writes_any_tracked_file(repo, monkeypatch):
+    """Read-only guarantee: gather()/draw() must not create or modify the
+    ledger, live sheet, or anything under inventory/."""
+    inv = repo / "inventory"
+    s = _shoot(inv, "lot", "item-1")
+    _frame(s)
+    (s / "draft.md").write_text('---\ntitle: "x"\nprice: "1"\nmeta:\n---\nbody\n')
+    ledger = repo / "listings_ledger.csv"
+    _write_ledger(ledger, [{"sku": "s1", "title": "x", "price": "1", "status": "DRAFTED"}])
+    before = ledger.read_bytes()
+    before_tree = sorted(p.relative_to(inv).as_posix() for p in inv.rglob("*") if p.is_file())
+
+    dash.draw(dash.gather())
+
+    assert ledger.read_bytes() == before
+    after_tree = sorted(p.relative_to(inv).as_posix() for p in inv.rglob("*") if p.is_file())
+    assert after_tree == before_tree
+
+
+# ---------------------------------------------------------------------------
+# PII: only structured fields ever reach the HTML, never raw context.txt prose
+# ---------------------------------------------------------------------------
+
+def test_context_txt_prose_never_appears_in_the_rendered_page(repo):
+    inv = repo / "inventory"
+    s = _shoot(inv, "lot", "item-1")
+    _frame(s)
+    secret_prose = "Bought from Jane Doe at 123 Maple St, paid $575 cash, her phone is 555-0100."
+    (inv / "lot" / "context.txt").write_text(secret_prose)
+    (s / "draft.md").write_text(
+        '---\ntitle: "Public Title"\nprice: "10.00"\nmeta:\n---\n'
+        'A normal public-facing listing description body, long enough.\n')
+    out = dash.draw(dash.gather())
+    assert secret_prose not in out
+    assert "Jane Doe" not in out
+    assert "555-0100" not in out
+
+
+def test_draft_body_text_never_appears_only_structured_fields_do(repo):
+    inv = repo / "inventory"
+    s = _shoot(inv, "lot", "item-1")
+    _frame(s)
+    (s / "draft.md").write_text(
+        '---\ntitle: "Public Title"\nprice: "10.00"\nmeta:\n---\n'
+        'This buyer-facing body must never leak into the dashboard rows verbatim '
+        'because the dashboard only shows structured fields, not descriptions.\n')
+    out = dash.draw(dash.gather())
+    assert "Public Title" in out                       # structured field: fine
+    assert "buyer-facing body must never leak" not in out
+
+
+# ---------------------------------------------------------------------------
+# CLI registration
+# ---------------------------------------------------------------------------
+
+def test_dashboard_registered_in_cli_commands():
+    from lib.cli import COMMANDS
+    assert "dashboard" in COMMANDS
+    mod, desc = COMMANDS["dashboard"]
+    assert mod == "tools.dashboard"
+    assert desc
+
+
+def test_dashboard_cli_help_does_not_error():
+    import subprocess
+    r = subprocess.run([sys.executable, "-m", "lib.cli", "dashboard", "--help"],
+                       cwd=ROOT, capture_output=True, text=True, timeout=60)
+    assert r.returncode == 0
+    assert "--out" in r.stdout

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -604,6 +604,19 @@ def test_main_refuses_to_overwrite_the_ledger_via_out(repo, monkeypatch):
     assert "<html" not in ledger.read_text().lower()
 
 
+def test_main_refuses_to_overwrite_the_sales_ledger_via_out(repo, monkeypatch):
+    # lib.report.SALES — a third tracked data file the module docstring
+    # names, distinct from the two the guard already checked. It's a
+    # module-level constant computed at lib.report's own import time, so
+    # patch it directly rather than relying on the repo fixture's REPO swap.
+    sales = repo / "sales_ledger.csv"
+    sales.write_text("sku,sold_at,price\nabc12345,2026-01-01,19.99\n")
+    monkeypatch.setattr(_report, "SALES", sales)
+    monkeypatch.setattr(sys, "argv", ["dashboard", "--out", str(sales)])
+    assert dash.main() == 1
+    assert "<html" not in sales.read_text().lower()
+
+
 def test_main_refuses_to_overwrite_the_live_sheet_via_out(repo, monkeypatch):
     live = repo / "inventory_sheet.csv"
     _write_live_sheet(live, [{"sku": "abc12345", "live": "yes"}])

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -592,3 +592,36 @@ def test_main_creates_out_s_parent_directory_when_missing(repo, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["dashboard", "--out", str(out)])
     assert dash.main() == 0
     assert out.exists()
+
+
+def test_main_refuses_to_overwrite_the_ledger_via_out(repo, monkeypatch):
+    ledger = repo / "listings_ledger.csv"
+    _write_ledger(ledger, [{"sku": "abc12345", "status": "PUBLISHED"}])
+    monkeypatch.setattr(sys, "argv", ["dashboard", "--out", str(ledger)])
+    assert dash.main() == 1
+    # untouched — still the real ledger content, not overwritten with HTML
+    assert "PUBLISHED" in ledger.read_text()
+    assert "<html" not in ledger.read_text().lower()
+
+
+def test_main_refuses_to_overwrite_the_live_sheet_via_out(repo, monkeypatch):
+    live = repo / "inventory_sheet.csv"
+    _write_live_sheet(live, [{"sku": "abc12345", "live": "yes"}])
+    monkeypatch.setattr(sys, "argv", ["dashboard", "--out", str(live)])
+    assert dash.main() == 1
+    assert "<html" not in live.read_text().lower()
+
+
+def test_main_refuses_to_write_inside_inventory_via_out(repo, monkeypatch):
+    inv = repo / "inventory"
+    out = inv / "sneaky.html"
+    monkeypatch.setattr(sys, "argv", ["dashboard", "--out", str(out)])
+    assert dash.main() == 1
+    assert not out.exists()
+
+
+def test_main_normal_out_path_is_unaffected_by_the_guard(repo, monkeypatch):
+    out = repo / "reports" / "dashboard.html"
+    monkeypatch.setattr(sys, "argv", ["dashboard", "--out", str(out)])
+    assert dash.main() == 0
+    assert out.exists()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -259,6 +259,21 @@ def test_gather_drafts_redacts_voice_check_snippet_but_names_the_field(repo):
         assert i.startswith("voice (block): body —")
 
 
+def test_gather_drafts_redacts_a_draft_parse_error_instead_of_the_yaml_text(repo):
+    inv = repo / "inventory"
+    s = _shoot(inv, "lot", "bad-yaml")
+    # unterminated quoted scalar -> yaml.safe_load raises, and the raised
+    # DraftParseError's own message embeds a snippet of this exact line
+    (s / "draft.md").write_text(
+        '---\ntitle: "SECRET-CONSIGNOR-NAME-MARKER unterminated\nmeta:\n---\nbody\n')
+    d = dash.gather_drafts()
+    issues = d["drafted"][0]["blocking_issues"]
+    assert any(i.startswith("draft parse error —") for i in issues)
+    for i in issues:
+        assert "SECRET-CONSIGNOR-NAME-MARKER" not in i
+    assert any("listing --validate" in i for i in issues)
+
+
 def test_gather_drafts_skips_validation_for_group_drafts(repo):
     inv = repo / "inventory"
     s = _shoot(inv, "lot", "group-item")
@@ -274,6 +289,15 @@ def test_gather_drafts_skips_validation_for_group_drafts(repo):
 def test_gather_drift_no_files_present(repo):
     d = dash.gather_drift()
     assert d == {"rows": [], "have_live_snapshot": False, "have_ledger": False, "count": 0}
+
+
+def test_gather_drift_treats_an_empty_but_present_csv_as_a_real_snapshot(repo):
+    # header-only CSVs: an account synced with nothing live yet, not a
+    # missing/unsynced snapshot — have_* must key off existence, not row count
+    _write_live_sheet(repo / "inventory_sheet.csv", [])
+    _write_ledger(repo / "listings_ledger.csv", [])
+    d = dash.gather_drift()
+    assert d == {"rows": [], "have_live_snapshot": True, "have_ledger": True, "count": 0}
 
 
 def test_gather_drift_flags_price_and_title_mismatch(repo):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -490,3 +490,12 @@ def test_dashboard_cli_help_does_not_error():
                        cwd=ROOT, capture_output=True, text=True, timeout=60)
     assert r.returncode == 0
     assert "--out" in r.stdout
+
+
+def test_main_creates_out_s_parent_directory_when_missing(repo, monkeypatch):
+    # --out pointing under a directory that doesn't exist yet must not fail —
+    # only the resolved output path's own parent needs creating, not reports/
+    out = repo / "some" / "new" / "nested" / "path.html"
+    monkeypatch.setattr(sys, "argv", ["dashboard", "--out", str(out)])
+    assert dash.main() == 0
+    assert out.exists()

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -471,7 +471,7 @@ def _unsafe_out_reason(out: Path) -> str | None:
     mistaken for real shoot data. Returns a reason string to refuse on, or
     None if the path is fine to write."""
     resolved = out.resolve()
-    for tracked in (LEDGER, LIVE_SHEET):
+    for tracked in (LEDGER, LIVE_SHEET, _report.SALES):
         if resolved == tracked.resolve():
             return f"refusing to overwrite tracked data file {tracked}"
     inv = INVENTORY.resolve()

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -125,9 +125,12 @@ def gather_backlog() -> dict:
     """One row per shoot, via `lib.status.gather()` — untouched per-shoot
     state logic, just assembled across the whole tree and bucketed by which
     stage is currently blocking each one."""
+    # Preloaded once so lib.status.gather() doesn't re-scan
+    # listings_ledger.csv from scratch for every shoot in the tree.
+    ledger_by_sku = {r["sku"]: r for r in _rows(LEDGER) if r.get("sku")}
     rows = []
     for shoot in iter_shoot_dirs():
-        state = _status.gather(shoot)
+        state = _status.gather(shoot, ledger_by_sku=ledger_by_sku)
         try:
             state["dir"] = shoot.relative_to(REPO).as_posix()
         except ValueError:

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -105,9 +105,9 @@ def gather_backlog() -> dict:
     for shoot in iter_shoot_dirs():
         state = _status.gather(shoot)
         try:
-            state["dir"] = str(shoot.relative_to(REPO))
+            state["dir"] = shoot.relative_to(REPO).as_posix()
         except ValueError:
-            state["dir"] = str(shoot)
+            state["dir"] = shoot.as_posix()
         ready = state["next_action"].startswith("all stages clear")
         state["blocked_stage"] = None if ready else state["next_action"].split(":", 1)[0]
         rows.append(state)

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -140,21 +140,30 @@ def gather_backlog() -> dict:
 # ---------------------------------------------------------------------------
 
 _VOICE_PREFIX = "voice (block): "
+_PARSE_ERROR_PREFIX = "draft parse error: "
 
 
-def _redact_voice_snippet(issue: str) -> str:
-    """`validate_draft_for_sync()` folds in `check_voice()`, which quotes up
-    to 90 chars of the flagged BUYER-FACING body/field text verbatim (see
-    lib/voice_check.py). That text is meant for eBay's own listing page, not
-    PII or context.txt prose — but this dashboard is still meant to show only
-    structured/aggregated fields (matching lib/source_report.py and
-    tools/sales_report.py), so the quoted snippet is dropped here and only
-    which field tripped the check is kept. The exact phrase is still one
-    `ebz voice <draft>` away."""
-    if not issue.startswith(_VOICE_PREFIX):
-        return issue
-    field = issue[len(_VOICE_PREFIX):].split(":", 1)[0].strip() or "body"
-    return f"{_VOICE_PREFIX}{field} — in-hand voice phrase flagged (run `ebz voice` for the text)"
+def _redact_issue(issue: str, path) -> str:
+    """`validate_draft_for_sync()` can return two kinds of issue string that
+    carry free text from the draft itself, not just a structured field name:
+
+    - `check_voice()`'s voice-block lines quote up to 90 chars of the
+      flagged BUYER-FACING body/field text verbatim (lib/voice_check.py).
+    - A `draft parse error: {e}` line embeds the underlying exception's
+      message directly — for a YAML error, that's often a quoted excerpt of
+      the draft's own front matter or body.
+
+    Neither is PII, but this dashboard's own policy (matching
+    lib/source_report.py / tools/sales_report.py) is structured/aggregated
+    fields only, so both get redacted to "what kind of problem" plus a
+    pointer to the real command for the actual text."""
+    if issue.startswith(_VOICE_PREFIX):
+        field = issue[len(_VOICE_PREFIX):].split(":", 1)[0].strip() or "body"
+        return f"{_VOICE_PREFIX}{field} — in-hand voice phrase flagged (run `ebz voice` for the text)"
+    if issue.startswith(_PARSE_ERROR_PREFIX):
+        return (f"draft parse error — run "
+                f"`python -m lib.cli listing --validate {path}` for details")
+    return issue
 
 
 def _blocking_issues(row: dict) -> list[str]:
@@ -176,7 +185,7 @@ def _blocking_issues(row: dict) -> list[str]:
         # not its text — and point at the real command for the details.
         return [f"validation error ({type(e).__name__}) — run "
                 f"`python -m lib.cli listing --validate {row.get('path')}` for details"]
-    return [_redact_voice_snippet(i) for i in issues]
+    return [_redact_issue(i, row.get("path")) for i in issues]
 
 
 def gather_drafts() -> dict:
@@ -256,8 +265,11 @@ def gather_drift() -> dict:
 
     return {
         "rows": rows,
-        "have_live_snapshot": bool(live),
-        "have_ledger": bool(ledger),
+        # File existence, not "has rows" — an empty-but-present CSV (e.g. a
+        # freshly-synced account with nothing live yet) is a real, current
+        # snapshot, not a missing one.
+        "have_live_snapshot": LIVE_SHEET.exists(),
+        "have_ledger": LEDGER.exists(),
         "count": len(rows),
     }
 

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -111,6 +111,14 @@ def iter_shoot_dirs():
             yield d
 
 
+# identify/investigate/draft's pending detail can come straight from a
+# `.single_pass/ask.json` a stage wrote — free text (e.g. a maker-mark
+# reading, a grouping question), not a structured field. prep's and price's
+# own pending messages are always code-generated (filenames, crop reasons,
+# canned "not written yet" text), never file-sourced free text — safe as-is.
+_ASK_SOURCED_STAGES = frozenset({"identify", "investigate", "draft"})
+
+
 def gather_backlog() -> dict:
     """One row per shoot, via `lib.status.gather()` — untouched per-shoot
     state logic, just assembled across the whole tree and bucketed by which
@@ -128,6 +136,10 @@ def gather_backlog() -> dict:
         # build that string, just not tied to its exact display phrasing.
         state["blocked_stage"] = next(
             (stage for stage in STAGE_ORDER if state["stages"][stage]["pending"]), None)
+        if state["blocked_stage"] in _ASK_SOURCED_STAGES:
+            state["next_action"] = (
+                f"{state['blocked_stage']}: pending — run `python -m lib.cli "
+                f"status {state['dir']}` for the question")
         rows.append(state)
 
     def _rank(r: dict) -> int:

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""dashboard — one page: backlog by stage, drafts awaiting review, live/ledger drift.
+
+Phase 1 of #31 (see `docs/webapp-architecture.md`): extends the existing
+static-HTML-generator pattern this repo already has —
+`tools/sales_report.py`'s `gather()` -> `reports/sales_dashboard.html` — to the
+other read-only views the issue names, beyond sales. Still just
+
+    python -m lib.cli dashboard                # -> reports/dashboard.html
+    python -m lib.cli dashboard --out FILE
+
+writing one HTML file to open locally. No server, no job queue, no background
+process, no new dependency, no network call of any kind — every gather
+function below reads only what is already on disk:
+
+  * **Backlog by stage** — one row per `inventory/<shoot>/`, entirely via
+    `lib.status.gather()` (already a pure, read-only, per-shoot state read —
+    reused as-is, not reimplemented; see the module-mapping table in the
+    architecture doc).
+  * **Drafts awaiting review** — `lib.report.collect()`, the same disk
+    draft.md/draft_group.md + `listings_ledger.csv` merge the activity report
+    already builds, filtered to rows with no `published_at` (the same split
+    `lib.report.report_pipeline()` prints as text, kept structured here for
+    HTML instead of re-parsed). Each row's local, offline-only
+    `lib.list_edit.validate_draft_for_sync()` issues are attached where a
+    disk draft exists, so "awaiting review" also says what would block it.
+  * **Live-listing vs. ledger drift** — a new, local-only comparison between
+    `inventory_sheet.csv` (the last `tools/ebay_sheet.py` sync — a snapshot
+    already on disk, not re-fetched here) and `listings_ledger.csv`, using
+    `tools/sales_report.py`'s own CSV-reading helper (`_rows`) and its
+    CHOICE-variation dedup rule (group by `listing_id`) so the two dashboards
+    can't drift apart on what counts as "one live listing". `tools/
+    ledger_reconcile.py`'s `compute_drift()` is the closest existing pattern
+    for this shape of diff, but it calls the live Sell API for eBay's truth —
+    out of bounds for a read-only local dashboard, so this instead diffs two
+    already-synced local CSVs against each other, at the cost of being only
+    as fresh as the last sync of each.
+
+Read-only, always: nothing here writes to `sales_ledger.csv`,
+`listings_ledger.csv`, or any file under `inventory/`.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))   # sibling tools
+
+import list_edit as _list_edit                              # noqa: E402
+import report as _report                                    # noqa: E402
+import status as _status                                    # noqa: E402
+from single_pass import STAGE_ORDER, STAGE_OUTPUT            # noqa: E402
+from source_report import _is_backup_path                    # noqa: E402
+from sales_report import STYLE, _e, _f, _itm, _money, _rows, _stat  # noqa: E402
+
+REPORTS = REPO / "reports"
+INVENTORY = REPO / "inventory"
+LEDGER = REPO / "listings_ledger.csv"
+LIVE_SHEET = REPO / "inventory_sheet.csv"
+OUT_HTML = REPORTS / "dashboard.html"
+
+
+# ---------------------------------------------------------------------------
+# 1 · backlog by stage — lib.status.gather() over every shoot dir
+# ---------------------------------------------------------------------------
+
+def _looks_like_shoot(d: Path) -> bool:
+    """A shoot dir is one with either a frame in it (the very first thing any
+    shoot has) or one of the five stage outputs — the same two facts
+    `lib.status.gather()` itself reads, not a new definition of "shoot"."""
+    try:
+        if any(p.is_file() and p.suffix.lower() in _status._FRAME_EXT
+               for p in d.iterdir()):
+            return True
+    except OSError:
+        return False
+    return any((d / STAGE_OUTPUT[stage]).exists() for stage in STAGE_ORDER)
+
+
+def iter_shoot_dirs():
+    """Every `inventory/<shoot>/` dir, backup/scratch dirs excluded (the same
+    rule `lib.source_report` already uses for the same reason: a `_prepped`
+    or dot-prefixed copy is not a distinct shoot)."""
+    root = INVENTORY
+    if not root.is_dir():
+        return
+    for d in sorted(p for p in root.rglob("*") if p.is_dir()):
+        rel = d.relative_to(root).as_posix()
+        if _is_backup_path(rel):
+            continue
+        if _looks_like_shoot(d):
+            yield d
+
+
+def gather_backlog() -> dict:
+    """One row per shoot, via `lib.status.gather()` — untouched per-shoot
+    state logic, just assembled across the whole tree and bucketed by which
+    stage is currently blocking each one."""
+    rows = []
+    for shoot in iter_shoot_dirs():
+        state = _status.gather(shoot)
+        try:
+            state["dir"] = str(shoot.relative_to(REPO))
+        except ValueError:
+            state["dir"] = str(shoot)
+        ready = state["next_action"].startswith("all stages clear")
+        state["blocked_stage"] = None if ready else state["next_action"].split(":", 1)[0]
+        rows.append(state)
+
+    def _rank(r: dict) -> int:
+        return STAGE_ORDER.index(r["blocked_stage"]) if r["blocked_stage"] in STAGE_ORDER \
+            else len(STAGE_ORDER)
+
+    rows.sort(key=lambda r: (_rank(r), r["dir"]))
+    stage_counts = Counter(r["blocked_stage"] or "ready for review" for r in rows)
+    return {"rows": rows, "stage_counts": stage_counts, "count": len(rows)}
+
+
+# ---------------------------------------------------------------------------
+# 2 · drafts awaiting review — lib.report.collect(), filtered to unpublished
+# ---------------------------------------------------------------------------
+
+_VOICE_PREFIX = "voice (block): "
+
+
+def _redact_voice_snippet(issue: str) -> str:
+    """`validate_draft_for_sync()` folds in `check_voice()`, which quotes up
+    to 90 chars of the flagged BUYER-FACING body/field text verbatim (see
+    lib/voice_check.py). That text is meant for eBay's own listing page, not
+    PII or context.txt prose — but this dashboard is still meant to show only
+    structured/aggregated fields (matching lib/source_report.py and
+    tools/sales_report.py), so the quoted snippet is dropped here and only
+    which field tripped the check is kept. The exact phrase is still one
+    `ebz voice <draft>` away."""
+    if not issue.startswith(_VOICE_PREFIX):
+        return issue
+    field = issue[len(_VOICE_PREFIX):].split(":", 1)[0].strip() or "body"
+    return f"{_VOICE_PREFIX}{field} — in-hand voice phrase flagged (run `ebz voice` for the text)"
+
+
+def _blocking_issues(row: dict) -> list[str]:
+    """Offline `validate_draft_for_sync()` issues for a disk draft — nothing
+    here calls eBay. Skipped for a CHOICE group (`draft_group.md` doesn't
+    have the single-item shape that function validates) or a ledger-only row
+    with no draft file to read."""
+    if row.get("group") or not row.get("path"):
+        return []
+    p = REPO / row["path"]
+    if not p.exists():
+        return []
+    try:
+        issues = _list_edit.validate_draft_for_sync(p)
+    except Exception as e:                                   # noqa: BLE001
+        return [f"validation error: {e}"]
+    return [_redact_voice_snippet(i) for i in issues]
+
+
+def gather_drafts() -> dict:
+    """Drafted-only and synced-not-published rows — the same split
+    `lib.report.report_pipeline()` already prints as text, kept structured
+    here so it can render as an HTML section instead."""
+    rows = [r for r in _report.collect() if not r.get("published_at")]
+    for r in rows:
+        r["blocking_issues"] = _blocking_issues(r)
+
+    synced, drafted = [], []
+    for r in rows:
+        (synced if r.get("offer_id") or r.get("synced_at") else drafted).append(r)
+    synced.sort(key=lambda r: -_f(r.get("price"), 0.0))
+    drafted.sort(key=lambda r: -_f(r.get("price"), 0.0))
+    return {"synced": synced, "drafted": drafted, "count": len(rows)}
+
+
+# ---------------------------------------------------------------------------
+# 3 · live-listing vs. ledger drift — two local CSVs, no eBay call
+# ---------------------------------------------------------------------------
+
+def _price_drift(live_price, ledger_price) -> bool:
+    lp, dp = _f(live_price, None), _f(ledger_price, None)
+    return lp is not None and dp is not None and abs(lp - dp) >= 0.005
+
+
+def gather_drift() -> dict:
+    """Compare the last-synced `inventory_sheet.csv` against
+    `listings_ledger.csv`. Both are local snapshots an earlier sync already
+    wrote to disk (`tools/ebay_sheet.py`, `lib.list_edit`) — this makes no
+    eBay call of its own, so it is only as fresh as those snapshots are."""
+    live = _rows(LIVE_SHEET)
+    ledger = _rows(LEDGER)
+    ledger_by_sku = {r["sku"]: r for r in ledger if r.get("sku")}
+
+    seen_lids: set = set()
+    rows = []
+    for lv in live:
+        lid = lv.get("listing_id") or ""
+        if (lv.get("live") or "").lower() != "yes" or not lid or lid in seen_lids:
+            continue                                          # CHOICE variation, already counted
+        seen_lids.add(lid)
+        sku = lv.get("sku") or ""
+        led = ledger_by_sku.get(sku)
+        issues = []
+        if led is None:
+            issues.append("no listings_ledger.csv row for this live sku")
+        else:
+            if _price_drift(lv.get("price"), led.get("price")):
+                issues.append(f"price: ledger {_money(_f(led.get('price')))} "
+                              f"vs live {_money(_f(lv.get('price')))}")
+            live_title = (lv.get("title") or "").strip()
+            ledger_title = (led.get("title") or "").strip()
+            if live_title and ledger_title and live_title != ledger_title:
+                issues.append("title differs from ledger")
+            if (led.get("status") or "") != "PUBLISHED":
+                issues.append(f"ledger status is {led.get('status') or '(blank)'}, not PUBLISHED")
+        if issues:
+            rows.append({
+                "sku": sku, "listing_id": lid, "title": lv.get("title", ""),
+                "live_price": lv.get("price", ""),
+                "ledger_price": (led or {}).get("price", ""),
+                "issues": issues,
+            })
+
+    live_skus = {lv.get("sku") for lv in live if (lv.get("live") or "").lower() == "yes"}
+    for r in ledger:
+        if r.get("status") == "PUBLISHED" and r.get("sku") and r["sku"] not in live_skus:
+            rows.append({
+                "sku": r["sku"], "listing_id": r.get("listing_id", ""),
+                "title": r.get("title", ""), "live_price": "",
+                "ledger_price": r.get("price", ""),
+                "issues": ["ledger says PUBLISHED but this sku is not in the "
+                           "current live sheet (inventory_sheet.csv)"],
+            })
+
+    return {
+        "rows": rows,
+        "have_live_snapshot": bool(live),
+        "have_ledger": bool(ledger),
+        "count": len(rows),
+    }
+
+
+# ---------------------------------------------------------------------------
+# combined gather
+# ---------------------------------------------------------------------------
+
+def gather() -> dict:
+    return {
+        "backlog": gather_backlog(),
+        "drafts": gather_drafts(),
+        "drift": gather_drift(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# draw
+# ---------------------------------------------------------------------------
+
+def _backlog_section(d: dict) -> str:
+    counts = " · ".join(f"{k} {v}" for k, v in
+                        sorted(d["stage_counts"].items(),
+                               key=lambda kv: (kv[0] != "ready for review", kv[0])))
+    rows = "".join(
+        f'<tr><td>{_e(r["dir"])}</td>'
+        f'<td class="num">{r["frames"]}</td>'
+        f'<td>{_e(r["blocked_stage"] or "ready for review")}</td>'
+        f'<td class="dim">{_e(r["next_action"])}</td>'
+        f'<td>{_e(r["sku"] or "—")}</td>'
+        f'<td>{_e(r["ledger_status"] or "—")}</td></tr>'
+        for r in d["rows"][:200])
+    return (
+        '<div class="card"><div class="pad"><h2>Backlog by stage</h2>'
+        f'<p class="note" style="margin:0 0 14px;padding:0;border:0">{d["count"]} shoot(s) '
+        f'in <code>inventory/</code>. By blocking stage: {_e(counts) or "—"}</p>'
+        '<div class="scroll"><table><tr><th>Shoot</th><th class="num">Frames</th>'
+        '<th>Blocked at</th><th>Next action</th><th>SKU</th><th>Ledger</th></tr>'
+        f'{rows}</table></div>'
+        + ('' if d["rows"] else '<p class="note">No shoot directories found under '
+                                'inventory/.</p>')
+        + '</div></div>')
+
+
+def _draft_rows(rows: list[dict]) -> str:
+    return "".join(
+        f'<tr><td>{_e(r.get("title") or "(untitled)")}'
+        + ('<span class="pill on" style="margin-left:8px">GROUP</span>'
+           if r.get("group") else "")
+        + f'<div class="dim" style="font-size:11.5px">{_e(r.get("path") or r.get("sku") or "")}'
+          f'</div></td>'
+        f'<td class="num">{_money(_f(r.get("price"), 0.0))}</td>'
+        f'<td>{_e(r.get("sku") or "—")}</td>'
+        f'<td class="warn">{_e("; ".join(r.get("blocking_issues") or []) or "—")}</td></tr>'
+        for r in rows[:100])
+
+
+def _drafts_section(d: dict) -> str:
+    return (
+        '<div class="card"><div class="pad"><h2>Drafts awaiting review</h2>'
+        '<div class="stats" style="margin:0 -24px 18px;border-top:1px solid var(--rule);'
+        'border-bottom:1px solid var(--rule)">'
+        + _stat(str(len(d["synced"])), "synced, not published",
+                "an eBay draft exists — one step from live")
+        + _stat(str(len(d["drafted"])), "drafted, not synced", "local only")
+        + '</div>'
+        + (f'<h3 style="font:600 11px/1 &quot;IBM Plex Sans&quot;,sans-serif;'
+           f'letter-spacing:.1em;text-transform:uppercase;color:var(--muted);'
+           f'margin:0 0 10px">Synced, awaiting publish</h3>'
+           f'<div class="scroll"><table><tr><th>Item</th><th class="num">Price</th>'
+           f'<th>SKU</th><th>Blocking</th></tr>{_draft_rows(d["synced"])}</table></div>'
+           if d["synced"] else "")
+        + (f'<h3 style="font:600 11px/1 &quot;IBM Plex Sans&quot;,sans-serif;'
+           f'letter-spacing:.1em;text-transform:uppercase;color:var(--muted);'
+           f'margin:22px 0 10px">Drafted, not yet synced</h3>'
+           f'<div class="scroll"><table><tr><th>Item</th><th class="num">Price</th>'
+           f'<th>SKU</th><th>Blocking</th></tr>{_draft_rows(d["drafted"])}</table></div>'
+           if d["drafted"] else "")
+        + ('' if d["count"] else '<p class="note">Nothing drafted or synced-but-unpublished '
+                                  'right now.</p>')
+        + '</div></div>')
+
+
+def _drift_section(d: dict) -> str:
+    rows = "".join(
+        f'<tr><td>{_itm(r["listing_id"], r["title"][:64] or r["sku"])}'
+        f'<div class="dim" style="font-size:11.5px">{_e(r["sku"])}</div></td>'
+        f'<td class="num">{_e(r["live_price"] or "—")}</td>'
+        f'<td class="num">{_e(r["ledger_price"] or "—")}</td>'
+        f'<td class="warn">{_e("; ".join(r["issues"]))}</td></tr>'
+        for r in d["rows"][:100])
+    if not d["have_live_snapshot"] or not d["have_ledger"]:
+        missing = " and ".join(
+            n for n, have in (("inventory_sheet.csv", d["have_live_snapshot"]),
+                              ("listings_ledger.csv", d["have_ledger"])) if not have)
+        note = (f'<p class="note">{_e(missing)} not found — run the usual sync '
+                f'(<code>tools/ebay_sheet.py</code> / a listing sync) at least once, '
+                f'then re-run this dashboard.</p>')
+    else:
+        note = ('<p class="note">Compares two local snapshots as of their own last sync — '
+                'this makes no eBay call, so drift here can lag the truth by however old '
+                'the last sync is.</p>')
+    return (
+        '<div class="card"><div class="pad"><h2>Live listing vs. ledger drift</h2>'
+        f'<p class="note" style="margin:0 0 14px;padding:0;border:0">{d["count"]} live '
+        f'listing(s) disagree with the local ledger.</p>'
+        '<div class="scroll"><table><tr><th>Item</th><th class="num">Live price</th>'
+        f'<th class="num">Ledger price</th><th>Issue</th></tr>{rows}</table></div>'
+        + ('' if d["rows"] else '<p class="note">No drift found.</p>')
+        + note + '</div></div>')
+
+
+def draw(d: dict) -> str:
+    from datetime import datetime
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    header = (
+        '<div class="card"><div class="hdr">'
+        '<p class="eyebrow">ebaybiz · dashboard</p>'
+        '<h1>Backlog, review queue &amp; drift</h1>'
+        f'<div class="ct">built {_e(now)} local · read-only, local files only — '
+        'no eBay/Apify call</div></div>'
+        '<div class="stats">'
+        + _stat(str(d["backlog"]["count"]), "shoots in the pipeline")
+        + _stat(str(d["drafts"]["count"]), "drafts awaiting review")
+        + _stat(str(d["drift"]["count"]), "live/ledger disagreements")
+        + '</div></div>')
+    body = "\n".join([
+        header,
+        _backlog_section(d["backlog"]),
+        _drafts_section(d["drafts"]),
+        _drift_section(d["drift"]),
+    ])
+    return ('<meta charset="utf-8">\n<title>Dashboard</title>\n'
+            '<meta name="viewport" content="width=device-width,initial-scale=1">\n'
+            f'<style>{STYLE}</style>\n<div class="wrap">\n{body}\n</div>\n')
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--out", default=str(OUT_HTML))
+    a = ap.parse_args()
+
+    REPORTS.mkdir(exist_ok=True)
+    d = gather()
+    out = Path(a.out)
+    out.write_text(draw(d), encoding="utf-8")
+
+    print(f"{d['backlog']['count']} shoot(s) · {d['drafts']['count']} draft(s) awaiting "
+          f"review · {d['drift']['count']} live/ledger disagreement(s)")
+    print(f"[OK] {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -464,13 +464,34 @@ def draw(d: dict) -> str:
             f'<style>{STYLE}</style>\n<div class="wrap">\n{body}\n</div>\n')
 
 
+def _unsafe_out_reason(out: Path) -> str | None:
+    """`--out` is user-supplied and this module's whole premise is
+    read-only — a custom path must not let it clobber one of the tracked
+    data files it reads, or land inside `inventory/` where it could be
+    mistaken for real shoot data. Returns a reason string to refuse on, or
+    None if the path is fine to write."""
+    resolved = out.resolve()
+    for tracked in (LEDGER, LIVE_SHEET):
+        if resolved == tracked.resolve():
+            return f"refusing to overwrite tracked data file {tracked}"
+    inv = INVENTORY.resolve()
+    if resolved == inv or inv in resolved.parents:
+        return f"refusing to write inside {INVENTORY} (real shoot data lives there)"
+    return None
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--out", default=str(OUT_HTML))
     a = ap.parse_args()
 
-    d = gather()
     out = Path(a.out)
+    reason = _unsafe_out_reason(out)
+    if reason:
+        print(f"[ERROR] {reason}", file=sys.stderr)
+        return 1
+
+    d = gather()
     out.parent.mkdir(parents=True, exist_ok=True)  # still creates reports/ for the default
     out.write_text(draw(d), encoding="utf-8")
 

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -263,25 +263,30 @@ def gather_drift() -> dict:
         lid = lv.get("listing_id") or ""
         if not lid:
             continue
-        g = groups.setdefault(lid, {"rep": lv, "skus": set()})
+        g = groups.setdefault(lid, {"rep": lv, "by_sku": {}})
         if lv.get("sku"):
-            g["skus"].add(lv["sku"])
+            g["by_sku"][lv["sku"]] = lv
 
     rows = []
     for lid, g in groups.items():
         rep = g["rep"]
-        matched_sku = next((s for s in g["skus"] if s in ledger_by_sku), None)
+        by_sku = g["by_sku"]
+        matched_sku = next((s for s in by_sku if s in ledger_by_sku), None)
         led = ledger_by_sku.get(matched_sku) if matched_sku else None
+        # Compare the ledger's matched row against ITS OWN variation's live
+        # row, not the group's representative — price/title can legitimately
+        # differ between variations of one CHOICE listing.
+        lv_cmp = by_sku[matched_sku] if matched_sku else rep
         issues = []
         if led is None:
             issues.append(
                 "no listings_ledger.csv row for any sku in this listing"
-                if len(g["skus"]) > 1 else "no listings_ledger.csv row for this live sku")
+                if len(by_sku) > 1 else "no listings_ledger.csv row for this live sku")
         else:
-            if _price_drift(rep.get("price"), led.get("price")):
+            if _price_drift(lv_cmp.get("price"), led.get("price")):
                 issues.append(f"price: ledger {_money(_f(led.get('price')))} "
-                              f"vs live {_money(_f(rep.get('price')))}")
-            live_title = (rep.get("title") or "").strip()
+                              f"vs live {_money(_f(lv_cmp.get('price')))}")
+            live_title = (lv_cmp.get("title") or "").strip()
             ledger_title = (led.get("title") or "").strip()
             if live_title and ledger_title and live_title != ledger_title:
                 issues.append("title differs from ledger")
@@ -290,8 +295,8 @@ def gather_drift() -> dict:
         if issues:
             rows.append({
                 "sku": matched_sku or rep.get("sku") or "", "listing_id": lid,
-                "title": rep.get("title", ""),
-                "live_price": rep.get("price", ""),
+                "title": lv_cmp.get("title", ""),
+                "live_price": lv_cmp.get("price", ""),
                 "ledger_price": (led or {}).get("price", ""),
                 "issues": issues,
             })

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -218,6 +218,17 @@ def gather_drift() -> dict:
     `listings_ledger.csv`. Both are local snapshots an earlier sync already
     wrote to disk (`tools/ebay_sheet.py`, `lib.list_edit`) — this makes no
     eBay call of its own, so it is only as fresh as those snapshots are."""
+    have_live_snapshot, have_ledger = LIVE_SHEET.exists(), LEDGER.exists()
+    if not (have_live_snapshot and have_ledger):
+        # _rows() returns [] for a missing file the same as for an empty
+        # one, so comparing against a genuinely missing side would flag
+        # every row on the other side as "missing" from a file that was
+        # simply never synced — not a real drift finding. The "not found"
+        # note the page renders from have_* already says why there's
+        # nothing to compare.
+        return {"rows": [], "have_live_snapshot": have_live_snapshot,
+                "have_ledger": have_ledger, "count": 0}
+
     live = _rows(LIVE_SHEET)
     ledger = _rows(LEDGER)
     ledger_by_sku = {r["sku"]: r for r in ledger if r.get("sku")}
@@ -265,11 +276,8 @@ def gather_drift() -> dict:
 
     return {
         "rows": rows,
-        # File existence, not "has rows" — an empty-but-present CSV (e.g. a
-        # freshly-synced account with nothing live yet) is a real, current
-        # snapshot, not a missing one.
-        "have_live_snapshot": LIVE_SHEET.exists(),
-        "have_ledger": LEDGER.exists(),
+        "have_live_snapshot": have_live_snapshot,
+        "have_ledger": have_ledger,
         "count": len(rows),
     }
 

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -122,8 +122,12 @@ def gather_backlog() -> dict:
             state["dir"] = shoot.relative_to(REPO).as_posix()
         except ValueError:
             state["dir"] = shoot.as_posix()
-        ready = state["next_action"].startswith("all stages clear")
-        state["blocked_stage"] = None if ready else state["next_action"].split(":", 1)[0]
+        # Read the structured `stages` map directly rather than parsing
+        # `next_action`'s human-readable "stage: reason" text — the same
+        # first-pending-stage rule `lib.status.gather()` itself uses to
+        # build that string, just not tied to its exact display phrasing.
+        state["blocked_stage"] = next(
+            (stage for stage in STAGE_ORDER if state["stages"][stage]["pending"]), None)
         rows.append(state)
 
     def _rank(r: dict) -> int:
@@ -420,9 +424,9 @@ def main() -> int:
     ap.add_argument("--out", default=str(OUT_HTML))
     a = ap.parse_args()
 
-    REPORTS.mkdir(exist_ok=True)
     d = gather()
     out = Path(a.out)
+    out.parent.mkdir(parents=True, exist_ok=True)  # still creates reports/ for the default
     out.write_text(draw(d), encoding="utf-8")
 
     print(f"{d['backlog']['count']} shoot(s) · {d['drafts']['count']} draft(s) awaiting "

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -251,23 +251,37 @@ def gather_drift() -> dict:
     ledger = _rows(LEDGER)
     ledger_by_sku = {r["sku"]: r for r in ledger if r.get("sku")}
 
-    seen_lids: set = set()
-    rows = []
+    # Group live rows by listing_id first (a CHOICE listing has one row per
+    # variation SKU sharing one listing_id) — matching only the first
+    # variation encountered against the ledger, as a single-SKU comparison
+    # would, can false-flag "no ledger row" when the ledger happens to
+    # record a *different* variation's SKU for the same listing.
+    groups: dict[str, dict] = {}
     for lv in live:
+        if (lv.get("live") or "").lower() != "yes":
+            continue
         lid = lv.get("listing_id") or ""
-        if (lv.get("live") or "").lower() != "yes" or not lid or lid in seen_lids:
-            continue                                          # CHOICE variation, already counted
-        seen_lids.add(lid)
-        sku = lv.get("sku") or ""
-        led = ledger_by_sku.get(sku)
+        if not lid:
+            continue
+        g = groups.setdefault(lid, {"rep": lv, "skus": set()})
+        if lv.get("sku"):
+            g["skus"].add(lv["sku"])
+
+    rows = []
+    for lid, g in groups.items():
+        rep = g["rep"]
+        matched_sku = next((s for s in g["skus"] if s in ledger_by_sku), None)
+        led = ledger_by_sku.get(matched_sku) if matched_sku else None
         issues = []
         if led is None:
-            issues.append("no listings_ledger.csv row for this live sku")
+            issues.append(
+                "no listings_ledger.csv row for any sku in this listing"
+                if len(g["skus"]) > 1 else "no listings_ledger.csv row for this live sku")
         else:
-            if _price_drift(lv.get("price"), led.get("price")):
+            if _price_drift(rep.get("price"), led.get("price")):
                 issues.append(f"price: ledger {_money(_f(led.get('price')))} "
-                              f"vs live {_money(_f(lv.get('price')))}")
-            live_title = (lv.get("title") or "").strip()
+                              f"vs live {_money(_f(rep.get('price')))}")
+            live_title = (rep.get("title") or "").strip()
             ledger_title = (led.get("title") or "").strip()
             if live_title and ledger_title and live_title != ledger_title:
                 issues.append("title differs from ledger")
@@ -275,8 +289,9 @@ def gather_drift() -> dict:
                 issues.append(f"ledger status is {led.get('status') or '(blank)'}, not PUBLISHED")
         if issues:
             rows.append({
-                "sku": sku, "listing_id": lid, "title": lv.get("title", ""),
-                "live_price": lv.get("price", ""),
+                "sku": matched_sku or rep.get("sku") or "", "listing_id": lid,
+                "title": rep.get("title", ""),
+                "live_price": rep.get("price", ""),
                 "ledger_price": (led or {}).get("price", ""),
                 "issues": issues,
             })
@@ -340,6 +355,14 @@ def _backlog_section(d: dict) -> str:
         + '</div></div>')
 
 
+def _draft_price_cell(price) -> str:
+    # A missing/non-numeric price is a real validation problem
+    # (validate_draft_for_sync() already flags it in blocking_issues) — show
+    # it as unknown, not as a misleadingly-precise "$0.00".
+    v = _f(price, None)
+    return _money(v) if v is not None else "—"
+
+
 def _draft_rows(rows: list[dict]) -> str:
     return "".join(
         f'<tr><td>{_e(r.get("title") or "(untitled)")}'
@@ -347,7 +370,7 @@ def _draft_rows(rows: list[dict]) -> str:
            if r.get("group") else "")
         + f'<div class="dim" style="font-size:11.5px">{_e(r.get("path") or r.get("sku") or "")}'
           f'</div></td>'
-        f'<td class="num">{_money(_f(r.get("price"), 0.0))}</td>'
+        f'<td class="num">{_draft_price_cell(r.get("price"))}</td>'
         f'<td>{_e(r.get("sku") or "—")}</td>'
         f'<td class="warn">{_e("; ".join(r.get("blocking_issues") or []) or "—")}</td></tr>'
         for r in rows[:100])

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -42,6 +42,7 @@ Read-only, always: nothing here writes to `sales_ledger.csv`,
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from collections import Counter
 from pathlib import Path
@@ -85,14 +86,27 @@ def _looks_like_shoot(d: Path) -> bool:
 def iter_shoot_dirs():
     """Every `inventory/<shoot>/` dir, backup/scratch dirs excluded (the same
     rule `lib.source_report` already uses for the same reason: a `_prepped`
-    or dot-prefixed copy is not a distinct shoot)."""
+    or dot-prefixed copy is not a distinct shoot).
+
+    Walks directories only (`os.walk`, pruning excluded subtrees in place)
+    rather than `rglob("*")`, which would otherwise stat every photo file
+    under `inventory/` just to find directory names — and would still
+    descend into a `_prepped`/dot-prefixed subtree before the exclusion
+    filter got a chance to skip it."""
     root = INVENTORY
     if not root.is_dir():
         return
-    for d in sorted(p for p in root.rglob("*") if p.is_dir()):
-        rel = d.relative_to(root).as_posix()
-        if _is_backup_path(rel):
-            continue
+    found = []
+    for dirpath, dirnames, _filenames in os.walk(root):
+        keep = []
+        for name in dirnames:
+            rel = (Path(dirpath) / name).relative_to(root).as_posix()
+            if _is_backup_path(rel):
+                continue
+            keep.append(name)
+        dirnames[:] = keep
+        found.extend(Path(dirpath) / name for name in keep)
+    for d in sorted(found):
         if _looks_like_shoot(d):
             yield d
 
@@ -156,7 +170,12 @@ def _blocking_issues(row: dict) -> list[str]:
     try:
         issues = _list_edit.validate_draft_for_sync(p)
     except Exception as e:                                   # noqa: BLE001
-        return [f"validation error: {e}"]
+        # A parse/validation exception (e.g. a YAML error) can carry a quoted
+        # excerpt of the draft's own front matter in its message. Keep this
+        # page to structured/aggregated fields only — name the failure type,
+        # not its text — and point at the real command for the details.
+        return [f"validation error ({type(e).__name__}) — run "
+                f"`python -m lib.cli listing --validate {row.get('path')}` for details"]
     return [_redact_voice_snippet(i) for i in issues]
 
 

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -74,13 +74,15 @@ def _looks_like_shoot(d: Path) -> bool:
     """A shoot dir is one with either a frame in it (the very first thing any
     shoot has) or one of the five stage outputs — the same two facts
     `lib.status.gather()` itself reads, not a new definition of "shoot"."""
+    # Cheap, fixed-count existence checks first — a shoot past IDENTIFY
+    # already has one of these and never needs the iterdir() scan below.
+    if any((d / STAGE_OUTPUT[stage]).exists() for stage in STAGE_ORDER):
+        return True
     try:
-        if any(p.is_file() and p.suffix.lower() in _status._FRAME_EXT
-               for p in d.iterdir()):
-            return True
+        return any(p.is_file() and p.suffix.lower() in _status._FRAME_EXT
+                   for p in d.iterdir())
     except OSError:
         return False
-    return any((d / STAGE_OUTPUT[stage]).exists() for stage in STAGE_ORDER)
 
 
 def iter_shoot_dirs():


### PR DESCRIPTION
## Summary

Addresses part of #31 ("Idea: web app front-end — Claude becomes a backend
service, not the UI"), building exactly Phase 1 of the plan
`docs/webapp-architecture.md` (PR #91) laid out: **a read-only local
dashboard, no server, no job queue, no new network surface.**

Extends the static-HTML-generator pattern `tools/sales_report.py` already
proves (`gather()` → `draw()` → `reports/sales_dashboard.html`) to the other
views the issue names, beyond sales:

    python -m lib.cli dashboard                # -> reports/dashboard.html
    python -m lib.cli dashboard --out FILE

| View | Reuses | Notes |
|---|---|---|
| **Backlog by stage** | `lib.status.gather()`, unchanged | One row per `inventory/<shoot>/`; shoot dirs found the same way `lib.status` itself defines one (a frame file, or any of the five stage outputs), backup/dot dirs excluded via `lib.source_report._is_backup_path` |
| **Drafts awaiting review** | `lib.report.collect()` | The same disk-draft + ledger merge `report_pipeline()` already prints as text, filtered to unpublished, split into synced-not-published / drafted-only, kept structured for HTML. Each row's `lib.list_edit.validate_draft_for_sync()` issues (offline, no eBay call) are attached |
| **Live listing vs. ledger drift** | `tools.sales_report`'s `_rows()`/CHOICE-dedup rule | New comparison — diffs the last-synced `inventory_sheet.csv` against `listings_ledger.csv`, both already on disk; makes no eBay call of its own |

## Judgment calls worth a second look

- **Drift reads two already-synced local CSVs, not the live Sell API.**
  `tools/ledger_reconcile.py`'s `compute_drift()` is the closest existing
  pattern for this shape of diff, but it calls eBay for truth — out of
  bounds for a read-only local dashboard per the plan's hard constraint. This
  view is therefore only as fresh as the last `tools/ebay_sheet.py` /
  listing sync, and says so on the page when either CSV is missing.
- **Voice-check snippets are redacted.** `validate_draft_for_sync()` folds in
  `lib.voice_check.check_voice()`, which quotes up to 90 chars of the
  buyer-facing draft body verbatim when it flags an in-hand-voice violation.
  That text is meant for eBay's own listing page, not PII — but to keep this
  dashboard to structured/aggregated fields only (the same policy
  `lib/source_report.py` / `tools/sales_report.py` already follow), the
  quoted phrase is stripped before rendering and only "which field flagged"
  survives (`voice (block): body — ... run \`ebz voice\` for the text`). A
  human should confirm this is the right line to draw.
- **CHOICE group drafts** (`draft_group.md`) are listed but not run through
  `validate_draft_for_sync()` — that function assumes a single-item draft
  shape, so group rows show no blocking issues rather than a wrong one.

## Not in this PR (Phases 2-4)

Per the architecture doc's own sequencing, this PR is Phase 1 only:

- **No server, no job queue, no background process.** This is a one-shot
  CLI command that writes a file, exactly like `sales-report`.
- **No new network call and no new dependency.** Every gather function
  reads only local files already on disk; nothing here syncs eBay or Apify.
- **No writes.** Nothing here touches `sales_ledger.csv`,
  `listings_ledger.csv`, or any file under `inventory/` — read-only, always
  (see the `test_dashboard_never_writes_any_tracked_file` regression test).
- Phases 2-4 (local job queue, secrets story + network reach, Claude as an
  invoked backend service) are untouched — this doesn't move any credential,
  open any port, or wrap any writing code as a job.

#31 stays open for the remaining phases.

## Tests

`tests/test_dashboard.py` — 29 new tests, synthetic fixtures only (no real
`inventory/`, no credentials, no network), following this repo's existing
monkeypatch-module-constants pattern (`tests/test_source_report.py`,
`tests/test_status.py`):

- shoot-dir discovery, including backup/dot-dir exclusion and the
  no-`inventory/`-directory case
- per-stage backlog bucketing and sku/ledger passthrough
- drafts: synced/drafted split, price sort, published-row exclusion,
  blocking-issue attachment, voice-snippet redaction, group-draft skip
- drift: price/title mismatch, matching rows, orphan-live, orphan-ledger,
  CHOICE-variation dedup, non-live rows ignored, missing-CSV case
- combined `draw()` on both an empty repo and populated data
- a read-only guarantee (nothing under `inventory/` or the ledger changes)
- two PII regression tests: context.txt prose and raw draft body text never
  reach the rendered page, only structured fields do
- CLI registration (`dashboard` in `lib.cli.COMMANDS`, `--help` works)

`python -m pytest tests/ -q` → **673 passed, 1 skipped**, run twice
(matching this repo's CI convention). The one skip
(`tests/test_marble_gate.py`) is pre-existing — it needs
`sentence-transformers`, not installed in CI by design. Compared against a
clean run of the same suite before this branch's changes: identical skip,
+29 passing (this PR's new tests), no regressions.

`ruff check` clean on `tools/dashboard.py`, `lib/cli.py`,
`tests/test_dashboard.py`. `python -m py_compile` clean on every tracked
`.py` file (matches the CI step).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RxdmWWe6ZEbZEWGVxoBMG3)_