### PR TITLE
feat(guard): enforce the always-background rule instead of documenting it (#121)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,19 @@
 {
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR/tools/bg_guard.py\"",
+            "timeout": 10,
+            "statusMessage": "background guard"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(cd:*)",

--- a/RUN.md
+++ b/RUN.md
@@ -113,15 +113,33 @@ it lands. The same applies to any other foreground call in that range.
 **Always start these backgrounded — by command prefix, not judgment call**
 (measured across 122 sessions, #74; prefixes match the real invocation
 forms used throughout `prompts/`, not bare names):
-`python -m lib.photo_prep.prep`, `python -m pytest`,
+`python -m lib.photo_prep.prep`, `python -m lib.cli prep`,
+`python -m lib.cli single-pass`, `python -m lib.cli observe`,
+`python -m pytest`,
 `python tests/run_all.py`, `python tools/ledger_reconcile.py`,
-`python tools/prep_sheet_html.py`, the comp-hunt call
+`python tools/prep_sheet_html.py`, `python tools/review_card_html.py`,
+the comp-hunt call
 (`python lib/ebay_sold_browse.py` — Apify is retired, see
 [`docs/archive/pricing-backend-issues.md`](docs/archive/pricing-backend-issues.md)),
-`python lib/lens_id.py`,
-`python tools/reindex_*.py`. Each one routinely runs long enough that
+`python lib/lens_id.py`, `python lib/list_edit.py` (the EPS photo upload
+alone runs a minute),
+`python tools/reindex_`\*`.py`. Each one routinely runs long enough that
 foregrounding it is a wasted turn waiting on nothing the next step needs
 yet.
+
+**This one is enforced, not advised (#121).** The rule above was
+documentation from #74's audit until a 7-day observer read measured what
+that was worth: **54 shell calls over 30s totalling 9.8h of blocked
+wall-clock, with 2.2% of 947 calls backgrounded.** A `PreToolUse` hook
+([`tools/bg_guard.py`](tools/bg_guard.py), wired up in
+`.claude/settings.json`) now **denies** a foreground call whose command
+runs one of those prefixes — matched per shell segment, so the usual
+`cd "<dir>" && python -m …` form is caught — and the deny message says to
+re-issue the same call with `run_in_background`. The prefix list lives in
+`bg_guard.py`; `tests/test_bg_guard.py` fails if this section stops naming
+one of them. A genuinely instant invocation of a listed tool (`--status`,
+`--check`) opts out with a leading `# fg-ok: <reason>` comment — stated on
+the command line, never silent.
 
 **Never poll a backgrounded job with `sleep`.** A `sleep N` loop burns a turn
 per poll for no signal a proper wait doesn't already give you — a

--- a/tests/test_bg_guard.py
+++ b/tests/test_bg_guard.py
@@ -1,0 +1,140 @@
+"""Background guard — the #121 acceptance set.
+
+Every "should deny" case below is a real command shape from the session
+transcripts the observer read; the `cd … && python …` form is how essentially
+every repo call is actually issued, which is exactly why a naive startswith
+guard would have caught none of them.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT))
+
+from bg_guard import SLOW_PREFIXES, offending_prefix, segments, verdict  # noqa: E402
+
+
+def test_bare_slow_command_is_caught():
+    assert offending_prefix("python -m pytest") == "python -m pytest"
+
+
+def test_prefix_after_cd_is_caught():
+    """The real invocation form. A whole-string startswith would miss this."""
+    cmd = 'cd "C:/repo" && python -m lib.photo_prep.prep "shoot" --auto'
+    assert offending_prefix(cmd) == "python -m lib.photo_prep.prep"
+
+
+def test_prefix_in_a_later_segment_is_caught():
+    cmd = 'echo start; python tests/run_all.py --fast'
+    assert offending_prefix(cmd) == "python tests/run_all.py"
+
+
+def test_python3_and_py_are_the_same_runner():
+    assert offending_prefix("python3 -m pytest") == "python -m pytest"
+    assert offending_prefix("py tools/ledger_reconcile.py") == "python tools/ledger_reconcile.py"
+
+
+def test_reindex_glob_prefix():
+    assert offending_prefix("python tools/reindex_full.py") == "python tools/reindex_"
+
+
+def test_fast_command_is_untouched():
+    assert offending_prefix('cd "C:/repo" && git status') is None
+    assert offending_prefix("ls -la") is None
+    assert offending_prefix("python lib/dir_context.py x --root y") is None
+
+
+def test_a_similar_looking_path_is_not_a_prefix():
+    """`prep_card.py` is fast and is NOT on the list; `prep_sheet_html.py` is."""
+    assert offending_prefix("python tools/prep_card.py shoot") is None
+    assert offending_prefix("python tools/prep_sheet_html.py shoot") == "python tools/prep_sheet_html.py"
+
+
+def test_backgrounded_call_is_allowed():
+    ti = {"command": "python -m pytest", "run_in_background": True}
+    assert verdict(ti) is None
+
+
+def test_foreground_call_is_denied_with_an_actionable_reason():
+    reason = verdict({"command": "python -m pytest"})
+    assert reason is not None
+    assert "run_in_background" in reason
+    assert "python -m pytest" in reason
+    assert "sleep" in reason           # the "don't poll" half of the RUN.md rule
+
+
+def test_escape_hatch_allows_with_a_stated_reason():
+    cmd = '# fg-ok: --status is instant\npython -m lib.photo_prep.prep shoot --status'
+    assert offending_prefix(cmd) is None
+    assert verdict({"command": cmd}) is None
+
+
+def test_escape_hatch_must_lead_the_command():
+    """A `# fg-ok` buried mid-command is not an opt-out — it would hide the rule."""
+    cmd = 'python -m pytest  # fg-ok: I promise'
+    assert offending_prefix(cmd) == "python -m pytest"
+
+
+def test_segments_normalises_and_splits():
+    assert "python -m pytest" in segments('cd x && python3 -m pytest')
+
+
+def test_separator_inside_quotes_is_not_a_split():
+    """The regression that denied this guard's own pipe-test.
+
+    `echo '{"command":"cd x && python -m pytest"}' | python tools/bg_guard.py`
+    runs no slow tool — the prefix is argument text. Splitting on the quoted
+    `&&` produced a fragment starting with the prefix and blocked the call.
+    """
+    cmd = ('echo \'{"tool_input":{"command":"cd x && python -m pytest"}}\''
+           ' | python tools/bg_guard.py')
+    assert offending_prefix(cmd) is None
+
+
+def test_prefix_named_inside_a_grep_is_not_a_run():
+    assert offending_prefix("""grep -n 'python -m pytest' RUN.md""") is None
+    assert offending_prefix('rg "python lib/lens_id.py" docs/') is None
+
+
+def test_real_pipe_after_a_quoted_mention_still_catches_a_real_run():
+    """Quote-awareness must not make the guard blind to an actual run."""
+    cmd = 'echo "about to run python -m pytest" && python -m pytest -q'
+    assert offending_prefix(cmd) == "python -m pytest"
+
+
+def test_run_md_names_every_prefix():
+    """The guard is the source of truth; RUN.md must not drift from it."""
+    run_md = (ROOT / "RUN.md").read_text(encoding="utf-8")
+    missing = [p for p in SLOW_PREFIXES if p not in run_md]
+    assert not missing, f"RUN.md does not name: {missing}"
+
+
+def _hook(payload: dict) -> str:
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "bg_guard.py")],
+        input=json.dumps(payload), capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+def test_hook_denies_over_stdin():
+    out = _hook({"tool_name": "Bash", "tool_input": {"command": "python -m pytest"}})
+    decision = json.loads(out)["hookSpecificOutput"]
+    assert decision["hookEventName"] == "PreToolUse"
+    assert decision["permissionDecision"] == "deny"
+
+
+def test_hook_stays_silent_when_allowing():
+    assert _hook({"tool_name": "Bash", "tool_input": {"command": "ls"}}) == ""
+    assert _hook({"tool_name": "Read", "tool_input": {"file_path": "x"}}) == ""
+
+
+def test_malformed_input_never_blocks():
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "bg_guard.py")],
+        input="not json", capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0
+    assert proc.stdout == ""

--- a/tools/bg_guard.py
+++ b/tools/bg_guard.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""BACKGROUND GUARD — refuse a foreground shell call that should have been backgrounded (#121).
+
+RUN.md has carried the rule since #74: a fixed list of command prefixes always
+starts with `run_in_background`, "by command prefix, not judgment call". The
+7-day observer read that produced #121 measured what the documented rule is
+actually worth: **54 Bash calls over 30s totalling 9.8h, with 2.2% of 947 calls
+backgrounded**. A rule that nobody follows is not a rule, it is a comment.
+
+So this is the same rule with teeth. It runs as a `PreToolUse` hook on `Bash`,
+reads the tool input, and denies the call when a listed prefix appears in the
+command and `run_in_background` is not set. The deny message names the prefix
+and says what to do, so the fix is one re-issue of the same call.
+
+Deliberate design choices, each of which is a way this could have gone wrong:
+
+- **Prefixes are matched per shell segment**, not against the whole string.
+  Nearly every real call in this repo is `cd "<dir>" && python -m ...`, so a
+  `startswith` test on the raw command would have matched almost nothing and
+  the guard would have been decoration.
+- **Segmenting is quote-aware.** The first version split on `&&`/`;`/`|`
+  anywhere, and promptly denied the command that pipe-tested it — the operator
+  it split on was inside a quoted JSON argument, leaving a fragment that
+  *started with* `python -m pytest`. Any command that merely mentions one of
+  these tools inside a string (a grep, a heredoc, docs about the rule) would
+  have been blocked. Operators inside quotes are not separators.
+- **The list here is the source of truth**, and `tests/test_bg_guard.py`
+  asserts RUN.md still names every entry. The failure mode for a rule that
+  lives in two places is that they drift and neither is trusted.
+- **There is one escape hatch, and it leaves a trace.** Prefix the command with
+  `# fg-ok: <reason>` to run it in the foreground anyway. Some of these tools
+  have genuinely instant flags (`prep --status`), and a guard with no way out
+  gets disabled wholesale the first time it is wrong. A stated reason in the
+  command line is cheap; a silently weakened rule is not.
+- **Unparseable input allows.** A guard that blocks the shell because its own
+  JSON was malformed would be worse than the friction it prevents.
+
+    echo '{"tool_name":"Bash","tool_input":{"command":"python -m pytest"}}' \
+        | python tools/bg_guard.py        # -> deny, exit 0
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+# Every prefix RUN.md's "Always start these backgrounded" list names, in its
+# real invocation form. Keep in sync with RUN.md — test_bg_guard enforces it.
+SLOW_PREFIXES = (
+    "python -m lib.photo_prep.prep",
+    "python -m lib.cli prep",
+    "python -m lib.cli single-pass",
+    "python -m lib.cli observe",
+    "python -m pytest",
+    "python tests/run_all.py",
+    "python tools/ledger_reconcile.py",
+    "python tools/prep_sheet_html.py",
+    "python tools/review_card_html.py",
+    "python lib/ebay_sold_browse.py",
+    "python lib/lens_id.py",
+    "python lib/list_edit.py",
+    "python tools/reindex_",
+)
+
+# `cd x && python …`, `a; b`, `a | b` — a prefix can sit in any segment.
+_SEPARATORS = ("&&", "||", ";", "|", "\n")
+# `python3 …` and `py …` are the same runner; normalise before matching.
+_RUNNER = re.compile(r"^(python3|py)\b")
+_ESCAPE = re.compile(r"^\s*#\s*fg-ok\b", re.I)
+
+
+def segments(command: str) -> list[str]:
+    """The command split into shell segments, each stripped and normalised.
+
+    Quote-aware: a separator inside '…' or "…" is argument text, not a break.
+    Without that, `echo '… && python -m pytest'` splits into a fragment that
+    starts with the prefix and the guard blocks a command that runs nothing.
+    """
+    out, buf, quote, i = [], [], None, 0
+    text = command or ""
+    while i < len(text):
+        ch = text[i]
+        if quote:
+            buf.append(ch)
+            if ch == "\\" and quote == '"' and i + 1 < len(text):
+                buf.append(text[i + 1])        # escaped char stays inside the quote
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in "'\"":
+            quote = ch
+            buf.append(ch)
+            i += 1
+            continue
+        hit = next((s for s in _SEPARATORS if text.startswith(s, i)), None)
+        if hit:
+            out.append("".join(buf))
+            buf = []
+            i += len(hit)
+            continue
+        buf.append(ch)
+        i += 1
+    out.append("".join(buf))
+
+    cleaned = []
+    for raw in out:
+        seg = raw.strip()
+        while seg[:1] in ("(", "{"):
+            seg = seg[1:].strip()
+        cleaned.append(_RUNNER.sub("python", seg))
+    return cleaned
+
+
+def offending_prefix(command: str) -> str | None:
+    """The first slow prefix this command runs, or None.
+
+    Returns None when the `# fg-ok:` escape is present — the operator (or the
+    model, on the record) has said why the foreground run is correct here.
+    """
+    if _ESCAPE.match(command or ""):
+        return None
+    for seg in segments(command):
+        for prefix in SLOW_PREFIXES:
+            if seg.startswith(prefix):
+                return prefix
+    return None
+
+
+def verdict(tool_input: dict) -> str | None:
+    """The deny reason for this Bash tool input, or None to allow."""
+    if tool_input.get("run_in_background"):
+        return None
+    prefix = offending_prefix(tool_input.get("command", ""))
+    if not prefix:
+        return None
+    return (
+        f"`{prefix}` is on RUN.md's always-background list and this call has no "
+        f"run_in_background. Measured in #121: 54 foreground shell calls over 30s "
+        f"cost 9.8h of blocked wall-clock in one week.\n"
+        f"Re-issue the SAME command with run_in_background: true, then carry on "
+        f"with the next step — its output is available on demand and the result "
+        f"arrives on its own when it lands. Do not poll it with sleep.\n"
+        f"If this particular invocation really is instant (a --status or --check "
+        f"read), prefix the command with `# fg-ok: <reason>` and it will run."
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:                       # malformed input must never block work
+        return 0
+    if payload.get("tool_name") not in ("Bash", "PowerShell"):
+        return 0
+    reason = verdict(payload.get("tool_input") or {})
+    if not reason:
+        return 0
+    json.dump({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }}, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the first finding of #121.

## Why a hook and not more prose

RUN.md has carried the always-background prefix list since **#74**'s audit. The
7-day observer read behind #121 measured what documentation alone was worth:

> **54 shell calls over 30s totalling 9.8h of blocked wall-clock, with 2.2% of
> 947 calls backgrounded.**

The rule already existed and did nothing. Writing it down a second time, harder,
is not a fix — so this is the same rule with teeth.

`tools/bg_guard.py` runs as a `PreToolUse` hook on `Bash` and **denies** a
foreground call whose command runs one of the listed prefixes. The deny names
the prefix and says to re-issue the same call with `run_in_background`, so the
correction costs one turn.

## The three details that are the whole difficulty

- **Matching is per shell segment.** Essentially every real call in this repo is
  `cd "<dir>" && python -m ...`. A `startswith` on the raw command would have
  matched close to nothing — a guard that reports success while catching
  nothing is worse than no guard.
- **Segmenting is quote-aware** — found the hard way. The first version split on
  `&&` anywhere and immediately denied the command that pipe-tested it: the
  operator it split on was inside a quoted JSON argument, leaving a fragment
  that *started with* `python -m pytest`. Every `grep 'python -m pytest'`, every
  heredoc, every doc edit about this rule would have been blocked. Regression
  test: `test_separator_inside_quotes_is_not_a_split`.
- **One escape hatch, and it leaves a trace.** A leading `# fg-ok: <reason>`
  comment runs the command anyway, for the genuinely instant invocations
  (`--status`, `--check`). A guard with no way out gets switched off wholesale
  the first time it is wrong; a stated reason on the command line is cheap.

Two more deliberate choices: **unparseable hook input allows** (a guard that
blocks the shell because its own JSON was malformed is worse than the friction
it prevents), and **the prefix list lives in `bg_guard.py`** with
`test_bg_guard.py` failing if RUN.md stops naming one of them — a rule with two
homes drifts and then neither is trusted.

## Changes

| file | |
|---|---|
| `tools/bg_guard.py` | new — the hook and its predicate |
| `tests/test_bg_guard.py` | new — 19 tests, incl. the RUN.md drift guard |
| `.claude/settings.json` | `PreToolUse` → `Bash` wiring |
| `RUN.md` | list extended, rule marked enforced |

Prefixes added since #74, all measured: the `ebz` forms (`lib.cli prep` /
`single-pass` / `observe`), `review_card_html.py`, and `list_edit.py` — whose
EPS photo upload alone runs about a minute.

## Testing

`python -m pytest tests/ -q` (what CI runs): **609 passed, 1 failed** in 4m40s.

The one failure is pre-existing and unrelated —
`test_dir_context.py::test_chain_for_walks_root_to_item_outermost_first`
string-compares `str(path.relative_to(root))` against literal forward slashes,
so it fails on Windows and passes on CI's ubuntu-latest. Not touched by this
branch; being fixed separately.

`run_all.py --fast` reports "3 FAILURE(S)", which is misleading: the same
Windows path test, plus two in `test_ebay_sold_browse_cache` that pass under
pytest and only fail under `run_all`'s fixture-less harness (its siblings in
that file are openly SKIPped for the same reason).

## What this does NOT do

#121's findings 2 and 3 proposed giving the **"Review card"** gate a
confidence-gate default it can self-approve. **Deliberately not implemented.**
REVIEW is the publish gate — the single HARD gate left in RUN.md's gate
contract. Its 4.8h is a human deciding whether to publish, which is the product,
not friction. The PREP analogy fails: a wrong crop is revisable, a wrong publish
is not. Reasoning and the follow-ups (a gate-name denylist for the proposal
generator; per-finding dedup, which would have caught that #121 duplicates #74
and #100) are on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
