### PR TITLE
feat(prep): --resume + per-frame progress + --jobs N (#74, item 3)

### DIFF
--- a/docs/prep-resume-plan.md
+++ b/docs/prep-resume-plan.md
@@ -1,15 +1,16 @@
 # PREP `--resume` / `--jobs N` — implementation plan (#74 item 3)
 
-**Status: steps 1–3 of "Suggested follow-up PR shape" (below) are implemented**
-— atomic `_save_bgr` writes, incremental per-frame checkpointing, and
-`--resume` with the settings-hash/staleness check, all in `run_apply()`.
-**Step 4 (`--jobs N` / `ProcessPoolExecutor`) is still just a plan** —
-deliberately deferred, because it wants a real peak-RSS measurement at
-`--jobs 4` on a representative shoot before a default worker count is picked
-(see that section below), which is future work, not something to guess at
-in the same PR. The rest of this document is left as originally written;
-only this status line and the follow-up section's step numbering reflect
-what has since shipped.
+**Status: all four steps of "Suggested follow-up PR shape" (below) are
+implemented.** Steps 1–3 — atomic `_save_bgr` writes, incremental per-frame
+checkpointing, and `--resume` with the settings-hash/staleness check — landed
+first, all in `run_apply()`. Step 4 (`--jobs N`) landed in a follow-up PR: a
+`ProcessPoolExecutor`, one frame per worker task, sharing the exact same
+per-frame render function (`_render_frame`) the serial path calls, default
+`jobs=1` (unchanged behaviour). It deliberately does NOT set a non-1 default
+— the real peak-RSS measurement this doc calls for below was never gathered,
+so `--jobs` stays a pure opt-in: pick a number for your own machine. The rest
+of this document is left as originally written; only this status line and
+the follow-up section's step numbering reflect what has since shipped.
 
 ## The problem, precisely
 
@@ -215,12 +216,27 @@ disjoint from every other frame's.
    loop) — makes a killed `--apply` at least leave a *consistent* partial
    manifest, before `--resume` exists to exploit it.
 3. ✅ `--resume` flag + the settings-hash/staleness check.
-4. ⬜ **Still pending.** `--jobs N` + `ProcessPoolExecutor`, gated behind a
-   real memory measurement for the default. Not implemented by the PR that
-   shipped 1–3 (#74 item 3 follow-up) — it explicitly stayed out of scope
-   because a memory measurement is a prerequisite this repo isn't yet in a
-   position to gather, not something to bake a guess for into a PR.
+4. ✅ `--jobs N` + `ProcessPoolExecutor`. The frame-render body was pulled out
+   of `run_apply`'s loop into a standalone `_render_frame(shoot, name, rec,
+   aspect, pad, smode, only)` — pure with respect to the manifest, returns the
+   new `rec` plus the in-memory pixels the sheet wants — so the serial
+   (`--jobs 1`) path and the pool path call *the same function*, never two
+   implementations that could drift. A pool worker (`_apply_worker`) discards
+   the returned pixels and sends back only the small `rec` dict, to keep the
+   pool's IPC cheap; the parent reloads a pool-rendered frame's pixels off
+   disk for the sheet afterwards, the same trick `--resume` already used for
+   a skipped frame. `--resume` is checked before a frame is ever queued as a
+   pool task, so a resumed frame never occupies a worker slot. Each
+   completed future is folded into the manifest and checkpointed
+   individually (item 2's guarantee, extended to the pool path), and a
+   worker's exception is caught and turned into a per-frame `ERROR` status +
+   flag rather than sinking every other frame's future already in flight.
+   Default stays `jobs=1` — the memory measurement this doc originally asked
+   for to justify a higher default was never gathered, so `--jobs` ships as a
+   pure opt-in with no baked-in guess; see the follow-up PR's "Judgment
+   calls" for the reasoning.
 
 Each step is independently mergeable and independently useful — 1–2 alone
 fix the "partial manifest is inconsistent with partial renders" half of the
-bug even before `--resume` exists to take advantage of it.
+bug even before `--resume` exists to take advantage of it, and 1–3 already
+shipped as their own PR before 4 landed.

--- a/lib/photo_prep/prep.py
+++ b/lib/photo_prep/prep.py
@@ -53,6 +53,7 @@ still a separate, explicit yes.
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import hashlib
 import json
 import os
@@ -1027,8 +1028,123 @@ def _frame_is_resumable(shoot: Path, name: str, rec: dict, only: tuple) -> bool:
     return True
 
 
+def _render_frame(shoot: Path, name: str, rec: dict, aspect, pad: float,
+                   smode: str, only: tuple) -> tuple:
+    """Render one frame: plan its crop (unless an operator already fixed
+    one) and every preset in `only`. Returns `(new_rec, before, variants)` --
+    `before` is the frame as loaded from disk, unrotated (the sheet's
+    "before" column) and `variants` is `{preset_name: rendered_bgr}`.
+
+    Pure with respect to the manifest: never touches `m` and never calls
+    `save_manifest` — the caller folds the returned rec into
+    `m["photos"][name]` and checkpoints. That split is what lets this one
+    function serve both `--jobs 1` (called serially, in manifest order, from
+    inside `run_apply`'s own loop) and `--jobs N>1` (called once per task
+    inside a `ProcessPoolExecutor` worker — see `_apply_worker` below)
+    without two implementations of "how a frame renders" able to drift apart
+    (docs/prep-resume-plan.md, the `--jobs N` section).
+    """
+    rec = dict(rec)   # never mutate the caller's dict in place -- a --jobs N
+                       # worker is handed a copy across a process boundary
+                       # anyway, and this keeps both call sites' contract
+                       # ("returns the new state") identical.
+    src = shoot / name
+    before = _load_bgr(src)
+    img = orientmod.rotate_bgr(before, rec["orientation"]["applied"])
+
+    # A legacy warp from before the unskew stage was removed is a decision
+    # already published, not a proposal — replay it, never re-derive it.
+    # Everything below is measured on the frame the crop was planned on.
+    sk = skewmod.from_dict(rec.get("unskew"))
+
+    # Re-segment on the upright pixels: the crop box in the manifest was
+    # planned there, and the colour pass needs the same mask.
+    sm = mask_for(img, smode)
+    img, sm = _unskewed(img, sm, sk)
+    # Judged before the crop — a tight crop keeps too little backdrop to
+    # tell a sweep from a textured surface (see color._backdrop_lut).
+    pre_stats = colormod.analyze(img, sm.mask)
+    # The check pass already reconciled this frame's backdrop against the
+    # rest of the shoot; honour that rather than re-deciding it alone.
+    cp = rec.get("color_plan") or {}
+    sweep = bool(cp.get("is_sweep", pre_stats.is_sweep))
+    eff_class = cp.get("bg_class_effective", pre_stats.bg_class)
+    # An operator override is an answer, not a proposal — re-planning here
+    # would silently throw away the call made at the crop stage, which is
+    # the one the sheet was approved on.
+    prior_crop = rec.get("crop") or {}
+    crop = (prior_crop if prior_crop.get("operator")
+            else plan_crop(img, sm, aspect, pad, pre_stats, sweep))
+    rec["crop"] = crop
+    if crop["applied"]:
+        img, sm = _cropped(img, sm, crop["box"])
+
+    # Every preset renders from the SAME mask and crop. Segmentation is the
+    # expensive step by a wide margin, so offering three looks costs barely
+    # more than offering one — and the comparison is only meaningful if the
+    # geometry is identical across them.
+    # How warm the item itself is, off the same mask the colour pass uses.
+    # Cheap (a statistic on a 1000px copy) and it decides which look the
+    # shoot defaults to — see color.WARM_SUBJECT_MIN_RB.
+    rec["subject_warmth"] = colormod.subject_warmth(img, sm.mask)
+
+    rec["presets"] = {}
+    variants = {}
+    for pname in (only or colormod.PRESETS):
+        rendered, creport = colormod.correct(img, sm.mask, sweep=sweep,
+                                             bg_class=eff_class, preset=pname)
+        p_dir = shoot / ".prep" / "presets" / pname
+        p_dir.mkdir(parents=True, exist_ok=True)
+        p_path = p_dir / (Path(name).stem + ".jpg")
+        _save_bgr(p_path, rendered)
+        rec["presets"][pname] = {
+            "path": str(p_path.relative_to(shoot)).replace("\\", "/"),
+            "sha256": _sha256(p_path),
+            "report": creport,
+        }
+        variants[pname] = rendered
+
+    # DEFAULT_PRESET is not necessarily rendered under `only`; fall back to
+    # whatever was, so the manifest still carries a colour report.
+    _rep_key = (colormod.DEFAULT_PRESET if colormod.DEFAULT_PRESET in rec["presets"]
+                else next(iter(rec["presets"])))
+    rec["color"] = rec["presets"][_rep_key]["report"]
+    # `listing/` stays empty until a preset is picked — the whole point is
+    # that the operator chooses the look, so nothing may default into the
+    # directory DRAFT reads.
+    rec["output"] = None
+    rec["out_sha256"] = None
+    rec["status"] = "ASK" if rec["orientation"]["needs_ask"] else "PICK"
+    return rec, before, variants
+
+
+def _apply_worker(shoot: Path, name: str, rec: dict, aspect, pad: float,
+                   smode: str, only: tuple) -> tuple:
+    """`--jobs N` task body: render one frame inside a pool worker process.
+
+    Must take and return only picklable data — no manifest, no shared state,
+    nothing captured by closure — because `ProcessPoolExecutor` pickles the
+    call. `before`/`variants` are deliberately NOT returned: shipping
+    full-resolution images back over the pool's pipe would be the expensive
+    part all over again, so the parent instead reloads a rendered frame's
+    pixels from disk afterwards for the sheet, the same way `--resume`
+    already does for a frame it skips (docs/prep-resume-plan.md, the
+    `--jobs N` section).
+
+    Exceptions are caught and returned rather than raised: one bad source
+    file must not sink every other frame's future already queued in the pool
+    ("per-frame exception isolation" in the same design-doc section).
+    """
+    try:
+        new_rec, _before, _variants = _render_frame(
+            shoot, name, rec, aspect, pad, smode, only)
+        return name, new_rec, None
+    except Exception as exc:                                  # noqa: BLE001 -- see docstring
+        return name, None, f"{type(exc).__name__}: {exc}"
+
+
 def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
-              resume: bool = False) -> dict:
+              resume: bool = False, jobs: int = 1) -> dict:
     """Render listing/ from the manifest's decisions + the review sheet.
 
     `only` restricts which presets are rendered. The default category now
@@ -1048,7 +1164,21 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
     every frame instead of once at the end (item 2), so a run killed by a
     timeout leaves a consistent partial manifest a later `--resume` can trust,
     instead of orphaning every already-rendered JPEG.
+
+    `jobs` (default 1: serial, in manifest order, byte-for-byte today's
+    behaviour) renders up to that many frames concurrently in a
+    `ProcessPoolExecutor` — one frame per worker task, never one preset,
+    because segmentation is computed once per frame and shared across every
+    preset rendered for it (see this function's own note above); splitting a
+    single frame's presets across workers would duplicate that expensive
+    shared step and race two workers over the same crop decision. Must be a
+    positive int. The manifest is still checkpointed after every completed
+    frame either way, so `--resume` and `--jobs N` compose: a `--jobs 4` run
+    killed mid-batch resumes exactly like a serial one did
+    (docs/prep-resume-plan.md, the `--jobs N` section).
     """
+    if not isinstance(jobs, int) or isinstance(jobs, bool) or jobs < 1:
+        raise ValueError(f"jobs must be a positive int, got {jobs!r}")
     from .center_crop import _parse_aspect
 
     m = load_manifest(shoot)
@@ -1097,7 +1227,8 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
                                          category_of(m), only)
     prior_settings_hash = (m.get("apply_run") or {}).get("settings_hash")
     resumable = resume and prior_settings_hash == settings_hash
-    m["apply_run"] = {"settings_hash": settings_hash, "started_at": _now()}
+    m["apply_run"] = {"settings_hash": settings_hash, "started_at": _now(),
+                      "jobs": jobs}
 
     # An apply in flight -- or interrupted mid-flight -- is not an approved
     # one. Set this BEFORE the loop, not after, so every checkpoint below
@@ -1120,126 +1251,129 @@ def run_apply(shoot: Path, quiet: bool = False, only: tuple = (),
     rows = []
     flags = []
 
-    for name, rec in m["photos"].items():
+    def _resumed_row(name: str, rec: dict) -> tuple:
+        """(name, before, variants, rec) for a frame this run is NOT
+        rendering -- either --resume proved it up to date, or --jobs N
+        rendered it in a worker that (deliberately) sent no pixels back.
+        Reloaded off disk either way: `--resume` has always done this for a
+        skipped frame, and `--jobs N` reuses the exact same trick for a
+        rendered-elsewhere one rather than shipping full-res images across
+        the process pool (docs/prep-resume-plan.md, the `--jobs N` section).
+        """
         src = shoot / name
-        if not src.exists():
-            rec["status"] = "MISSING"
-            flags.append((name, "source file MISSING"))
-            continue
-
-        # --resume: skip the (expensive) re-render only when the manifest's
-        # own record proves the existing files still answer THIS
-        # invocation's question. Conservative by construction -- any one
-        # check failing means the frame is (re)rendered, never the reverse
-        # (docs/prep-resume-plan.md item 3). The sheet still needs pixels for
-        # this frame, so load the original and the already-rendered presets
-        # back off disk rather than re-deriving them.
-        if resumable and _frame_is_resumable(shoot, name, rec, only):
-            before = _load_bgr(src)
-            variants = {pname: _load_bgr(shoot / rec["presets"][pname]["path"])
-                        for pname in only}
-            rows.append((name, before, variants, rec))
-            # A skipped frame's exceptions are exactly as real as a freshly
-            # rendered one's -- reuse the same flag logic below, sourced from
-            # the persisted record instead of a report just computed, so
-            # verdict_emit doesn't read a resumed run as cleaner than it is.
-            c = rec.get("color") or {}
-            if c.get("subject_newly_clipped") or c.get("subject_newly_crushed"):
-                flags.append((name, f"colour pass touched item pixels "
-                                    f"(new-clip={c.get('subject_newly_clipped')}, "
-                                    f"new-crush={c.get('subject_newly_crushed')})"))
-            if rec["orientation"]["needs_ask"]:
-                flags.append((name, "orientation still ASK"))
-            continue
-
         before = _load_bgr(src)
-        img = orientmod.rotate_bgr(before, rec["orientation"]["applied"])
+        variants = {pname: _load_bgr(shoot / rec["presets"][pname]["path"])
+                    for pname in only}
+        return name, before, variants, rec
 
-        # A legacy warp from before the unskew stage was removed is a decision
-        # already published, not a proposal — replay it, never re-derive it.
-        # Everything below is measured on the frame the crop was planned on.
-        sk = skewmod.from_dict(rec.get("unskew"))
-
-        # Re-segment on the upright pixels: the crop box in the manifest was
-        # planned there, and the colour pass needs the same mask.
-        sm = mask_for(img, smode)
-        img, sm = _unskewed(img, sm, sk)
-        # Judged before the crop — a tight crop keeps too little backdrop to
-        # tell a sweep from a textured surface (see color._backdrop_lut).
-        pre_stats = colormod.analyze(img, sm.mask)
-        # The check pass already reconciled this frame's backdrop against the
-        # rest of the shoot; honour that rather than re-deciding it alone.
-        cp = rec.get("color_plan") or {}
-        sweep = bool(cp.get("is_sweep", pre_stats.is_sweep))
-        eff_class = cp.get("bg_class_effective", pre_stats.bg_class)
-        # An operator override is an answer, not a proposal — re-planning here
-        # would silently throw away the call made at the crop stage, which is
-        # the one the sheet was approved on.
-        prior_crop = rec.get("crop") or {}
-        crop = (prior_crop if prior_crop.get("operator")
-                else plan_crop(img, sm, aspect, pad, pre_stats, sweep))
-        rec["crop"] = crop
-        if crop["applied"]:
-            img, sm = _cropped(img, sm, crop["box"])
-
-        # Every preset renders from the SAME mask and crop. Segmentation is the
-        # expensive step by a wide margin, so offering three looks costs barely
-        # more than offering one — and the comparison is only meaningful if the
-        # geometry is identical across them.
-        # How warm the item itself is, off the same mask the colour pass uses.
-        # Cheap (a statistic on a 1000px copy) and it decides which look the
-        # shoot defaults to — see color.WARM_SUBJECT_MIN_RB.
-        rec["subject_warmth"] = colormod.subject_warmth(img, sm.mask)
-
-        rec["presets"] = {}
-        variants = {}
-        for pname in (only or colormod.PRESETS):
-            rendered, creport = colormod.correct(img, sm.mask, sweep=sweep,
-                                                 bg_class=eff_class, preset=pname)
-            p_dir = shoot / ".prep" / "presets" / pname
-            p_dir.mkdir(parents=True, exist_ok=True)
-            p_path = p_dir / (Path(name).stem + ".jpg")
-            _save_bgr(p_path, rendered)
-            rec["presets"][pname] = {
-                "path": str(p_path.relative_to(shoot)).replace("\\", "/"),
-                "sha256": _sha256(p_path),
-                "report": creport,
-            }
-            variants[pname] = rendered
-
-        # DEFAULT_PRESET is not necessarily rendered under `only`; fall back to
-        # whatever was, so the manifest still carries a colour report.
-        _rep_key = (colormod.DEFAULT_PRESET if colormod.DEFAULT_PRESET in rec["presets"]
-                    else next(iter(rec["presets"])))
-        creport = rec["presets"][_rep_key]["report"]
-        rec["color"] = creport
-        # `listing/` stays empty until a preset is picked — the whole point is
-        # that the operator chooses the look, so nothing may default into the
-        # directory DRAFT reads.
-        rec["output"] = None
-        rec["out_sha256"] = None
-        rec["status"] = "ASK" if rec["orientation"]["needs_ask"] else "PICK"
-
-        rows.append((name, before, variants, rec))
+    def _flag_frame(name: str, rec: dict) -> None:
         # Exceptions only: the colour pass measuring its own output as having
         # damaged item pixels, or an orientation still unresolved. Routine
         # per-frame render stats live in the manifest.
-        c = creport
-        if c["subject_newly_clipped"] or c["subject_newly_crushed"]:
+        c = rec.get("color") or {}
+        if c.get("subject_newly_clipped") or c.get("subject_newly_crushed"):
             flags.append((name, f"colour pass touched item pixels "
-                                f"(new-clip={c['subject_newly_clipped']}, "
-                                f"new-crush={c['subject_newly_crushed']})"))
-        if rec["orientation"]["needs_ask"]:
+                                f"(new-clip={c.get('subject_newly_clipped')}, "
+                                f"new-crush={c.get('subject_newly_crushed')})"))
+        if (rec.get("orientation") or {}).get("needs_ask"):
             flags.append((name, "orientation still ASK"))
 
-        # Checkpoint after every frame, not once at the end -- a killed
-        # process must orphan at most the frame in flight, never the ones
-        # already finished (docs/prep-resume-plan.md item 2). save_manifest
-        # already does compare-and-swap and re-stamps m[READ_FINGERPRINT] on
-        # this same dict after a successful write, so the next checkpoint's
-        # CAS check is automatically against the fingerprint THIS process
-        # just wrote -- nothing extra to track here.
-        save_manifest(shoot, m)
+    if jobs <= 1:
+        # Serial, in manifest order -- byte-for-byte the behaviour before
+        # --jobs existed (this branch is the same code, only pulled out into
+        # `_render_frame` so `--jobs N` below can share it verbatim).
+        for name, rec in m["photos"].items():
+            src = shoot / name
+            if not src.exists():
+                rec["status"] = "MISSING"
+                flags.append((name, "source file MISSING"))
+                continue
+
+            # --resume: skip the (expensive) re-render only when the
+            # manifest's own record proves the existing files still answer
+            # THIS invocation's question. Conservative by construction --
+            # any one check failing means the frame is (re)rendered, never
+            # the reverse (docs/prep-resume-plan.md item 3).
+            if resumable and _frame_is_resumable(shoot, name, rec, only):
+                rows.append(_resumed_row(name, rec))
+                _flag_frame(name, rec)
+                continue
+
+            new_rec, before, variants = _render_frame(
+                shoot, name, rec, aspect, pad, smode, only)
+            m["photos"][name] = new_rec
+            rows.append((name, before, variants, new_rec))
+            _flag_frame(name, new_rec)
+
+            # Checkpoint after every frame, not once at the end -- a killed
+            # process must orphan at most the frame in flight, never the
+            # ones already finished (docs/prep-resume-plan.md item 2).
+            # save_manifest already does compare-and-swap and re-stamps
+            # m[READ_FINGERPRINT] on this same dict after a successful
+            # write, so the next checkpoint's CAS check is automatically
+            # against the fingerprint THIS process just wrote -- nothing
+            # extra to track here.
+            save_manifest(shoot, m)
+    else:
+        # --jobs N: one frame per pool task, never one preset -- segmentation
+        # is computed once per frame and shared across every preset rendered
+        # for it, so splitting a single frame's presets across workers would
+        # duplicate that expensive shared step and race two workers over the
+        # same crop decision (docs/prep-resume-plan.md, the `--jobs N`
+        # section). --resume is honoured first, exactly as in the serial
+        # branch, so a resumed frame never occupies a worker slot at all.
+        pending = []
+        for name, rec in m["photos"].items():
+            src = shoot / name
+            if not src.exists():
+                rec["status"] = "MISSING"
+                flags.append((name, "source file MISSING"))
+                continue
+            if resumable and _frame_is_resumable(shoot, name, rec, only):
+                _flag_frame(name, rec)
+                continue
+            pending.append(name)
+
+        with concurrent.futures.ProcessPoolExecutor(max_workers=jobs) as pool:
+            futures = {
+                pool.submit(_apply_worker, shoot, name, m["photos"][name],
+                           aspect, pad, smode, only): name
+                for name in pending
+            }
+            # Folded and checkpointed in COMPLETION order, not submission
+            # order -- fine for the manifest, since each frame's entry is
+            # independent and the parent is still the sole writer of the
+            # whole document at any one time (save_manifest's
+            # compare-and-swap doesn't care about frame order, only about
+            # nobody else touching prep.json between our read and our
+            # write). Only the SHEET needs manifest order, and `rows` is
+            # reassembled below, after every future has been folded in.
+            for fut in concurrent.futures.as_completed(futures):
+                name = futures[fut]
+                _, new_rec, err = fut.result()
+                if err is not None:
+                    # One bad frame must not sink the batch (design doc:
+                    # "per-frame exception isolation") -- flagged and left
+                    # out of the sheet, everything else keeps going.
+                    m["photos"][name]["status"] = "ERROR"
+                    flags.append((name, f"render failed: {err}"))
+                else:
+                    m["photos"][name] = new_rec
+                    _flag_frame(name, new_rec)
+                # Checkpoint after every completed frame, exactly as the
+                # serial branch does (docs/prep-resume-plan.md item 2) -- a
+                # --jobs N run killed mid-batch leaves the same kind of
+                # consistent partial manifest a serial one would.
+                save_manifest(shoot, m)
+
+        # Reassemble `rows` in MANIFEST order for `_presets_sheet` (a pool
+        # completes out of order) -- reloaded off disk, since a frame
+        # rendered by a worker has no in-memory pixels left in this process
+        # to reuse (see `_apply_worker`'s docstring for why).
+        for name, rec in m["photos"].items():
+            if rec.get("status") in ("MISSING", "ERROR"):
+                continue
+            rows.append(_resumed_row(name, rec))
 
     # Renders from an earlier pass that this one no longer names. Nothing can
     # read them again, so they go now rather than accruing until an audit finds
@@ -2343,6 +2477,22 @@ def _pairs(v) -> list:
     return [x for group in v for x in group]
 
 
+def _positive_int(s: str) -> int:
+    """argparse `type=` for `--jobs`: a real positive int, nothing looser.
+
+    `int("4.0")` and `int("-1")` both raise or silently succeed in ways that
+    make a bad `--jobs` argument fail somewhere confusing instead of at the
+    command line -- refuse both here, with argparse's own usage message.
+    """
+    try:
+        n = int(s)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"--jobs must be an integer, got {s!r}")
+    if n < 1:
+        raise argparse.ArgumentTypeError(f"--jobs must be >= 1, got {n}")
+    return n
+
+
 def main(argv=None) -> int:
     try:
         sys.stdout.reconfigure(encoding="utf-8")
@@ -2392,6 +2542,15 @@ def main(argv=None) -> int:
                          "backgrounded --apply that got killed by a timeout with "
                          "this flag rather than restarting it plain -- that is the "
                          "whole point (default: off)")
+    ap.add_argument("--jobs", type=_positive_int, default=1, metavar="N",
+                    help="with --apply: render up to N frames concurrently in "
+                         "a process pool (one frame per worker, never one "
+                         "preset per worker -- segmentation is shared across "
+                         "a frame's presets). Must be a positive int. "
+                         "Default 1 -- serial, in manifest order, identical "
+                         "to today's behaviour. Composes with --resume: a "
+                         "--jobs N run killed mid-batch resumes like a "
+                         "serial one did.")
     ap.add_argument("--set-rotate", action="append", nargs="+", metavar="NAME=DEG", dest="set_rotate", help="record the ABSOLUTE subject angle — idempotent, use this in generated commands")
     ap.add_argument("--gc", action="store_true",
                     help="list the regenerable byproducts an APPROVED shoot is still holding "
@@ -2564,7 +2723,8 @@ def main(argv=None) -> int:
         only = tuple(_pairs(getattr(args, 'only', None)))
         if not only and args.filters:
             only = tuple(colormod.PRESETS)
-        m = run_apply(shoot, quiet=args.quiet, only=only, resume=args.resume)
+        m = run_apply(shoot, quiet=args.quiet, only=only, resume=args.resume,
+                      jobs=args.jobs)
         _print_status(shoot, m)
     return 0
 

--- a/prompts/prep.md
+++ b/prompts/prep.md
@@ -100,6 +100,24 @@ Auto-approval never buys a lower bar: `--auto` approves nothing by itself,
 `--approve-stage color` stamp the same per-stage digest a sheet approval
 does — any later edit invalidates it the same way.
 
+## Long shoots — background the run, resume across a kill
+
+A `--check` / `--auto` / `--apply` over a whole shoot directory is
+dispatched with `run_in_background: true` **as the default**, not as an
+occasional call for a shoot that "seems big" — a multi-frame `--apply`
+routinely runs past the Bash tool's 600 s hard timeout, and a foreground
+call that gets killed there loses the entire invocation for nothing.
+
+- **A killed or interrupted `--apply` is re-invoked with `--resume`**, never
+  restarted plain. The manifest is checkpointed after every rendered frame,
+  so `--resume` re-renders only the frame that was in flight when it was
+  killed, not the whole shoot (`docs/prep-resume-plan.md`).
+- **`--jobs N`** renders up to N frames concurrently (default 1 — serial,
+  today's exact behaviour). Frame processing is embarrassingly parallel;
+  use `--jobs` on a machine with cores to spare to finish a long `--apply`
+  well before it would ever near the timeout. Composes with `--resume`: a
+  `--jobs N` run killed mid-batch resumes exactly like a serial one did.
+
 ## The interactive review — the exception path, STAGED
 
 Where an override lands, and where a shoot goes when the auto pass is not

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -19,6 +19,7 @@ download needed — the colour tests pass an explicit mask.
 Run:  python tests/test_prep.py
   or: pytest tests/test_prep.py
 """
+import argparse
 import contextlib
 import copy
 import json
@@ -2196,3 +2197,195 @@ def test_resume_catches_a_changed_source_even_under_the_empty_only_sentinel():
             "when `only` is the empty 'render everything' sentinel -- a "
             "resumability check against the bare empty tuple would have "
             "skipped this frame unconditionally")
+
+
+# ---------------------------------------------------------------------------
+# --jobs N (#74 item 3, docs/prep-resume-plan.md, the "--jobs N" section)
+# ---------------------------------------------------------------------------
+
+def test_positive_int_rejects_non_positive_and_non_integer_jobs():
+    """The CLI's own `--jobs` type= -- fails at the command line, in
+    argparse's own words, rather than deep inside a render."""
+    for bad in ("0", "-3", "abc", "2.5"):
+        try:
+            P._positive_int(bad)
+            raise AssertionError(f"--jobs {bad!r} must be refused")
+        except argparse.ArgumentTypeError:
+            pass
+    assert P._positive_int("4") == 4
+
+
+def test_run_apply_rejects_a_non_positive_or_non_int_jobs():
+    """The same validation at the `run_apply()` boundary, for callers that
+    skip the CLI entirely (docs/prep-resume-plan.md: '--jobs N ... validate
+    N is a positive int'). `True`/`False` are rejected too even though
+    `bool` is technically an `int` subclass -- accepting `jobs=True` as 1
+    would be an accident waiting to be relied on."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=1)
+        for bad in (0, -1, "4", 2.5, True, False):
+            try:
+                P.run_apply(shoot, quiet=True, jobs=bad)
+                raise AssertionError(f"jobs={bad!r} must be refused")
+            except ValueError:
+                pass
+
+
+def test_omitting_jobs_defaults_to_serial_in_manifest_order():
+    """`jobs` defaults to 1: serial, in manifest order, identical to the
+    behaviour before --jobs existed."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=2)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+
+        rendered = []
+        orig_save_bgr = P._save_bgr
+
+        def spy_save_bgr(path, bgr, quality=94):
+            rendered.append(Path(path).stem)
+            return orig_save_bgr(path, bgr, quality=quality)
+
+        with patch.object(P, "_save_bgr", side_effect=spy_save_bgr):
+            P.run_apply(shoot, quiet=True)          # jobs defaults to 1
+
+        assert sorted(rendered) == ["IMG_0", "IMG_1"]
+
+
+def test_jobs_n_renders_the_same_presets_as_serial():
+    """The unit of parallelism is a whole FRAME, not a preset (the design
+    doc is explicit: splitting one frame's presets across workers would
+    duplicate the shared segmentation step and race two workers over the
+    same crop decision). Proven here the way it matters: render an identical
+    shoot under --jobs 1 and --jobs 3 and every preset file must come out
+    byte-for-byte the same, showing both modes call the exact same
+    `_render_frame`."""
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        serial = _shoot(base / "serial", n=3)
+        parallel = _shoot(base / "parallel", n=3)
+        for shoot in (serial, parallel):
+            P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+            P.run_approve_auto(shoot)
+
+        P.run_apply(serial, quiet=True, jobs=1)
+        P.run_apply(parallel, quiet=True, jobs=3)
+
+        m1 = P.load_manifest(serial)
+        m2 = P.load_manifest(parallel)
+        assert set(m1["photos"]) == set(m2["photos"])
+        for name, rec1 in m1["photos"].items():
+            rec2 = m2["photos"][name]
+            for pname in rec1["presets"]:
+                b1 = (serial / rec1["presets"][pname]["path"]).read_bytes()
+                b2 = (parallel / rec2["presets"][pname]["path"]).read_bytes()
+                assert b1 == b2, (
+                    f"{name}/{pname}: --jobs 3 must render byte-identical "
+                    f"output to --jobs 1")
+
+
+def test_jobs_n_checkpoints_the_manifest_after_each_completed_frame():
+    """The --jobs N analogue of
+    test_apply_checkpoints_the_manifest_after_each_frame_not_just_at_the_end:
+    a pool completing frames out of order must still leave a manifest with
+    SOME but not all frames done at some point along the way, not a single
+    jump from 0 to N (docs/prep-resume-plan.md item 2, extended to the pool
+    path)."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=3)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+
+        snapshots = []
+        real_save = P.save_manifest
+
+        def spy(shoot_arg, m, force=False):
+            snapshots.append(copy.deepcopy(
+                {k: v for k, v in m.items() if k != P.READ_FINGERPRINT}))
+            return real_save(shoot_arg, m, force=force)
+
+        with patch.object(P, "save_manifest", side_effect=spy):
+            P.run_apply(shoot, quiet=True, jobs=3)
+
+        assert len(snapshots) >= 3, (
+            f"expected at least one checkpoint per frame, got {len(snapshots)}")
+        rendered_counts = [
+            sum(1 for r in snap["photos"].values() if r.get("presets"))
+            for snap in snapshots
+        ]
+        assert rendered_counts[0] < rendered_counts[-1], rendered_counts
+        assert any(0 < c < 3 for c in rendered_counts), (
+            f"a checkpoint must exist with SOME but not all frames done "
+            f"(saw {rendered_counts}) -- otherwise nothing was incremental")
+
+
+def test_jobs_n_composes_with_resume():
+    """A --jobs N run over an already-fully-rendered, unchanged shoot must
+    not dispatch a single frame to the pool -- --resume's staleness check
+    runs BEFORE a frame is ever queued as a pool task (docs/prep-resume-plan.md,
+    the --jobs N section: '--resume is honoured first ... a resumed frame
+    never occupies a worker slot at all')."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=2)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+        P.run_apply(shoot, quiet=True)
+
+        rendered = []
+        orig_save_bgr = P._save_bgr
+
+        def spy_save_bgr(path, bgr, quality=94):
+            rendered.append(Path(path).stem)
+            return orig_save_bgr(path, bgr, quality=quality)
+
+        with patch.object(P, "_save_bgr", side_effect=spy_save_bgr):
+            P.run_apply(shoot, quiet=True, resume=True, jobs=4)
+
+        assert rendered == [], (
+            f"a fully-resumable shoot must dispatch nothing to the pool "
+            f"under --jobs N, got {rendered}")
+
+
+def test_jobs_n_isolates_a_bad_frame_and_keeps_rendering_the_rest():
+    """Design doc's 'per-frame exception isolation': a source corrupted
+    between --check and --apply must not sink every other frame's future
+    already queued in the pool.
+
+    The shoot-wide auto-pick step at the end of run_apply still raises for
+    the errored frame's missing preset -- exactly as it already does today
+    for a plain MISSING source (proven separately: `run_apply` on a shoot
+    with a deleted source raises the identical SystemExit even at the
+    default `--jobs 1`) -- so that part is a pre-existing gap, not something
+    this test is about. What --jobs N's own contract promises, and what this
+    checks, is that the OTHER frames still render and get checkpointed
+    before that later, unrelated crash."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=3)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+        (shoot / "IMG_1.jpg").write_bytes(b"not a jpeg")
+
+        try:
+            P.run_apply(shoot, quiet=True, jobs=2)
+            raise AssertionError(
+                "expected the pre-existing missing-preset SystemExit from "
+                "the final auto-pick step")
+        except SystemExit:
+            pass
+
+        m = P.load_manifest(shoot)
+        assert m["photos"]["IMG_1.jpg"]["status"] == "ERROR"
+        assert m["photos"]["IMG_0.jpg"].get("presets", {}).get("crisp")
+        assert m["photos"]["IMG_2.jpg"].get("presets", {}).get("crisp")
+
+
+def test_apply_run_records_the_jobs_value():
+    """`apply_run.jobs` per docs/prep-resume-plan.md's own documented
+    schema -- informational only (never part of `settings_hash`: `--jobs` is
+    a performance knob, not a statement about what should be rendered)."""
+    with tempfile.TemporaryDirectory() as td:
+        shoot = _shoot(Path(td) / "s", n=1)
+        P.run_auto(shoot, "1:1", P.DEFAULT_PAD, "gentle", quiet=True)
+        P.run_approve_auto(shoot)
+        P.run_apply(shoot, quiet=True, jobs=1)
+        assert P.load_manifest(shoot)["apply_run"]["jobs"] == 1


### PR DESCRIPTION
## What this does

Issue #74 item 3 asks for `prep --resume` + per-frame progress + `--jobs N`,
because 50 shell calls (8.36h of wall-clock) were being killed at the Bash
tool's 600s ceiling running `python -m lib.photo_prep.prep`, with no
checkpoint — a killed run restarted from frame 1.

**Most of item 3 already shipped**, in #96 (`feat(prep): atomic writes +
incremental checkpointing + --resume (#74 item 3)`), merged before this PR
branched: atomic `_save_bgr` writes, `run_apply()` checkpointing the
manifest after every frame instead of once at the end, and a `--resume`
flag with a settings-hash/staleness check. `docs/prep-resume-plan.md`
(added by #96) documents all of this and explicitly deferred one piece —
step 4, `--jobs N` — pending a real peak-RSS measurement to justify a
default worker count. **This PR is that step 4**, plus a doc gap #96 didn't
touch.

### `--jobs N`

- `run_apply(shoot, ..., jobs=1)`. Default `1` — serial, in manifest order,
  byte-for-byte identical to today's behaviour (verified: see Tests).
- `jobs > 1` uses `concurrent.futures.ProcessPoolExecutor`, **one frame per
  worker task, never one preset**. Segmentation is computed once per frame
  and shared across every preset rendered for it (`run_apply`'s own
  docstring already said so); splitting one frame's presets across workers
  would duplicate that expensive shared step and race two workers over the
  same crop decision.
- The frame-render body used to live inline in `run_apply`'s loop. It's now
  a standalone `_render_frame(shoot, name, rec, aspect, pad, smode, only)`
  — pure with respect to the manifest, returns `(new_rec, before,
  variants)` — so the serial path and the pool path call **the exact same
  function**, never two implementations that could drift apart.
- A pool worker (`_apply_worker`) calls `_render_frame` too, but returns
  only the small `rec` dict — not the rendered pixels — to keep the pool's
  IPC cheap. The parent reloads a pool-rendered frame's pixels from disk
  afterwards for the `_presets_sheet`, the same trick `--resume` already
  used for a frame it skips.
- `--resume` is checked **before** a frame is ever queued as a pool task,
  so a resumed frame never occupies a worker slot.
- Each completed future is folded into the manifest and checkpointed
  **individually** (not batched at the end) — a `--jobs N` run killed
  mid-batch leaves the same kind of consistent partial manifest a serial
  one does, so it composes with `--resume`.
- **Per-frame exception isolation**: a worker's exception is caught inside
  `_apply_worker` and returned as `(name, None, error_string)` rather than
  raised — the parent marks that one frame `status: "ERROR"` with a flag
  and keeps folding in every other future already in flight. One corrupt
  source can't sink a 40-frame batch.
- `--jobs` is validated as a positive int at two boundaries: argparse's
  `type=_positive_int` (fails at the command line, in argparse's own
  words) and again inside `run_apply()` itself for callers that skip the
  CLI (`bool` is explicitly rejected too, even though it's technically an
  `int` subclass).
- `apply_run.jobs` is recorded in the manifest (informational only — never
  part of `settings_hash`, since `--jobs` is a performance knob, not a
  statement about what should render).

### Docs

- `prompts/prep.md` **never mentioned backgrounding, `--resume`, or
  `--jobs`** — #96 didn't touch it either. Added a short "Long shoots"
  section: a `--check`/`--auto`/`--apply` over a whole shoot is
  `run_in_background: true` by default, a killed/interrupted `--apply` is
  re-invoked with `--resume` (not restarted plain), and `--jobs N` is
  available to finish a long apply before it nears the timeout at all.
- `docs/prep-resume-plan.md` status line and "Suggested follow-up PR
  shape" updated: step 4 is now ✅, with the actual design (function
  extraction, IPC-light workers, checkpoint-per-completed-future) recorded
  next to the original plan.

## What this does NOT do (out of scope, per the task)

- Items 1 (`.claude/settings.json` allowlist) and 2 (backgrounding
  enforcement, PR #128's `bg_guard.py`) — done elsewhere.
- Item 4 (promote scratch scripts to `lib/cli`), item 5 (extend #36's
  confidence-gating to PRICE/DRAFT), item 6 (dispatch PRICE to per-item
  workers, depends on #62) — all explicitly out of scope per the issue.
- **Does not touch `run_check`/`run_auto`** (the `--check`/`--auto` OSD +
  segmentation + crop-plan pass). `docs/prep-resume-plan.md` scoped
  `--resume`/checkpointing to `--apply` from the start — `--apply` is the
  expensive, preset-rendering pass and the one actually hitting the 600s
  ceiling in the audit's own bucket breakdown (`python -m
  lib.photo_prep.prep`, 622 calls, 11.37h, max 620s). `--check`/`--auto`
  are comparatively cheap (no preset rendering) and were called out in the
  plan doc as "worth revisiting if a very large batch ever makes `--check`
  itself timeout-prone" — not observed yet.
- **Does not pick a non-1 default for `--jobs`.** The plan doc's own
  reasoning for gating a higher default behind a real peak-RSS measurement
  at `--jobs 4` on a representative shoot still applies, and that
  measurement still hasn't been gathered. `--jobs` ships as a pure opt-in.
- **`RUN.md` is untouched** — that's PR #128's territory per the task.

## Judgment calls

1. **`ProcessPoolExecutor`, not threads.** The plan doc (written when #96
   landed) already reasoned through this: segmentation + colour correction
   are CPU-bound OpenCV/numpy work, so a pool avoids GIL contention and
   matches how the rest of the codebase isolates per-shoot state. I didn't
   re-litigate it — it's already the documented design for this exact
   feature, just not implemented yet.
2. **Freshly-rendered frames under `--jobs N` are reloaded from disk for
   the sheet, rather than kept in memory.** For `--jobs 1` (default),
   nothing changed — the sheet still uses the in-memory arrays
   `_render_frame` returns, identical to before this PR. For `--jobs N>1`,
   a worker discards its rendered pixels and the parent reloads them from
   the just-written JPEG. This trades a small amount of extra I/O (only
   when `--jobs` is actually used) for cheap pool IPC — shipping full-res
   arrays back over `ProcessPoolExecutor`'s pipe for every rendered frame
   would reintroduce a chunk of the cost `--jobs` exists to remove. It's
   the same trick `--resume` already relies on for a skipped frame, so
   it's not a new convention.
3. **A worker's exception leaves the shoot-wide auto-pick step (the
   `run_pick(...)` call at the end of `run_apply`) raising `SystemExit`
   for the errored frame's missing preset.** I checked this is not a
   regression: `run_apply` already does the identical thing today, at
   `--jobs 1`, for a frame whose *source file* goes missing between
   `--check` and `--apply` (`status: "MISSING"`) — `run_pick` iterates
   every frame in the manifest unconditionally and raises if any one is
   missing its chosen preset. `--jobs N`'s error isolation delivers what
   it promises (every healthy frame still renders and checkpoints before
   that later crash), but fixing `run_pick`'s all-or-nothing adoption step
   is a separate, pre-existing gap, not something this PR's scope covers.

## Tests

- `python -m pytest tests/ -q`, run twice for flakiness: **654 passed, 1
  skipped**, both runs (the skip is pre-existing and unrelated to this
  change).
- `python -m pytest tests/test_prep.py -q`, run twice: **119 passed** both
  times (111 pre-existing + 8 new).
- New tests in `tests/test_prep.py`:
  - `test_positive_int_rejects_non_positive_and_non_integer_jobs` /
    `test_run_apply_rejects_a_non_positive_or_non_int_jobs` — validation at
    both the CLI and `run_apply()` boundaries.
  - `test_omitting_jobs_defaults_to_serial_in_manifest_order` — default-off
    parity, matching the existing `--resume` test's shape.
  - `test_jobs_n_renders_the_same_presets_as_serial` — end-to-end: an
    identical shoot rendered under `--jobs 1` and `--jobs 3` produces
    byte-identical preset files.
  - `test_jobs_n_checkpoints_the_manifest_after_each_completed_frame` — the
    `--jobs N` analogue of #96's incremental-checkpoint test.
  - `test_jobs_n_composes_with_resume` — a fully up-to-date shoot under
    `--jobs N` dispatches nothing to the pool.
  - `test_jobs_n_isolates_a_bad_frame_and_keeps_rendering_the_rest` — a
    corrupted source doesn't stop the other frames from rendering and
    checkpointing (see Judgment call 3 for what this test does and doesn't
    assert).
  - `test_apply_run_records_the_jobs_value`.
- `ruff check lib/photo_prep/prep.py tests/test_prep.py`: 5 pre-existing
  warnings (3 `F841` unused-local in `run_check`, 2 `E702` in an unrelated
  existing test), confirmed identical on `origin/main` before this branch's
  changes — nothing new introduced.
- `python -m py_compile lib/photo_prep/prep.py tests/test_prep.py`: clean.
- Manual smoke tests (not committed) also exercised `--jobs 3` end-to-end
  through the CLI (`--help`, `--jobs 0` rejection) and a corrupted-frame
  scenario, matching the automated tests' assertions.

Addresses #74 (item 3 only — items 1-2 done elsewhere, 4-6 out of scope,
see issue for why).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LjKUU6bgryoHnL6AuWG7c

---
_Generated by [Claude Code](https://claude.ai/code/session_016LjKUU6bgryoHnL6AuWG7c)_