### PR TITLE
docs(gitignore): document that untracking does not scrub git history (#104)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,14 @@
 #
 # When adding a rule, say which class it belongs to. When in doubt about a file
 # that contains numbers from real sales: it is business data, exclude it.
+#
+# THESE RULES ARE FORWARD-LOOKING ONLY. Untracking a path (`git rm --cached`)
+# stops it appearing in new commits; it does not remove the blob from history.
+# Anything ever committed here — including paths later added to this file —
+# remains fetchable from this public repo at its old commit SHAs. See #104 for
+# what that currently includes and the decision on whether/how to address it.
+# A path listed below with "kept on disk, not tracked" describes today's HEAD,
+# not a guarantee about history.
 
 # ---------------------------------------------------------------- 1. SECRETS
 # Live config holds API tokens — never commit. Use lib/config.example.yaml
@@ -142,6 +150,8 @@ desktop.ini
 # live pipeline read it, and the local copy still carries real listing drafts,
 # prices, eBay draft ids and the seller ZIP. The whole directory stays ignored
 # so an operator's local archive can never be re-added to a public repo.
+# Untracking did NOT scrub history: this content is still present in commits
+# before 2026-08-31 and fetchable by anyone with a clone. See #104.
 /deprecated/
 
 # PREP batch working files — the queue, its log, and the candidate scan. Derived
@@ -196,7 +206,9 @@ desktop.ini
 
 # Business formation checklist — entity names, what has and has not been filed,
 # the counties being worked. Not pipeline, and this repo is public; untracked
-# 2026-08-31 (#99) and kept on disk. Same class as /formation/.
+# 2026-08-31 (#99) and kept on disk. Same class as /formation/. It was tracked
+# from this repo's initial commit until then, so it remains in history and
+# fetchable from old commit SHAs — untracking did not remove it. See #104.
 /todo.md
 
 # local working backups (ledger/sales/config) — never committed


### PR DESCRIPTION
## What this is

Implements **option 3 ("Accept and document")** from #104, which is what the issue's author leans toward absent confirmation that the exposed ZIP-matching files carry a home address: *"Add a line to `.gitignore`'s charter saying history is not clean and the untracking rules are forward-looking only, so nobody reads them as a guarantee."*

Options 1 (`git filter-repo` + force-push) and 2 (make the repo private) are both destructive/irreversible calls with real costs to existing clones, forks, and PR/commit links — the issue is explicit that these need **a decision from the owner**, not automatic execution. This PR does not attempt either. It only fixes the part that was actively misleading: the `.gitignore` charter and its per-path notes described paths as "removed"/"untracked"/"kept on disk" in a way that reads as "not in the repo," when the blobs are still fetchable from every pre-untracking commit SHA.

## Changes

- New charter note at the top of `.gitignore`: untracking (`git rm --cached`) stops a path appearing in *new* commits, not a guarantee about history; points to #104 for what's currently exposed.
- `/deprecated/`'s note now says the v1/v2 archive content (real listing drafts, prices, eBay draft ids, the seller ZIP) is still present in commits before 2026-08-31 and fetchable by anyone with a clone.
- `/todo.md`'s note now says the same for the LLC-formation checklist, which was tracked from the repo's initial commit until 2026-08-31.

## Not in this PR

- No history rewrite, no repo-visibility change — both need the owner's explicit go-ahead per the issue.
- The lower-severity, currently-*tracked* `docs/archive/prep_pushed*.md` / `docs/archive/root-cards/updated_listings.md` listing-ID maps the issue flags as "worth deciding on in the same pass, not urgent" — left untouched; the issue treats it as a separate, non-urgent decision.
- Confirming exactly what the 17 ZIP-matching files in `deprecated/PRL-batches/` contain — the issue notes this could change the recommendation to option 1 or 2; that's a judgment call for the owner, not something this PR can verify.

## Acceptance criteria from #104

- [x] "If 3: the `.gitignore` charter no longer implies history is clean" — done, this PR.
- [ ] "You pick an option" — this PR implements the issue's own leaning default (3); still open for the owner to override with 1 or 2 if the ZIP-code files turn out to carry a home address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2a7nQ7gyks9Qu6rd9cqGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2a7nQ7gyks9Qu6rd9cqGA)_